### PR TITLE
changed base image for ci-linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ADD sha3pow /creditcoin-node/sha3pow
 ADD chainspecs /creditcoin-node/chainspecs
 RUN source ~/.cargo/env && cargo build --release
 
-FROM ubuntu:latest
+FROM ubuntu:20.04
 EXPOSE 30333/tcp
 EXPOSE 30333/udp
 EXPOSE 9944 9933 9615

--- a/ci-linux/ci-linux.Dockerfile
+++ b/ci-linux/ci-linux.Dockerfile
@@ -1,5 +1,5 @@
 #Build the image and tag it creditcoin/ci-linux:production
-FROM debian:bullseye-slim
+FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND=noninteractive
 SHELL ["/bin/bash", "-c"]
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
Debian base image for `ci-linux` having rustup nightly inconsistencies. #115