### PR TITLE
CSUB-1: Check if miner balance changes after mining blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4019,6 +4019,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
+ "sp-tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4011,6 +4011,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "log",
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",

--- a/pallets/rewards/Cargo.toml
+++ b/pallets/rewards/Cargo.toml
@@ -78,6 +78,10 @@ git = 'https://github.com/gluwa/substrate.git'
 rev = '57cab2f30bcc5343771c8bc763dd6c9c9e10f0a8'
 version = '4.0.0-dev'
 
+[dev-dependencies.log]
+default-features = false
+version = "0.4.15"
+
 [features]
 default = ['std']
 runtime-benchmarks = ['frame-benchmarking']

--- a/pallets/rewards/Cargo.toml
+++ b/pallets/rewards/Cargo.toml
@@ -11,6 +11,9 @@ repository = 'https://github.com/gluwa/creditcoin-substrate/'
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']
 
+[dependencies]
+log = "0.4.16"
+
 [dependencies.codec]
 default-features = false
 features = ['derive']
@@ -78,9 +81,11 @@ git = 'https://github.com/gluwa/substrate.git'
 rev = '57cab2f30bcc5343771c8bc763dd6c9c9e10f0a8'
 version = '4.0.0-dev'
 
-[dev-dependencies.log]
+[dev-dependencies.sp-tracing]
 default-features = false
-version = "0.4.15"
+git = 'https://github.com/gluwa/substrate.git'
+rev = '57cab2f30bcc5343771c8bc763dd6c9c9e10f0a8'
+version = '4.0.0-dev'
 
 [features]
 default = ['std']
@@ -92,5 +97,6 @@ std = [
     'frame-system/std',
     'frame-benchmarking/std',
     'sp-consensus-pow/std',
+    'pallet-balances/std',
 ]
 try-runtime = ['frame-support/try-runtime']

--- a/pallets/rewards/src/mock.rs
+++ b/pallets/rewards/src/mock.rs
@@ -88,6 +88,7 @@ impl pallet_rewards::Config for Test {
 
 // Build genesis storage according to the mock runtime.
 pub fn new_test_ext() -> sp_io::TestExternalities {
+	sp_tracing::try_init_simple();
 	let mut t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
 	// accounts 1 to 5 have initial balances
 	pallet_balances::GenesisConfig::<Test> {

--- a/pallets/rewards/src/tests.rs
+++ b/pallets/rewards/src/tests.rs
@@ -53,9 +53,6 @@ fn rewards_were_issued_after_mining_blocks() {
 		roll_to(10, 1);
 
 		let new_balance = Balances::free_balance(1);
-
-		log::debug!("******* BALANCES={:?}, {:?}", initial_balance, new_balance);
-
 		assert!(new_balance > initial_balance);
 	});
 }

--- a/pallets/rewards/src/tests.rs
+++ b/pallets/rewards/src/tests.rs
@@ -50,7 +50,7 @@ fn rewards_were_issued_after_mining_blocks() {
 		let initial_balance = Balances::free_balance(1);
 
 		assert!(initial_balance > 0);
-		roll_to(10);
+		roll_to(10, 1);
 
 		let new_balance = Balances::free_balance(1);
 

--- a/pallets/rewards/src/tests.rs
+++ b/pallets/rewards/src/tests.rs
@@ -33,13 +33,29 @@ fn reward_amount_limit() {
 #[test]
 fn issue_reward_handling() {
 	new_test_ext().execute_with(|| {
-		Rewards::issue_reward(123456, 55);
+		Rewards::issue_reward(1, 55);
 
 		let event = <frame_system::Pallet<Test>>::events()
 			.pop()
 			.expect("Expected at least one EventRecord to be found")
 			.event;
 
-		assert_eq!(event, crate::mock::Event::Rewards(crate::Event::RewardIssued(123456, 55)),);
+		assert_eq!(event, crate::mock::Event::Rewards(crate::Event::RewardIssued(1, 55)),);
+	});
+}
+
+#[test]
+fn rewards_were_issued_after_mining_blocks() {
+	new_test_ext().execute_with(|| {
+		let initial_balance = Balances::free_balance(1);
+
+		assert!(initial_balance > 0);
+		roll_to(10);
+
+		let new_balance = Balances::free_balance(1);
+
+		log::debug!("******* BALANCES={:?}, {:?}", initial_balance, new_balance);
+
+		assert!(new_balance > initial_balance);
 	});
 }


### PR DESCRIPTION
I am getting a failure here

```
failures:

---- tests::rewards_were_issued_after_mining_blocks stdout ----
thread 'main' panicked at 'assertion failed: new_balance > initial_balance', pallets/rewards/src/tests.rs:49:9
```

and also not seeing the values printed by `log::debug!()` while I am seeing other values coming from `log::debug!` from other test functions. 

@nathanwhit my idea was to simulate mining of a few blocks and then see if there was a change in the balance of account 1.  Do you have any pointers to what I am doing incorrectly? 