### PR TITLE
Add mainnet chainspec + clean up chain specs + add option to configure number of mining worker threads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -933,7 +933,7 @@ dependencies = [
 
 [[package]]
 name = "creditcoin-node"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "creditcoin-node-rpc",
  "creditcoin-node-runtime",
@@ -979,7 +979,7 @@ dependencies = [
 
 [[package]]
 name = "creditcoin-node-rpc"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "creditcoin-node-runtime",
  "frame-support",
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "creditcoin-node-runtime"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",
@@ -3945,7 +3945,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-creditcoin"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "bstr",
  "ethabi",
@@ -3975,7 +3975,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-difficulty"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4006,7 +4006,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-rewards"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4476,7 +4476,7 @@ dependencies = [
 
 [[package]]
 name = "primitives"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "sp-core",
 ]
@@ -6016,7 +6016,7 @@ dependencies = [
 
 [[package]]
 name = "sha3pow"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "parity-scale-codec",
  "primitives",

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ ADD pallets /creditcoin-node/pallets
 ADD primitives /creditcoin-node/primitives
 ADD runtime /creditcoin-node/runtime
 ADD sha3pow /creditcoin-node/sha3pow
+ADD chainspecs /creditcoin-node/chainspecs
 RUN source ~/.cargo/env && cargo build --release
 
 FROM ubuntu:latest

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'creditcoin-node'
-version = '2.0.0-beta.4'
+version = '2.0.0-beta.5'
 description = 'A Creditcoin node built on substrate.'
 authors = ['Gluwa Inc.', 'Nathan Whitaker <nathan.whitaker01@gmail.com>']
 homepage = 'https://creditcoin.org'
@@ -23,7 +23,7 @@ version = '3.0.0'
 
 [dependencies.creditcoin-node-runtime]
 path = '../runtime'
-version = '2.0.0-beta.4'
+version = '2.0.0-beta.5'
 
 [dependencies]
 jsonrpc-core = '18.0.0'
@@ -35,7 +35,7 @@ log = "0.4.16"
 codec = { package = "parity-scale-codec", version = "2.3.1" }
 tiny-bip39 = "0.8.2"
 hex = "0.4.3"
-creditcoin-node-rpc = { version = "2.0.0-beta.4", path = "./rpc" }
+creditcoin-node-rpc = { version = "2.0.0-beta.5", path = "./rpc" }
 
 [dependencies.frame-benchmarking]
 git = 'https://github.com/gluwa/substrate.git'

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -2,7 +2,7 @@
 name = 'creditcoin-node'
 version = '2.0.0-beta.5'
 description = 'A Creditcoin node built on substrate.'
-authors = ['Gluwa Inc.', 'Nathan Whitaker <nathan.whitaker01@gmail.com>']
+authors = ['Gluwa Inc.', 'Nathan Whitaker <nathan.whitaker@gluwa.com>']
 homepage = 'https://creditcoin.org'
 edition = '2018'
 license = 'Unlicense'

--- a/node/rpc/Cargo.toml
+++ b/node/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "creditcoin-node-rpc"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -30,6 +30,6 @@ frame-system = { git = 'https://github.com/gluwa/substrate.git', rev = '57cab2f3
 frame-support = { git = 'https://github.com/gluwa/substrate.git', rev = '57cab2f30bcc5343771c8bc763dd6c9c9e10f0a8', version = '4.0.0-dev' }
 pallet-balances = { git = 'https://github.com/gluwa/substrate.git', rev = '57cab2f30bcc5343771c8bc763dd6c9c9e10f0a8', version = '4.0.0-dev' }
 pallet-timestamp = { git = 'https://github.com/gluwa/substrate.git', rev = '57cab2f30bcc5343771c8bc763dd6c9c9e10f0a8', version = '4.0.0-dev' }
-creditcoin-node-runtime = { version = "2.0.0-beta.4", path = "../../runtime" }
+creditcoin-node-runtime = { version = "2.0.0-beta.5", path = "../../runtime" }
 jsonrpc-pubsub = "18.0.0"
 futures = "0.3.21"

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -116,50 +116,11 @@ pub fn local_testnet_config() -> Result<ChainSpec, String> {
 }
 
 pub fn testnet_config() -> Result<ChainSpec, String> {
-	let wasm_binary = WASM_BINARY.ok_or_else(|| "Development wasm not available".to_string())?;
+	ChainSpec::from_json_bytes(&include_bytes!("../../chainspecs/testnetSpec.json")[..])
+}
 
-	Ok(ChainSpec::from_genesis(
-		// Name
-		"CC Substrate Testnet",
-		// ID
-		"cc_substrate_testnet",
-		ChainType::Live,
-		move || {
-			testnet_genesis(
-				wasm_binary,
-				// Sudo account
-				get_account_id_from_seed::<sr25519::Public>("Alice"),
-				// Pre-funded accounts
-				vec![
-					get_account_id_from_seed::<sr25519::Public>("Alice"),
-					get_account_id_from_seed::<sr25519::Public>("Bob"),
-					get_account_id_from_seed::<sr25519::Public>("Charlie"),
-					get_account_id_from_seed::<sr25519::Public>("Dave"),
-					get_account_id_from_seed::<sr25519::Public>("Eve"),
-					get_account_id_from_seed::<sr25519::Public>("Ferdie"),
-					get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
-					get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
-					get_account_id_from_seed::<sr25519::Public>("Charlie//stash"),
-					get_account_id_from_seed::<sr25519::Public>("Dave//stash"),
-					get_account_id_from_seed::<sr25519::Public>("Eve//stash"),
-					get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
-				],
-				true,
-			)
-		},
-		// Bootnodes
-		vec![],
-		// Telemetry
-		None,
-		// Protocol ID
-		None,
-		// Fork ID
-		None,
-		// Properties
-		None,
-		// Extensions
-		None,
-	))
+pub fn mainnet_config() -> Result<ChainSpec, String> {
+	ChainSpec::from_json_bytes(&include_bytes!("../../chainspecs/mainnetSpec.json")[..])
 }
 
 /// Configure initial storage state for FRAME modules.

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -50,7 +50,8 @@ pub fn development_config() -> Result<ChainSpec, String> {
 					get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
 					get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
 				],
-				true,
+				Some(6000),
+				Some(128),
 			)
 		},
 		// Bootnodes
@@ -97,7 +98,8 @@ pub fn local_testnet_config() -> Result<ChainSpec, String> {
 					get_account_id_from_seed::<sr25519::Public>("Eve//stash"),
 					get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
 				],
-				true,
+				None,
+				None,
 			)
 		},
 		// Bootnodes
