### PR TITLE
ci: Don't use secrets.CODECOV_TOKEN anymore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,6 @@ jobs:
 
       - uses: codecov/codecov-action@v2
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ steps.coverage.outputs.report }}
           fail_ci_if_error: true
           verbose: true


### PR DESCRIPTION
This is a public repo and it doesn't need to use a secret token
anymore. In addition after the repository rename CodeCov got
confused and the token value is different too.