### PR TITLE
CSUB-48 | change spec name field to "Creditcoin ..."

### DIFF
--- a/chainspecs/qaSpec.json
+++ b/chainspecs/qaSpec.json
@@ -1,6 +1,6 @@
 {
-  "name": "CC Substrate QA Network",
-  "id": "cc_substrate_qa",
+  "name": "Creditcoin QA",
+  "id": "creditcoin_qa",
   "chainType": "Live",
   "bootNodes": [],
   "telemetryEndpoints": null,

--- a/chainspecs/testnetSpec.json
+++ b/chainspecs/testnetSpec.json
@@ -1,6 +1,6 @@
 {
-  "name": "CC Substrate Testnet",
-  "id": "cc_substrate_testnet",
+  "name": "Creditcoin Testnet",
+  "id": "creditcoin_testnet",
   "chainType": "Live",
   "bootNodes": [],
   "telemetryEndpoints": null,


### PR DESCRIPTION
The current spec files name the chains "CC Substrate ...". Changing to "Creditcoin ..."