@@ -128,7 +130,8 @@ fn testnet_genesis(
 	wasm_binary: &[u8],
 	root_key: AccountId,
 	endowed_accounts: Vec<AccountId>,
-	_enable_println: bool,
+	target_time: Option<u64>,
+	adjustment: Option<i64>,
 ) -> GenesisConfig {
 	GenesisConfig {
 		system: SystemConfig {
@@ -144,9 +147,9 @@ fn testnet_genesis(
 			key: Some(root_key),
 		},
 		difficulty: DifficultyConfig {
-			initial_difficulty: U256::from(1_000_000),
-			target_time: 60 * 1000,
-			difficulty_adjustment_period: 56,
+			initial_difficulty: U256::from(1_000_000u64),
+			target_time: target_time.unwrap_or(60 * 1000),
+			difficulty_adjustment_period: adjustment.unwrap_or(43),
 		},
 		creditcoin: CreditcoinConfig::default(),
 	}

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -45,9 +45,15 @@ pub struct Cli {
 	pub run: RunCmd,
 
 	#[structopt(long)]
+	/// The public key or SS58 Address of the account to receive mining rewards in.
 	pub mining_key: Option<String>,
 
+	#[structopt(long)]
+	/// The number of mining worker threads to spawn. Defaults to the number of cores if omitted.
+	pub mining_threads: Option<usize>,
+
 	#[structopt(long, parse(try_from_str = parse_rpc_pair))]
+	/// If the node is an oracle authority, the RPC URL to use for a given external chain.
 	pub rpc_mapping: Option<Vec<(String, String)>>,
 }
 #[derive(Debug, StructOpt)]

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -34,9 +34,16 @@ impl SubstrateCli for Cli {
 
 	fn load_spec(&self, id: &str) -> Result<Box<dyn sc_service::ChainSpec>, String> {
 		Ok(match id {
+			"" => {
+				let msg =
+					"Please specify the chain with '--chain main' or '--chain test'".to_owned();
+				log::error!("{}", msg);
+				return Err(msg);
+			},
 			"dev" => Box::new(chain_spec::development_config()?),
-			"" | "local" => Box::new(chain_spec::local_testnet_config()?),
-			"testnet" => Box::new(chain_spec::testnet_config()?),
+			"local" => Box::new(chain_spec::local_testnet_config()?),
+			"test" | "testnet" => Box::new(chain_spec::testnet_config()?),
+			"main" | "mainnet" => Box::new(chain_spec::mainnet_config()?),
 			path => {
 				Box::new(chain_spec::ChainSpec::from_json_file(std::path::PathBuf::from(path))?)
 			},

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -123,7 +123,12 @@ pub fn run() -> sc_cli::Result<()> {
 			runner.run_node_until_exit(|config| async move {
 				match config.role {
 					Role::Light => Err("Light clients are not supported at this time".into()),
-					_ => service::new_full(config, cli.mining_key.as_deref(), cli.rpc_mapping),
+					_ => service::new_full(
+						config,
+						cli.mining_key.as_deref(),
+						cli.mining_threads,
+						cli.rpc_mapping,
+					),
 				}
 				.map_err(sc_cli::Error::Service)
 			})

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -183,6 +183,7 @@ pub fn decode_mining_key(
 pub fn new_full(
 	config: Configuration,
 	mining_key: Option<&str>,
+	mining_threads: Option<usize>,
 	rpc_mapping: Option<impl IntoIterator<Item = (String, String)>>,
 ) -> Result<TaskManager, ServiceError> {
 	let sc_service::PartialComponents {
@@ -318,7 +319,7 @@ pub fn new_full(
 			.spawn_essential_handle()
 			.spawn_blocking("pow", "pow_group", worker_task);
 
-		let threads = num_cpus::get();
+		let threads = mining_threads.unwrap_or_else(num_cpus::get);
 		for _ in 0..threads {
 			if let Some(keystore) = keystore_container.local_keystore() {
 				let worker = worker.clone();

--- a/pallets/creditcoin/Cargo.toml
+++ b/pallets/creditcoin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-creditcoin"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/pallets/creditcoin/Cargo.toml
+++ b/pallets/creditcoin/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 description = 'FRAME pallet template for defining custom runtime logic.'
-authors = ['Gluwa Inc.', 'Nathan Whitaker <nathan.whitaker01@gmail.com>']
+authors = ['Gluwa Inc.', 'Nathan Whitaker <nathan.whitaker@gluwa.com>']
 homepage = 'https://creditcoin.org'
 license = 'Unlicense'
 publish = false

--- a/pallets/difficulty/Cargo.toml
+++ b/pallets/difficulty/Cargo.toml
@@ -2,7 +2,7 @@
 name = 'pallet-difficulty'
 version = '2.0.0-beta.5'
 description = 'FRAME pallet for dynamic difficulty adjustment.'
-authors = ['Gluwa Inc.', 'Nathan Whitaker <nathan.whitaker01@gmail.com>']
+authors = ['Gluwa Inc.', 'Nathan Whitaker <nathan.whitaker@gluwa.com>']
 edition = '2018'
 license = 'Unlicense'
 publish = false

--- a/pallets/difficulty/Cargo.toml
+++ b/pallets/difficulty/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'pallet-difficulty'
-version = '2.0.0-beta.4'
+version = '2.0.0-beta.5'
 description = 'FRAME pallet for dynamic difficulty adjustment.'
 authors = ['Gluwa Inc.', 'Nathan Whitaker <nathan.whitaker01@gmail.com>']
 edition = '2018'
@@ -15,7 +15,7 @@ targets = ['x86_64-unknown-linux-gnu']
 log = "0.4.16"
 
 [dependencies.primitives]
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 path = "../../primitives"
 
 [dependencies.sp-arithmetic]

--- a/pallets/rewards/Cargo.toml
+++ b/pallets/rewards/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'pallet-rewards'
-version = '2.0.0-beta.4'
+version = '2.0.0-beta.5'
 description = 'FRAME pallet for rewarding block authors.'
 authors = ['Gluwa Inc.', 'Nathan Whitaker <nathan.whitaker01@gmail.com>']
 edition = '2018'

--- a/pallets/rewards/Cargo.toml
+++ b/pallets/rewards/Cargo.toml
@@ -2,7 +2,7 @@
 name = 'pallet-rewards'
 version = '2.0.0-beta.5'
 description = 'FRAME pallet for rewarding block authors.'
-authors = ['Gluwa Inc.', 'Nathan Whitaker <nathan.whitaker01@gmail.com>']
+authors = ['Gluwa Inc.', 'Nathan Whitaker <nathan.whitaker@gluwa.com>']
 edition = '2018'
 license = 'Unlicense'
 publish = false

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primitives"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -2,7 +2,7 @@
 name = 'creditcoin-node-runtime'
 version = '2.0.0-beta.5'
 description = 'Creditcoin runtime built on substrate.'
-authors = ['Gluwa Inc.', 'Nathan Whitaker <nathan.whitaker01@gmail.com>']
+authors = ['Gluwa Inc.', 'Nathan Whitaker <nathan.whitaker@gluwa.com>']
 edition = '2018'
 license = 'Unlicense'
 publish = false

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'creditcoin-node-runtime'
-version = '2.0.0-beta.4'
+version = '2.0.0-beta.5'
 description = 'Creditcoin runtime built on substrate.'
 authors = ['Gluwa Inc.', 'Nathan Whitaker <nathan.whitaker01@gmail.com>']
 edition = '2018'
@@ -16,22 +16,22 @@ smallvec = "1.8.0"
 
 [dependencies.primitives]
 path = "../primitives"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 
 [dependencies.pallet-rewards]
 default-features = false
 path = '../pallets/rewards'
-version = '2.0.0-beta.4'
+version = '2.0.0-beta.5'
 
 [dependencies.pallet-difficulty]
 default-features = false
 path = '../pallets/difficulty'
-version = '2.0.0-beta.4'
+version = '2.0.0-beta.5'
 
 [dependencies.pallet-creditcoin]
 default-features = false
 path = '../pallets/creditcoin'
-version = '2.0.0-beta.4'
+version = '2.0.0-beta.5'
 
 [build-dependencies.substrate-wasm-builder]
 git = 'https://github.com/gluwa/substrate.git'

--- a/sha3pow/Cargo.toml
+++ b/sha3pow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha3pow"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
- adds mainnet chainspec (what we have so far, at least)
- includes mainnet and testnet config in binary
- you can now run the testnet by specifying `--chain test` or `--chain testnet`, and the mainnet with `--chain main` or `--chain mainnet`
- adds a CLI option to set the number of mining worker threads. useful for development if you want to run a node without consuming too much CPU (or if you're a miner and want to tweak this to try to optimize performance)
- reduces the development config's target block time to 6s, which speeds up testing during development