### PR TITLE
Accept any public key type in register deal order

### DIFF
--- a/pallets/creditcoin/src/lib.rs
+++ b/pallets/creditcoin/src/lib.rs
@@ -715,7 +715,7 @@ pub mod pallet {
 			borrower_signature: T::SignerSignature,
 		) -> DispatchResult {
 			let lender_account = ensure_signed(origin)?;
-			let borrower_account = borrower_key.clone().into_account();
+			let borrower_account = borrower_key.into_account();
 
 			let message =
 				Self::register_deal_order_message(expiration_block, &ask_guid, &bid_guid, &terms);

--- a/pallets/creditcoin/src/mock.rs
+++ b/pallets/creditcoin/src/mock.rs
@@ -97,6 +97,7 @@ impl pallet_creditcoin::Config for Test {
 	type AuthorityId = pallet_creditcoin::crypto::CtcAuthId;
 
 	type Signer = <Signature as Verify>::Signer;
+	type SignerSignature = Signature;
 	type FromAccountId = AccountId;
 
 	type InternalPublic = sp_core::sr25519::Public;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -277,6 +277,7 @@ impl pallet_creditcoin::Config for Runtime {
 	type Call = Call;
 	type AuthorityId = pallet_creditcoin::crypto::CtcAuthId;
 	type Signer = Signer;
+	type SignerSignature = Signature;
 	type FromAccountId = AccountId;
 	type PublicSigning = <Signature as Verify>::Signer;
 	type InternalPublic = sp_core::sr25519::Public;


### PR DESCRIPTION
We originally only supported ECDSA for the sake of simplicity on the client side, but now that we're using PolkadotJS allowing Sr25519 and Ed25519 adds very little complexity.

This PR just changes `register_deal_order` to take a MultiSigner, which is just defined as
```
pub enum MultiSigner {
    Ecdsa(ecdsa::Public),
    Sr25519(sr25519::Public),
    Ed25519(ed25519::Public),
}
```

This allows us to accept a public key of any supported crypto type.