### PR TITLE
[CSUB-1] Implement mining rewards

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -943,6 +943,7 @@ dependencies = [
  "log",
  "num_cpus",
  "pallet-transaction-payment-rpc",
+ "parity-scale-codec",
  "sc-basic-authorship",
  "sc-cli",
  "sc-client-api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3887,6 +3887,7 @@ dependencies = [
  "frame-system",
  "parity-scale-codec",
  "scale-info",
+ "sp-consensus-pow",
  "sp-core",
  "sp-io",
  "sp-runtime",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -32,6 +32,7 @@ sha3pow = { path = '../sha3pow' }
 num_cpus = "1.13.0"
 futures-lite = "1.12.0"
 log = "0.4.14"
+codec = { package = "parity-scale-codec", version = "2.3.1" }
 
 [dependencies.frame-benchmarking]
 git = 'https://github.com/paritytech/substrate.git'

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -1,6 +1,6 @@
 use creditcoin_node_runtime::{
-	AccountId, BalancesConfig, DifficultyConfig, GenesisConfig, Signature, SudoConfig,
-	SystemConfig, WASM_BINARY,
+	AccountId, BalancesConfig, DifficultyConfig, GenesisConfig, RewardsConfig, Signature,
+	SudoConfig, SystemConfig, WASM_BINARY,
 };
 use sc_service::ChainType;
 use sp_core::{sr25519, Pair, Public, U256};
@@ -140,5 +140,6 @@ fn testnet_genesis(
 			target_time: 5 * 1000,
 			difficulty_adjustment_period: 50,
 		},
+		rewards: RewardsConfig { reward_amount: 1_000_000_000_000 },
 	}
 }

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -8,6 +8,9 @@ pub struct Cli {
 
 	#[structopt(flatten)]
 	pub run: RunCmd,
+
+	#[structopt(long)]
+	pub mining_key: Option<String>,
 }
 
 #[derive(Debug, StructOpt)]

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -113,7 +113,7 @@ pub fn run() -> sc_cli::Result<()> {
 			runner.run_node_until_exit(|config| async move {
 				match config.role {
 					Role::Light => Err("Light clients are not supported at this time".into()),
-					_ => service::new_full(config),
+					_ => service::new_full(config, cli.mining_key.as_deref()),
 				}
 				.map_err(sc_cli::Error::Service)
 			})

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -268,7 +268,7 @@ pub fn new_full(
 			proposer_factory,
 			network.clone(),
 			network,
-			None,
+			Some(mining_key.encode()),
 			move |_, ()| async move {
 				let timestamp = sp_timestamp::InherentDataProvider::from_system_time();
 				Ok(timestamp)
@@ -284,7 +284,7 @@ pub fn new_full(
 
 		let threads = num_cpus::get();
 		for _ in 0..threads {
-			if let Some(_keystore) = keystore_container.local_keystore() {
+			if let Some(keystore) = keystore_container.local_keystore() {
 				let worker = worker.clone();
 				let client = client.clone();
 
@@ -293,6 +293,7 @@ pub fn new_full(
 					if let Some(metadata) = metadata {
 						match sha3pow::mine(
 							client.as_ref(),
+							&keystore,
 							&metadata.pre_hash,
 							metadata.pre_runtime.as_ref().map(|v| &v[..]),
 							metadata.difficulty,

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -146,7 +146,10 @@ fn remote_keystore(_url: &String) -> Result<Arc<LocalKeystore>, &'static str> {
 }
 
 /// Builds a new service for a full client.
-pub fn new_full(config: Configuration) -> Result<TaskManager, ServiceError> {
+pub fn new_full(
+	config: Configuration,
+	mining_key: Option<&str>,
+) -> Result<TaskManager, ServiceError> {
 	let sc_service::PartialComponents {
 		client,
 		backend,

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -1,6 +1,6 @@
 //! Service and ServiceFactory implementation. Specialized wrapper over substrate service.
 
-use codec::{Decode, Encode};
+use codec::Encode;
 use creditcoin_node_runtime::{self, opaque::Block, RuntimeApi};
 use sc_client_api::ExecutorProvider;
 pub use sc_executor::NativeElseWasmExecutor;

--- a/pallets/rewards/Cargo.toml
+++ b/pallets/rewards/Cargo.toml
@@ -41,6 +41,12 @@ default-features = false
 features = ['derive']
 version = '1.0'
 
+[dependencies.sp-consensus-pow]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+rev = '94dfe152e61e42cd27844a65165cfdedde5232eb'
+version = '0.10.0-dev'
+
 [dev-dependencies.sp-core]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
@@ -68,5 +74,6 @@ std = [
     'frame-support/std',
     'frame-system/std',
     'frame-benchmarking/std',
+    'sp-consensus-pow/std',
 ]
 try-runtime = ['frame-support/try-runtime']

--- a/pallets/rewards/src/lib.rs
+++ b/pallets/rewards/src/lib.rs
@@ -50,6 +50,9 @@ pub mod pallet {
 	pub enum Event<T: Config> {
 		/// Reward was issued. [block_author, amount]
 		RewardIssued(AccountIdOf<T>, BalanceOf<T>),
+
+		/// Reward amount was changed. [new_reward_amount]
+		RewardChanged(BalanceOf<T>),
 	}
 
 	// Errors inform users that something went wrong.
@@ -60,7 +63,17 @@ pub mod pallet {
 	// These functions materialize as "extrinsics", which are often compared to transactions.
 	// Dispatchable functions must be annotated with a weight and must return a DispatchResult.
 	#[pallet::call]
-	impl<T: Config> Pallet<T> {}
+	impl<T: Config> Pallet<T> {
+		#[pallet::weight(10_000 + T::DbWeight::get().writes(1))]
+		pub fn set_reward_amount(origin: OriginFor<T>, new_amount: BalanceOf<T>) -> DispatchResult {
+			ensure_root(origin)?;
+
+			RewardAmount::<T>::put(new_amount);
+			Self::deposit_event(Event::<T>::RewardChanged(new_amount));
+
+			Ok(())
+		}
+	}
 
 	#[pallet::genesis_config]
 	pub struct GenesisConfig<T: Config> {

--- a/pallets/rewards/src/lib.rs
+++ b/pallets/rewards/src/lib.rs
@@ -1,8 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-/// Edit this file to define custom logic or remove it if it is not needed.
-/// Learn more about FRAME and the core library of Substrate FRAME pallets:
-/// <https://substrate.dev/docs/en/knowledgebase/runtime/frame>
+use frame_support::traits::Currency;
 pub use pallet::*;
 
 #[cfg(test)]
@@ -14,89 +12,101 @@ mod tests;
 #[cfg(feature = "runtime-benchmarks")]
 mod benchmarking;
 
+pub type BalanceOf<T> =
+	<<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
+
+pub type AccountIdOf<T> = <T as frame_system::Config>::AccountId;
+
 #[frame_support::pallet]
 pub mod pallet {
-	use frame_support::{dispatch::DispatchResult, pallet_prelude::*};
+	use super::*;
+	use frame_support::{dispatch::DispatchResult, pallet_prelude::*, traits::Currency};
 	use frame_system::pallet_prelude::*;
 
-	/// Configure the pallet by specifying the parameters and types on which it depends.
 	#[pallet::config]
 	pub trait Config: frame_system::Config {
 		/// Because this pallet emits events, it depends on the runtime's definition of an event.
 		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
+
+		type Currency: Currency<AccountIdOf<Self>>;
 	}
 
 	#[pallet::pallet]
 	#[pallet::generate_store(pub(super) trait Store)]
 	pub struct Pallet<T>(_);
 
-	// The pallet's runtime storage items.
-	// https://substrate.dev/docs/en/knowledgebase/runtime/storage
 	#[pallet::storage]
-	#[pallet::getter(fn something)]
-	// Learn more about declaring storage items:
-	// https://substrate.dev/docs/en/knowledgebase/runtime/storage#declaring-storage-items
-	pub type Something<T> = StorageValue<_, u32>;
+	#[pallet::getter(fn reward_amount)]
+	pub type RewardAmount<T> = StorageValue<_, BalanceOf<T>, ValueQuery>;
+
+	#[pallet::storage]
+	#[pallet::getter(fn block_author)]
+	pub type BlockAuthor<T> = StorageValue<_, AccountIdOf<T>>;
 
 	// Pallets use events to inform users when important changes are made.
 	// https://substrate.dev/docs/en/knowledgebase/runtime/events
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	pub enum Event<T: Config> {
-		/// Event documentation should end with an array that provides descriptive names for event
-		/// parameters. [something, who]
-		SomethingStored(u32, T::AccountId),
+		/// Reward was issued. [block_author, amount]
+		RewardIssued(AccountIdOf<T>, BalanceOf<T>),
 	}
 
 	// Errors inform users that something went wrong.
 	#[pallet::error]
-	pub enum Error<T> {
-		/// Error names should be descriptive.
-		NoneValue,
-		/// Errors should have helpful documentation associated with them.
-		StorageOverflow,
-	}
+	pub enum Error<T> {}
 
 	// Dispatchable functions allows users to interact with the pallet and invoke state changes.
 	// These functions materialize as "extrinsics", which are often compared to transactions.
 	// Dispatchable functions must be annotated with a weight and must return a DispatchResult.
 	#[pallet::call]
-	impl<T: Config> Pallet<T> {
-		/// An example dispatchable that takes a singles value as a parameter, writes the value to
-		/// storage and emits an event. This function must be dispatched by a signed extrinsic.
-		#[pallet::weight(10_000 + T::DbWeight::get().writes(1))]
-		pub fn do_something(origin: OriginFor<T>, something: u32) -> DispatchResult {
-			// Check that the extrinsic was signed and get the signer.
-			// This function will return an error if the extrinsic is not signed.
-			// https://substrate.dev/docs/en/knowledgebase/runtime/origin
-			let who = ensure_signed(origin)?;
+	impl<T: Config> Pallet<T> {}
 
-			// Update storage.
-			<Something<T>>::put(something);
+	#[pallet::genesis_config]
+	pub struct GenesisConfig<T: Config> {
+		pub reward_amount: BalanceOf<T>,
+	}
 
-			// Emit an event.
-			Self::deposit_event(Event::SomethingStored(something, who));
-			// Return a successful DispatchResultWithPostInfo
-			Ok(())
+	#[cfg(feature = "std")]
+	impl<T: Config> Default for GenesisConfig<T> {
+		fn default() -> Self {
+			Self { reward_amount: <T::Currency as Currency<AccountIdOf<T>>>::minimum_balance() }
+		}
+	}
+
+	#[pallet::genesis_build]
+	impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
+		fn build(&self) {
+			RewardAmount::<T>::put(self.reward_amount);
+		}
+	}
+
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+		fn on_initialize(_now: BlockNumberFor<T>) -> Weight {
+			let block_author = frame_system::Pallet::<T>::digest().convert_first(|item| {
+				item.pre_runtime_try_to::<AccountIdOf<T>>(&sp_consensus_pow::POW_ENGINE_ID)
+			});
+
+			if let Some(author) = block_author {
+				BlockAuthor::<T>::put(author);
+			}
+
+			0
 		}
 
-		/// An example dispatchable that may throw a custom error.
-		#[pallet::weight(10_000 + T::DbWeight::get().reads_writes(1,1))]
-		pub fn cause_error(origin: OriginFor<T>) -> DispatchResult {
-			let _who = ensure_signed(origin)?;
-
-			// Read a value from storage.
-			match <Something<T>>::get() {
-				// Return an error if the value has not been set.
-				None => Err(Error::<T>::NoneValue)?,
-				Some(old) => {
-					// Increment the value read from storage; will error in the event of overflow.
-					let new = old.checked_add(1).ok_or(Error::<T>::StorageOverflow)?;
-					// Update the value in storage with the incremented result.
-					<Something<T>>::put(new);
-					Ok(())
-				},
+		fn on_finalize(_block_number: BlockNumberFor<T>) {
+			if let Some(author) = BlockAuthor::<T>::get() {
+				let reward = Self::reward_amount();
+				Self::issue_reward(author, reward);
 			}
+		}
+	}
+
+	impl<T: Config> Pallet<T> {
+		pub fn issue_reward(recipient: AccountIdOf<T>, amount: BalanceOf<T>) {
+			drop(T::Currency::deposit_creating(&recipient, amount));
+			Self::deposit_event(Event::<T>::RewardIssued(recipient, amount));
 		}
 	}
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -245,6 +245,11 @@ impl pallet_difficulty::Config for Runtime {
 	type Moment = u64;
 }
 
+impl pallet_rewards::Config for Runtime {
+	type Event = Event;
+	type Currency = Balances;
+}
+
 pub type SignedPayload = generic::SignedPayload<Call, SignedExtra>;
 
 impl<LocalCall> frame_system::offchain::CreateSignedTransaction<LocalCall> for Runtime
@@ -300,6 +305,7 @@ construct_runtime!(
 		Sudo: pallet_sudo::{Pallet, Call, Config<T>, Storage, Event<T>},
 		Creditcoin: pallet_creditcoin::{Pallet, Call, Storage, Event<T>},
 		Difficulty: pallet_difficulty::{Pallet, Call, Config<T>, Storage},
+		Rewards: pallet_rewards::{Pallet, Call, Storage, Event<T>, Config<T>}
 	}
 );
 

--- a/sha3pow/src/lib.rs
+++ b/sha3pow/src/lib.rs
@@ -2,6 +2,7 @@ use parity_scale_codec::{Decode, Encode};
 use rand::{prelude::SmallRng, SeedableRng};
 use sc_client_api::{AuxStore, HeaderBackend};
 use sc_consensus_pow::{Error, PowAlgorithm};
+use sc_keystore::LocalKeystore;
 use sha3::{Digest, Sha3_256};
 use sp_api::{BlockId, BlockT, ProvideRuntimeApi};
 use sp_consensus_pow::{DifficultyApi, Seal as RawSeal};
@@ -125,6 +126,7 @@ where
 
 pub fn mine<B, C>(
 	_client: &C,
+	keystore: &LocalKeystore,
 	pre_hash: &H256,
 	_pre_digest: Option<&[u8]>,
 	difficulty: Difficulty,

--- a/sha3pow/src/lib.rs
+++ b/sha3pow/src/lib.rs
@@ -13,7 +13,7 @@ pub mod app {
 	use sp_application_crypto::{app_crypto, sr25519};
 	use sp_core::crypto::KeyTypeId;
 
-	pub const ID: KeyTypeId = KeyTypeId(*b"_ctc");
+	pub const ID: KeyTypeId = KeyTypeId(*b"ctcm");
 	app_crypto!(sr25519, ID);
 }
 
@@ -126,7 +126,7 @@ where
 
 pub fn mine<B, C>(
 	_client: &C,
-	keystore: &LocalKeystore,
+	_keystore: &LocalKeystore,
 	pre_hash: &H256,
 	_pre_digest: Option<&[u8]>,
 	difficulty: Difficulty,


### PR DESCRIPTION
This PR implements basic mining rewards. The miner must pass the public key to reward through a command line argument (`--mining-key`). At the start of each block, we record the block's author, and at the end of the block, we issue a reward to the author by minting new tokens. The reward amount is configurable through a root-level extrinsic `set_reward_amount`.

To generate a key for mining:

1. `creditcoin-node key generate`
2. Note the output, particularly the "Secret Seed" and the "Public key (SS58)"
3. `creditcoin-node key insert --scheme Sr25519 --key-type 'ctcm'` and then enter the seed associated with the key (the phrase from step 2) at the prompt

To start mining with a `--validator` node, pass the argument `--mining-key <pubkey>` where `pubkey` is the value of "Public Key (SS58)"  from step 2.