### PR TITLE
[CSUB-5] Add a CLI subcommand for generating and inserting a mining key into the keystore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,6 +939,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-benchmarking-cli",
  "futures-lite",
+ "hex",
  "jsonrpc-core",
  "log",
  "num_cpus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -965,11 +965,13 @@ dependencies = [
  "sp-consensus-pow",
  "sp-core",
  "sp-inherents",
+ "sp-keystore",
  "sp-runtime",
  "sp-timestamp",
  "structopt",
  "substrate-build-script-utils",
  "substrate-frame-rpc-system",
+ "tiny-bip39",
 ]
 
 [[package]]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,6 +5,7 @@ if [ "$MODE" = "rpc" ]; then
     rpc='--rpc-external'
     cors="--rpc-cors ${CORS:-all}"
 else
+    mining_key="--mining-key $(/bin/creditcoin-node generate-mining-key --chain /chainspec/testnetSpec.json --quiet)"
     validator='--validator'
 fi
 if [ -n "$BOOTNODE_IP" ]; then
@@ -21,7 +22,7 @@ if [ -n "$BOOTNODE_IP" ]; then
      --port 30333 --ws-port 9944 --rpc-port 9933 \
      --public-addr "/dns4/$FQDN/tcp/30333" \
      --telemetry-url "wss://telemetry.polkadot.io/submit/ 0" \
-     --base-path "${DATA:-/data}" $validator $ws $rpc $cors $EXTRA_ARGS
+     --base-path "${DATA:-/data}" $validator $mining_key $ws $rpc $cors $EXTRA_ARGS
 else
     key="${NODE_KEY:-c5eb4a9ada5c9dd76378d000f046e8cde064d68e96a1df569190eee70afba8e7}"
     node_name="${NODE_NAME:-bootnode}"
@@ -29,5 +30,5 @@ else
      --port 30333 --ws-port 9944 --rpc-port 9933 \
      --public-addr "/dns4/$FQDN/tcp/30333" \
      --telemetry-url "wss://telemetry.polkadot.io/submit/ 0" \
-     --base-path "${DATA:-/data}" $validator $ws $rpc $cors $EXTRA_ARGS
+     --base-path "${DATA:-/data}" $validator $mining_key $ws $rpc $cors $EXTRA_ARGS
 fi

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -34,6 +34,7 @@ futures-lite = "1.12.0"
 log = "0.4.14"
 codec = { package = "parity-scale-codec", version = "2.3.1" }
 tiny-bip39 = "0.8.2"
+hex = "0.4.3"
 
 [dependencies.frame-benchmarking]
 git = 'https://github.com/paritytech/substrate.git'

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -33,6 +33,7 @@ num_cpus = "1.13.0"
 futures-lite = "1.12.0"
 log = "0.4.14"
 codec = { package = "parity-scale-codec", version = "2.3.1" }
+tiny-bip39 = "0.8.2"
 
 [dependencies.frame-benchmarking]
 git = 'https://github.com/paritytech/substrate.git'
@@ -85,6 +86,11 @@ version = '0.10.0-dev'
 git = 'https://github.com/paritytech/substrate.git'
 rev = '94dfe152e61e42cd27844a65165cfdedde5232eb'
 version = '4.0.0-dev'
+
+[dependencies.sp-keystore]
+git = 'https://github.com/paritytech/substrate.git'
+rev = '94dfe152e61e42cd27844a65165cfdedde5232eb'
+version = '0.10.0-dev'
 
 [dependencies.sc-rpc]
 git = 'https://github.com/paritytech/substrate.git'

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -12,11 +12,14 @@ pub struct Cli {
 	#[structopt(long)]
 	pub mining_key: Option<String>,
 }
