### PR TITLE
[CSUB-2] Add extrinsic to claim legacy balance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1066,11 +1066,12 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4600d695eb3f6ce1cd44e6e291adceb2cc3ab12f20a33777ecd0bf6eba34e06"
+checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
 dependencies = [
  "generic-array 0.14.5",
+ "typenum",
 ]
 
 [[package]]
@@ -1217,9 +1218,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cb780dce4f9a8f5c087362b3a4595936b2019e7c8b30f2c3e9a7e94e6ae9837"
+checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
 dependencies = [
  "block-buffer 0.10.2",
  "crypto-common",
@@ -3914,6 +3915,7 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_json",
+ "sha2 0.10.2",
  "sp-core",
  "sp-io",
  "sp-keystore",
@@ -5951,13 +5953,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99c3bd8169c58782adad9290a9af5939994036b76187f7b4f0e6de91dbbfc0ec"
+checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures 0.2.1",
- "digest 0.10.2",
+ "digest 0.10.3",
 ]
 
 [[package]]
@@ -6263,7 +6265,7 @@ dependencies = [
  "schnorrkel",
  "secrecy",
  "serde",
- "sha2 0.10.1",
+ "sha2 0.10.2",
  "sp-core-hashing",
  "sp-debug-derive",
  "sp-externalities",
@@ -6287,7 +6289,7 @@ source = "git+https://github.com/paritytech/substrate.git?rev=94dfe152e61e42cd27
 dependencies = [
  "blake2-rfc",
  "byteorder",
- "sha2 0.10.1",
+ "sha2 0.10.2",
  "sp-std",
  "tiny-keccak",
  "twox-hash",

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -187,6 +187,6 @@ fn testnet_genesis(
 			target_time: 60 * 1000,
 			difficulty_adjustment_period: 56,
 		},
-		creditcoin: CreditcoinConfig { authorities: vec![] },
+		creditcoin: CreditcoinConfig::default(),
 	}
 }

--- a/pallets/creditcoin/Cargo.toml
+++ b/pallets/creditcoin/Cargo.toml
@@ -30,6 +30,7 @@ hex = { version = "0.4.3", features = ["alloc"], default-features = false }
 lexical = { version = "6.0.1", features = [
     "write-integers",
 ], default-features = false }
+sha2 = { version = "0.10.2", default-features = false }
 
 [dependencies.codec]
 default-features = false

--- a/pallets/rewards/src/mock.rs
+++ b/pallets/rewards/src/mock.rs
@@ -82,6 +82,7 @@ impl pallet_rewards::Config for Test {
 }
 
 // Build genesis storage according to the mock runtime.
+#[allow(dead_code)]
 pub fn new_test_ext() -> sp_io::TestExternalities {
 	system::GenesisConfig::default().build_storage::<Test>().unwrap().into()
 }

--- a/pallets/rewards/src/tests.rs
+++ b/pallets/rewards/src/tests.rs
@@ -1,5 +1,4 @@
 use crate::{mock::*, REWARD_HALF_LIFE};
-use frame_support::{assert_noop, assert_ok};
 
 #[test]
 fn reward_amount_genesis() {


### PR DESCRIPTION
Adds a `claim_legacy_wallet` extrinsic that accepts an ecdsa public key as a parameter. If the public key matches the sender and produces a sighash with a known legacy balance, we transfer the balance to their account and remove the entry.

To keep the amount of CTC in circulation constant, we use an account endowed at genesis with the total of the unclaimed balances and transfer from the endowed account upon claim.