### PR TITLE
Fix fee multiplier so that fees scale with extrinsic weight

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -242,7 +242,7 @@ impl WeightToFeePolynomial for WeightToCtcFee {
 	type Balance = Balance;
 
 	fn polynomial() -> WeightToFeeCoefficients<Self::Balance> {
-		let base = Balance::from(ExtrinsicBaseWeight::get());
+		let base = Balance::from(ExtrinsicBaseWeight::get()).saturating_mul(2);
 		let ratio = TARGET_FEE_CREDO / base;
 		let rem = TARGET_FEE_CREDO % base;
 		smallvec::smallvec!(WeightToFeeCoefficient {


### PR DESCRIPTION
Transaction fees are roughly calculated as

```
WeightToFee(baseWeight) + TransactionByteFee(extrinsicLen) + [FeeMultiplier * WeightToFee(extrinsicWeight)] + optionalTip
```

The fee multiplier is to allow fees to change dynamically based on network congestion, and is configured through the `FeeMultiplierUpdate` associated type. The `FeeMultiplierUpdate` basically takes the current multiplier and returns the desired next multiplier.

Before this PR we had the `FeeMultiplierUpdate` set to `()`, which was the default value in the substrate node template. I had assumed that this default implementation just left the fee multiplier constant over time. It turns out, however, that the default implementation actually returns `0`. This means that `[FeeMultiplier * WeightToFee(extrinsicWeight)] ` was always `0`, and so our fees were only the base fee + length fee.

This PR replaces the `FeeMultiplierUpdate` with an implementation that doesn't return `0` so that we take extrinsic weight into account.