-
 #[derive(Debug, StructOpt)]
 pub enum Subcommand {
 	/// Key management cli utilities
 	Key(sc_cli::KeySubcommand),
+
+	/// Generate and insert key for mining Creditcoin
+	GenerateMiningKey(crate::command::MiningKeySubcommand),
+
 	/// Build a chain specification.
 	BuildSpec(sc_cli::BuildSpecCmd),
 

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -1,3 +1,6 @@
+pub mod generate_mining_key;
+pub use generate_mining_key::MiningKeySubcommand;
+
 use crate::{
 	chain_spec,
 	cli::{Cli, Subcommand},
@@ -52,6 +55,7 @@ pub fn run() -> sc_cli::Result<()> {
 
 	match &cli.subcommand {
 		Some(Subcommand::Key(cmd)) => cmd.run(&cli),
+		Some(Subcommand::GenerateMiningKey(cmd)) => cmd.run(&cli),
 		Some(Subcommand::BuildSpec(cmd)) => {
 			let runner = cli.create_runner(cmd)?;
 			runner.sync_run(|config| cmd.run(config.chain_spec, config.network))

--- a/node/src/command/generate_mining_key.rs
+++ b/node/src/command/generate_mining_key.rs
@@ -89,9 +89,9 @@ impl MiningKeySubcommand {
 		let output = self.output_scheme.output_type.clone();
 		let uri = mnemonic.phrase();
 
-		let pwd = password.as_ref().map(|s| s.expose_secret().as_str());
 		if self.quiet {
-			let (pair, _) = sp_core::ecdsa::Pair::from_phrase(uri, pwd)
+			let raw_password = password.as_ref().map(|s| s.expose_secret().as_str());
+			let (pair, _) = sp_core::ecdsa::Pair::from_phrase(uri, raw_password)
 				.expect("we just generated the valid phrase; qed");
 			let public_address = pair.public().into_account().to_ss58check();
 			println!("{}", public_address);

--- a/node/src/command/generate_mining_key.rs
+++ b/node/src/command/generate_mining_key.rs
@@ -1,0 +1,137 @@
+use std::path::PathBuf;
+
+use bip39::{Language, Mnemonic, MnemonicType};
+use sc_cli::{
+	structopt, utils::print_from_uri, with_crypto_scheme, KeystoreParams, OutputTypeFlag,
+	SubstrateCli,
+};
+use sc_keystore::LocalKeystore;
+use sc_service::{config::KeystoreConfig, Arc, BasePath};
+use sp_core::{
+	crypto::{ExposeSecret, KeyTypeId, SecretString, Ss58Codec},
+	Pair,
+};
+use sp_keystore::{SyncCryptoStore, SyncCryptoStorePtr};
+use sp_runtime::traits::IdentifyAccount;
+
+use crate::cli::Cli;
+
+#[derive(Debug, structopt::StructOpt)]
+pub struct MiningKeySubcommand {
+	/// The number of words in the phrase to generate. One of 12 (default), 15, 18, 21 and 24.
+	#[structopt(long, short = "w", value_name = "WORDS")]
+	words: Option<usize>,
+
+	#[structopt(flatten)]
+	pub output_scheme: OutputTypeFlag,
+
+	#[structopt(flatten)]
+	pub keystore_params: KeystoreParams,
+
+	/// Specify the chain specification.
+	///
+	/// It can be one of the predefined ones (dev, local, or staging) or it can be a path to a file
+	/// with the chainspec (such as one exported by the `build-spec` subcommand).
+	#[structopt(long, value_name = "CHAIN_SPEC")]
+	pub chain: Option<String>,
+
+	/// Specify the development chain.
+	///
+	/// This flag sets `--chain=dev`, `--force-authoring`, `--rpc-cors=all`,
+	/// `--alice`, and `--tmp` flags, unless explicitly overridden.
+	#[structopt(long, conflicts_with_all = &["chain"])]
+	pub dev: bool,
+
+	/// Specify custom base path.
+	#[structopt(long, short = "d", value_name = "PATH", parse(from_os_str))]
+	pub base_path: Option<PathBuf>,
+
+	/// Output only the public address of the generated key
+	#[structopt(long, short = "q")]
+	pub quiet: bool,
+
+	/// Only generate the mining key, don't insert it into the keystore
+	#[structopt(long)]
+	pub no_insert: bool,
+}
+
+fn to_vec<P: sp_core::Pair>(
+	uri: &str,
+	pass: Option<SecretString>,
+) -> Result<Vec<u8>, sc_cli::Error> {
+	let p = sc_cli::utils::pair_from_suri::<P>(uri, pass)?;
+	Ok(p.public().as_ref().to_vec())
+}
+
+impl MiningKeySubcommand {
+	fn chain_id(&self) -> String {
+		match self.chain {
+			Some(ref chain) => chain.clone(),
+			None =>
+				if self.dev {
+					"dev".into()
+				} else {
+					"".into()
+				},
+		}
+	}
+	pub fn run(&self, cli: &Cli) -> Result<(), sc_cli::Error> {
+		let words = match self.words {
+			Some(words) => MnemonicType::for_word_count(words).map_err(|_| {
+				sc_cli::Error::Input(
+					"Invalid number of words given for phrase: must be 12/15/18/21/24".into(),
+				)
+			})?,
+			None => MnemonicType::Words12,
+		};
+		let mnemonic = Mnemonic::new(words, Language::English);
+		let password = self.keystore_params.read_password()?;
+		let output = self.output_scheme.output_type.clone();
+		let uri = mnemonic.phrase();
+
+		let pwd = password.as_ref().map(|s| s.expose_secret().as_str());
+		if self.quiet {
+			let (pair, _) = sp_core::sr25519::Pair::from_phrase(uri, pwd)
+				.expect("we just generated the valid phrase; qed");
+			let public_address = pair.public().into_account().to_ss58check();
+			println!("{}", public_address);
+		} else {
+			with_crypto_scheme!(
+				sc_cli::CryptoScheme::Sr25519,
+				print_from_uri(uri, password, None, output)
+			);
+		}
+
+		if self.no_insert {
+			let suri = sc_cli::utils::read_uri(Some(&uri.into()))?;
+			let base_path = self
+				.base_path
+				.clone()
+				.map(Into::into)
+				.unwrap_or_else(|| BasePath::from_project("", "", &Cli::executable_name()));
+			let chain_id = self.chain_id();
+			let chain_spec = cli.load_spec(&chain_id)?;
+			let config_dir = base_path.config_dir(chain_spec.id());
+
+			let (keystore, public) = match self.keystore_params.keystore_config(&config_dir)? {
+				(_, KeystoreConfig::Path { path, password }) => {
+					let public = with_crypto_scheme!(
+						sc_cli::CryptoScheme::Sr25519,
+						to_vec(&suri, password.clone())
+					)?;
+					let keystore: SyncCryptoStorePtr =
+						Arc::new(LocalKeystore::open(path, password)?);
+					(keystore, public)
+				},
+				_ => unreachable!("keystore_config always returns path and password; qed"),
+			};
+
+			let key_type = KeyTypeId::from(sha3pow::app::ID);
+
+			SyncCryptoStore::insert_unknown(&*keystore, key_type, &suri, &public[..])
+				.map_err(|_| sc_cli::Error::KeyStoreOperation)?;
+		}
+
+		Ok(())
+	}
+}

--- a/node/src/command/generate_mining_key.rs
+++ b/node/src/command/generate_mining_key.rs
@@ -91,13 +91,13 @@ impl MiningKeySubcommand {
 
 		let pwd = password.as_ref().map(|s| s.expose_secret().as_str());
 		if self.quiet {
-			let (pair, _) = sp_core::sr25519::Pair::from_phrase(uri, pwd)
+			let (pair, _) = sp_core::ecdsa::Pair::from_phrase(uri, pwd)
 				.expect("we just generated the valid phrase; qed");
 			let public_address = pair.public().into_account().to_ss58check();
 			println!("{}", public_address);
 		} else {
 			with_crypto_scheme!(
-				sc_cli::CryptoScheme::Sr25519,
+				sc_cli::CryptoScheme::Ecdsa,
 				print_from_uri(uri, password, None, output)
 			);
 		}
@@ -116,7 +116,7 @@ impl MiningKeySubcommand {
 			let (keystore, public) = match self.keystore_params.keystore_config(&config_dir)? {
 				(_, KeystoreConfig::Path { path, password }) => {
 					let public = with_crypto_scheme!(
-						sc_cli::CryptoScheme::Sr25519,
+						sc_cli::CryptoScheme::Ecdsa,
 						to_vec(&suri, password.clone())
 					)?;
 					let keystore: SyncCryptoStorePtr =

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -43,6 +43,8 @@ pub type BlockNumber = u32;
 /// Alias to 512-bit hash when used in the context of a transaction signature on the chain.
 pub type Signature = MultiSignature;
 
+pub type Signer = <Signature as Verify>::Signer;
+
 /// Some way of identifying an account on the chain. We intentionally make it equivalent
 /// to the public key of our transaction signing scheme.
 pub type AccountId = <<Signature as Verify>::Signer as IdentifyAccount>::AccountId;

--- a/sha3pow/src/lib.rs
+++ b/sha3pow/src/lib.rs
@@ -10,11 +10,11 @@ use sp_core::{H256, U256};
 use std::sync::Arc;
 
 pub mod app {
-	use sp_application_crypto::{app_crypto, sr25519};
+	use sp_application_crypto::{app_crypto, ecdsa};
 	use sp_core::crypto::KeyTypeId;
 
 	pub const ID: KeyTypeId = KeyTypeId(*b"ctcm");
-	app_crypto!(sr25519, ID);
+	app_crypto!(ecdsa, ID);
 }
 
 pub type Difficulty = U256;


### PR DESCRIPTION
This PR adds a subcommand `generate-mining-key` which generates the mining key and optionally inserts it into the keystore with the correct settings. This provides a better user experience and allows us to configure the mining key in automation in one step without having to parse command output.

The code itself is basically a combination of the built-in `generate` and `insert` key commands with the proper settings configured.

This PR also updates the entrypoint to generate and pass a key when running a mining node