### PR TITLE
Reject LoanTerms with a maturity of zero

### DIFF
--- a/pallets/creditcoin/src/helpers.rs
+++ b/pallets/creditcoin/src/helpers.rs
@@ -89,7 +89,7 @@ impl<T: Config> Pallet<T> {
 			&DealOrderFor<T>,
 		) -> Result<Option<crate::Event<T>>, crate::Error<T>>,
 	) -> Result<(), crate::Error<T>> {
-		let (deal_event, transfer_event) = DealOrders::<T>::try_mutate(
+		let result = DealOrders::<T>::try_mutate(
 			deal_order_id.expiration(),
 			deal_order_id.hash(),
 			|value| {
@@ -103,16 +103,21 @@ impl<T: Config> Pallet<T> {
 
 				Ok((deal_event, transfer_event))
 			},
-		)?;
+		);
 
-		if let Some(event) = deal_event {
-			Self::deposit_event(event);
-		}
-		if let Some(event) = transfer_event {
-			Self::deposit_event(event)
-		}
+		match result {
+			Ok((deal_event, transfer_event)) => {
+				if let Some(event) = deal_event {
+					Self::deposit_event(event);
+				}
+				if let Some(event) = transfer_event {
+					Self::deposit_event(event)
+				}
 
-		Ok(())
+				Ok(())
+			},
+			Err(e) => Err(e),
+		}
 	}
 
 	pub fn use_guid(guid: &Guid) -> Result<(), Error<T>> {

--- a/pallets/creditcoin/src/lib.rs
+++ b/pallets/creditcoin/src/lib.rs
@@ -475,7 +475,7 @@ pub mod pallet {
 			let ask_order = AskOrder {
 				blockchain: address.blockchain,
 				lender_address_id: address_id,
-				terms: terms.try_into().map_err(|_| Error::<T>::InvalidMaturity)?,
+				terms: terms.try_into().map_err(Error::<T>::from)?,
 				expiration_block,
 				block: <frame_system::Pallet<T>>::block_number(),
 				lender: who,

--- a/pallets/creditcoin/src/lib.rs
+++ b/pallets/creditcoin/src/lib.rs
@@ -309,6 +309,8 @@ pub mod pallet {
 		VerifyStringTooLong,
 
 		GuidAlreadyUsed,
+
+		InvalidMaturity,
 	}
 
 	#[pallet::genesis_config]
@@ -473,7 +475,7 @@ pub mod pallet {
 			let ask_order = AskOrder {
 				blockchain: address.blockchain,
 				lender_address_id: address_id,
-				terms: terms.into(),
+				terms: terms.try_into().map_err(|_| Error::<T>::InvalidMaturity)?,
 				expiration_block,
 				block: <frame_system::Pallet<T>>::block_number(),
 				lender: who,
@@ -503,7 +505,7 @@ pub mod pallet {
 			let bid_order = BidOrder {
 				blockchain: address.blockchain,
 				borrower_address_id: address_id,
-				terms: terms.into(),
+				terms: terms.try_into().map_err(Error::<T>::from)?,
 				expiration_block,
 				block: <frame_system::Pallet<T>>::block_number(),
 				borrower: who,
@@ -739,7 +741,7 @@ pub mod pallet {
 			let ask_order = AskOrder {
 				blockchain: lender.blockchain.clone(),
 				lender_address_id: lender_address_id.clone(),
-				terms: terms.clone().into(),
+				terms: terms.clone().try_into().map_err(Error::<T>::from)?,
 				expiration_block,
 				block: current_block,
 				lender: lender_account.clone(),
@@ -748,7 +750,7 @@ pub mod pallet {
 			let bid_order = BidOrder {
 				blockchain: lender.blockchain.clone(),
 				borrower_address_id: borrower_address_id.clone(),
-				terms: terms.clone().into(),
+				terms: terms.clone().try_into().map_err(Error::<T>::from)?,
 				expiration_block,
 				block: current_block,
 				borrower: borrower_account.clone(),

--- a/pallets/creditcoin/src/tests.rs
+++ b/pallets/creditcoin/src/tests.rs
@@ -450,10 +450,10 @@ fn add_ask_order_pre_existing() {
 fn add_add_ask_order_rejects_zero_maturity() {
 	ExtBuilder::default().build_and_execute(|| {
 		let test_info = TestInfo {
-			loan_terms: LoanTerms { amount: 0.into(), interest_rate: 0, maturity: 0 },
+			loan_terms: LoanTerms { amount: 0u64.into(), interest_rate: 0, maturity: 0 },
 			..TestInfo::new_defaults()
 		};
-		let _ = test_info.create_ask_order().unwrap();
+		let _ = test_info.create_ask_order();
 	});
 }
 
@@ -531,10 +531,10 @@ fn add_bid_order_pre_existing() {
 fn add_bid_ask_order_rejects_zero_maturity() {
 	ExtBuilder::default().build_and_execute(|| {
 		let test_info = TestInfo {
-			loan_terms: LoanTerms { amount: 0.into(), interest_rate: 0, maturity: 0 },
+			loan_terms: LoanTerms { amount: 0u64.into(), interest_rate: 0, maturity: 0 },
 			..TestInfo::new_defaults()
 		};
-		let _ = test_info.create_bid_order().unwrap();
+		let _ = test_info.create_bid_order();
 	});
 }
 


### PR DESCRIPTION
Before this PR when matching ask/bid terms we could hit a panic due to dividing by zero, which is bad.