### PR TITLE
Csub 33 ci linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,5 @@
-FROM ubuntu:latest AS builder
+FROM gluwa/ci-linux:production AS builder
 ENV DEBIAN_FRONTEND=noninteractive
-SHELL ["/bin/bash", "-c"]
-RUN apt-get update && apt-get install -y \
-    cmake \
-    pkg-config \
-    libssl-dev \
-    git \
-    build-essential \
-    clang \
-    libclang-dev \
-    curl \
-    && rm -rf /var/lib/apt/lists/*
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 RUN source ~/.cargo/env && rustup default stable && rustup update nightly && rustup update stable && rustup target add wasm32-unknown-unknown --toolchain nightly
 WORKDIR /creditcoin-node
 COPY Cargo.toml .

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,6 +10,7 @@ trigger:
   paths:
     exclude:
     - README.md
+    - ci-linux/*
 
 pr: none
 

--- a/ci-linux/azure-pipelines.yml
+++ b/ci-linux/azure-pipelines.yml
@@ -1,0 +1,50 @@
+# Docker
+# Build and push an image to Azure Container Registry
+# https://docs.microsoft.com/azure/devops/pipelines/languages/docker
+
+trigger:
+  batch: true
+  branches:
+    include:
+    - refs/tags/*
+    - franklin-azure-cache
+  paths:
+    include:
+    - ci-linux/*
+
+pr: none
+
+##Use self hosted build server. Resource ID: resourceGroups/devcommon/providers/Microsoft.Compute/virtualMachines/Ubuntu16BuildServer
+pool:
+  name: Creditcoin
+  demands:
+   - agent.name -equals Ubuntu16BuildServer
+
+resources:
+- repo: self
+
+variables:
+  dockerfilePath: '$(Build.SourcesDirectory)/ci-linux/ci-build.Dockerfile'
+  registryName: 'gluwa/ci-linux'
+  DOCKER_BUILDKIT: 1
+
+stages:
+- stage: Build_CI_Image
+  displayName: BuildnPush CI Image
+  jobs:
+  - job: Build_CI
+    displayName: Build_CI_Image
+    steps:
+    - task: Docker@2
+      displayName: Docker Login
+      inputs:
+        containerRegistry: 'Docker Hub - mrausnadian'
+        command: 'login'
+    - task: Docker@2
+      inputs:
+        containerRegistry: 'Docker Hub - mrausnadian'
+        repository: 'gluwa/ci-linux'
+        command: 'buildAndPush'
+        Dockerfile: $(dockerfilePath)
+        tags: |
+          production

--- a/ci-linux/azure-pipelines.yml
+++ b/ci-linux/azure-pipelines.yml
@@ -29,11 +29,6 @@ stages:
     displayName: Build_CI_Image
     steps:
     - task: Docker@2
-      displayName: Docker Login
-      inputs:
-        containerRegistry: 'Docker Hub - mrausnadian'
-        command: 'login'
-    - task: Docker@2
       inputs:
         containerRegistry: 'Docker Hub - mrausnadian'
         repository: 'gluwa/ci-linux'

--- a/ci-linux/azure-pipelines.yml
+++ b/ci-linux/azure-pipelines.yml
@@ -2,12 +2,7 @@
 # Build and push an image to Azure Container Registry
 # https://docs.microsoft.com/azure/devops/pipelines/languages/docker
 
-trigger:
-  batch: true
-  branches:
-    include:
-    - refs/tags/*
-    - franklin-azure-cache
+trigger: none
   paths:
     include:
     - ci-linux/*
@@ -16,9 +11,7 @@ pr: none
 
 ##Use self hosted build server. Resource ID: resourceGroups/devcommon/providers/Microsoft.Compute/virtualMachines/Ubuntu16BuildServer
 pool:
-  name: Creditcoin
-  demands:
-   - agent.name -equals Ubuntu16BuildServer
+  vmImage: ubuntu-latest
 
 resources:
 - repo: self

--- a/ci-linux/ci-linux.Dockerfile
+++ b/ci-linux/ci-linux.Dockerfile
@@ -1,0 +1,15 @@
+#Build the image and tag it creditcoin/ci-linux:production
+FROM debian:bullseye-slim
+ENV DEBIAN_FRONTEND=noninteractive
+SHELL ["/bin/bash", "-c"]
+RUN apt-get update && apt-get install -y \
+    cmake \
+    pkg-config \
+    libssl-dev \
+    git \
+    build-essential \
+    clang \
+    libclang-dev \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y


### PR DESCRIPTION
Changed the base image for building cargo dependencies to gluwa/ci-linux:production which contains packages:

```
FROM ubuntu:latest AS builder
ENV DEBIAN_FRONTEND=noninteractive
SHELL ["/bin/bash", "-c"]
RUN apt-get update && apt-get install -y \
    cmake \
    pkg-config \
    libssl-dev \
    git \
    build-essential \
    clang \
    libclang-dev \
    curl \
    && rm -rf /var/lib/apt/lists/*
RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
```