### PR TITLE
CSUB-57: Integration test for custom RPCs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -64,3 +64,13 @@ updates:
     directory: "/sha3pow"
     schedule:
       interval: "daily"
+
+  - package-ecosystem: "npm"
+    directory: "/integration-tests"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "npm"
+    directory: "/polkadotjs-examples"
+    schedule:
+      interval: "daily"

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -23,7 +23,9 @@
   "dependencies": {
     "@polkadot/api": "^7.12.1",
     "@polkadot/dev": "^0.65.95",
-    "@types/node": "^17.0.21"
+    "@types/node": "^17.0.21",
+    "@types/ws": "^8.5.3",
+    "ws": "^8.5.0"
   },
   "resolutions": {
     "typescript": "^4.6.2"

--- a/integration-tests/tests/rpc/creditcoin/getEvents.spec.ts
+++ b/integration-tests/tests/rpc/creditcoin/getEvents.spec.ts
@@ -1,0 +1,124 @@
+// [object Object]
+// SPDX-License-Identifier: Apache-2.0
+
+import { ApiPromise, WsProvider } from '@polkadot/api';
+import type { Vec } from '@polkadot/types-codec';
+import type { PalletCreditcoinAskOrderId, Transfer } from '../../../src/interfaces/lookup';
+
+describe('Creditcoin RPC', (): void => {
+  let api: ApiPromise;
+
+  beforeEach(async () => {
+    process.env.NODE_ENV = 'test';
+
+    const provider = new WsProvider('ws://127.0.0.1:9944');
+
+    api = await ApiPromise.create({
+      provider: provider,
+      types: {
+        // WARNING: copied from node/rpc/src/friendly.rs
+        // Will crash if we receive an event whose data type isn't defined here
+        // or references other unknown data types
+        friendly__Event: {
+          _enum: {
+            ctcTransfer: {
+              from: 'AccountId',
+              to: 'AccountId',
+              amount: String,
+            },
+            ctcDeposit: {
+              into: 'AccountId',
+              amount: String,
+            },
+            ctcWithdraw: {
+              from: 'AccountId',
+              amount: String,
+            },
+            rewardIssued: {
+              to: 'AccountId',
+              amount: String,
+            },
+            addressRegistered: {
+              address_id: 'AddressId<Hash>',
+              address: 'Address<AccountId>',
+            },
+            transferRegistered: {
+              transfer_id: 'TransferId<Hash>',
+              transfer: 'Transfer<AccountId, BlockNumber, Hash>',
+            },
+            transferVerified: {
+              transfer_id: 'TransferId<Hash>',
+              transfer: 'Transfer<AccountId, BlockNumber, Hash>',
+            },
+            transferProcessed: {
+              transfer_id: 'TransferId<Hash>',
+              transfer: 'Transfer<AccountId, BlockNumber, Hash>',
+            },
+            askOrderAdded: {
+              ask_id: 'AskOrderId<BlockNumber, Hash>',
+              ask: 'AskOrder<AccountId, BlockNumber, Hash, Moment>',
+            },
+            bidOrderAdded: {
+              bid_id: 'BidOrderId<BlockNumber, Hash>',
+              bid: 'BidOrder<AccountId, BlockNumber, Hash, Moment>',
+            },
+            offerAdded: {
+              offer_id: 'OfferId<BlockNumber, Hash>',
+              offer: 'Offer<AccountId, BlockNumber, Hash>',
+            },
+            dealOrderAdded: {
+              deal_id: 'DealOrderId<BlockNumber, Hash>',
+              deal: 'DealOrder<AccountId, BlockNumber, Hash, Moment>',
+            },
+            dealOrderFunded: {
+              deal_id: 'DealOrderId<BlockNumber, Hash>',
+              deal: 'DealOrder<AccountId, BlockNumber, Hash, Moment>',
+            },
+            dealOrderClosed: {
+              deal_id: 'DealOrderId<BlockNumber, Hash>',
+              deal: 'DealOrder<AccountId, BlockNumber, Hash, Moment>',
+            },
+            loanExempted: {
+                deal_id: 'DealOrderId<BlockNumber, Hash>',
+                exempt_transfer_id: 'TransferId<Hash>',
+            },
+            legacyWalletClaimed: {
+              new_account_id: 'AccountId',
+              legacy_sighash: 'LegacySighash',
+              claimed_balance: String,
+            },
+          }
+        },
+      },
+      rpc: {
+        creditcoin: {
+          getEvents: {
+            params: [
+              {
+                name: 'at',
+                type: 'Hash',
+                isOptional: true
+              }
+            ],
+            type: 'Vec<friendly__Event>'
+          }
+        }
+      }
+    });
+  });
+
+  afterEach(async () => {
+    await api.disconnect();
+  });
+
+  it('getEvents() should return some events', (): void => {
+    return api.rpc.creditcoin.getEvents().then(result => {
+      // in case of failures should be easy to spot what went wrong
+      console.log(`**** RESULT=${result}`);
+
+      expect(result.isEmpty).toBeFalsy();
+      expect(result.toJSON()).toEqual(expect.anything());
+    });
+  });
+
+});

--- a/integration-tests/tests/rpc/system/Sanity.spec.ts
+++ b/integration-tests/tests/rpc/system/Sanity.spec.ts
@@ -1,11 +1,10 @@
 // [object Object]
 // SPDX-License-Identifier: Apache-2.0
 
-import { ApiPromise, Keyring, WsProvider } from '@polkadot/api';
+import { ApiPromise, WsProvider } from '@polkadot/api';
 
-describe('System API', (): void => {
+describe('System RPC sanity test', (): void => {
   let api: ApiPromise;
-  let alice: KeyringPair;
 
   beforeEach(async () => {
     process.env.NODE_ENV = 'test';
@@ -13,11 +12,6 @@ describe('System API', (): void => {
     const provider = new WsProvider('ws://127.0.0.1:9944');
 
     api = await ApiPromise.create({ provider });
-
-    const keyring = new Keyring({
-      type: 'sr25519'
-    });
-    const alice = keyring.addFromUri('//Alice', { name: 'Alice' });
   });
 
   afterEach(async () => {


### PR DESCRIPTION
Builds on top of #85. Look only at the last commit. 

If I try with curl I can reach this function via JSON-RPC:

```bash
curl -H 'Content-Type: application/json' -d '{"id":"1", "jsonrpc":"2.0", "method": "creditcoin_getEvents", "params":[]}' http://127.0.0.1:9933
{"jsonrpc":"2.0","result":[{"ctcDeposit":{"amount":"28000000000000000000","into":"5DkPYq8hFiCeGxFBkz6DAwnTrvKevAJfTYrzFtr9hpDsEAU1"}},{"rewardIssued":{"amount":"28000000000000000000","to":"5DkPYq8hFiCeGxFBkz6DAwnTrvKevAJfTYrzFtr9hpDsEAU1"}}],"id":"1"}
```

However the integration test fails with

```bash
  ● Creditcoin RPC › getEvents() should return some events

    TypeError: Cannot read properties of undefined (reading 'getEvents')

      20 |
      21 |   it('getEvents() should return some events', (): void => {
    > 22 |     return api.rpc.creditcoin.getEvents().then(result => {
         |                               ^
      23 |       expect(result.toJSON()).toEqual(expect.anything());
      24 |     });
      25 |   });

      at Object.<anonymous> (src/test/rpc/creditcoin/getEvents.spec.ts:22:31)
```

Via the Polkadot Substrate web interface I can see in `Developer -> RPC calls` methods from the `author`, `chain`, `system` and other endpoints but the `creditcoin` endpoint is not present. Maybe it hasn't been registered properly.