### PR TITLE
[CSUB-98] Rework register transfer

### DIFF
--- a/node/rpc/src/friendly.rs
+++ b/node/rpc/src/friendly.rs
@@ -70,7 +70,6 @@ pub enum Event {
 
 	LoanExempted {
 		deal_id: DealOrderId<BlockNumber, Hash>,
-		exempt_transfer_id: TransferId<Hash>,
 	},
 
 	LegacyWalletClaimed {
@@ -134,9 +133,7 @@ impl Event {
 				pallet_creditcoin::Event::DealOrderClosed(deal_id, deal) => {
 					Event::DealOrderClosed { deal_id, deal }
 				},
-				pallet_creditcoin::Event::LoanExempted(deal_id, exempt_transfer_id) => {
-					Event::LoanExempted { deal_id, exempt_transfer_id }
-				},
+				pallet_creditcoin::Event::LoanExempted(deal_id) => Event::LoanExempted { deal_id },
 				pallet_creditcoin::Event::LegacyWalletClaimed(
 					new_account_id,
 					legacy_sighash,

--- a/pallets/creditcoin/src/helpers.rs
+++ b/pallets/creditcoin/src/helpers.rs
@@ -139,44 +139,26 @@ impl<T: Config> Pallet<T> {
 		let transfer_id = TransferId::new::<T>(&from.blockchain, &blockchain_tx_id);
 		ensure!(!Transfers::<T>::contains_key(&transfer_id), Error::<T>::TransferAlreadyRegistered);
 
-		if *blockchain_tx_id == *b"0" {
-			// this transfer is an exemption, no need to verify it
-			let transfer = Transfer {
-				blockchain: from.blockchain,
-				kind: transfer_kind,
-				amount: ExternalAmount::zero(),
-				block: <frame_system::Pallet<T>>::block_number(),
-				from: from_id,
-				to: to_id,
-				order_id,
-				processed: false,
-				sighash: who,
-				tx: blockchain_tx_id,
-			};
-			Transfers::<T>::insert(transfer_id.clone(), transfer.clone());
-			Ok((transfer_id, transfer))
-		} else {
-			let transfer = Transfer {
-				blockchain: from.blockchain,
-				kind: transfer_kind,
-				amount,
-				block: <frame_system::Pallet<T>>::block_number(),
-				from: from_id,
-				to: to_id,
-				order_id,
-				processed: false,
-				sighash: who,
-				tx: blockchain_tx_id,
-			};
+		let transfer = Transfer {
+			blockchain: from.blockchain,
+			kind: transfer_kind,
+			amount,
+			block: <frame_system::Pallet<T>>::block_number(),
+			from: from_id,
+			to: to_id,
+			order_id,
+			processed: false,
+			sighash: who,
+			tx: blockchain_tx_id,
+		};
 
-			let pending = UnverifiedTransfer {
-				from_external: from.value,
-				to_external: to.value,
-				transfer: transfer.clone(),
-			};
-			UnverifiedTransfers::<T>::try_mutate(|transfers| transfers.try_push(pending))
-				.map_err(|()| Error::<T>::UnverifiedTransferPoolFull)?;
-			Ok((transfer_id, transfer))
-		}
+		let pending = UnverifiedTransfer {
+			from_external: from.value,
+			to_external: to.value,
+			transfer: transfer.clone(),
+		};
+		UnverifiedTransfers::<T>::try_mutate(|transfers| transfers.try_push(pending))
+			.map_err(|()| Error::<T>::UnverifiedTransferPoolFull)?;
+		Ok((transfer_id, transfer))
 	}
 }

--- a/pallets/creditcoin/src/helpers.rs
+++ b/pallets/creditcoin/src/helpers.rs
@@ -144,7 +144,7 @@ impl<T: Config> Pallet<T> {
 			let transfer = Transfer {
 				blockchain: from.blockchain,
 				kind: transfer_kind,
-				amount,
+				amount: ExternalAmount::zero(),
 				block: <frame_system::Pallet<T>>::block_number(),
 				from: from_id,
 				to: to_id,

--- a/pallets/creditcoin/src/lib.rs
+++ b/pallets/creditcoin/src/lib.rs
@@ -944,7 +944,7 @@ pub mod pallet {
 
 					Ok(Some(Event::<T>::DealOrderClosed(deal_order_id.clone(), deal_order.clone())))
 				},
-				|transfer, deal_order| {
+				|transfer, _deal_order| {
 					ensure!(
 						transfer.order_id == OrderId::Deal(deal_order_id.clone()),
 						Error::<T>::TransferMismatch
@@ -953,14 +953,6 @@ pub mod pallet {
 					ensure!(transfer.block <= Self::block_number(), Error::<T>::MalformedTransfer);
 					ensure!(transfer.sighash == who, Error::<T>::TransferMismatch);
 					ensure!(!transfer.processed, Error::<T>::TransferAlreadyProcessed);
-
-					//TODO: add compound interest formula
-					let expected_interest = deal_order.terms.calc_interest();
-
-					ensure!(
-						transfer.amount >= expected_interest + deal_order.terms.amount,
-						Error::<T>::TransferAmountInsufficient
-					);
 
 					transfer.processed = true;
 					Ok(Some(Event::<T>::TransferProcessed(transfer_id.clone(), transfer.clone())))

--- a/pallets/creditcoin/src/lib.rs
+++ b/pallets/creditcoin/src/lib.rs
@@ -1054,14 +1054,14 @@ pub mod pallet {
 					tx: ExternalTxId::try_from(b"0".to_vec()).expect(
 						"0 is a length of one which will always be < size bound of ExternalTxId",
 					),
-					blockchain: lender.blockchain.clone(),
+					blockchain: lender.blockchain,
 					from: deal_order.lender_address_id.clone(),
 					to: deal_order.lender_address_id.clone(),
 				};
 					let fake_transfer_id =
 						TransferId::new::<T>(&fake_transfer.blockchain, &fake_transfer.tx);
 
-					deal_order.repayment_transfer_id = Some(fake_transfer_id.clone());
+					deal_order.repayment_transfer_id = Some(fake_transfer_id);
 
 					Ok(())
 				},

--- a/pallets/creditcoin/src/lib.rs
+++ b/pallets/creditcoin/src/lib.rs
@@ -1001,7 +1001,7 @@ pub mod pallet {
 		pub fn register_repayment_transfer(
 			origin: OriginFor<T>,
 			transfer_kind: TransferKind,
-			gain: ExternalAmount,
+			repayment_amount: ExternalAmount,
 			deal_order_id: DealOrderId<T::BlockNumber, T::Hash>,
 			blockchain_tx_id: ExternalTxId,
 		) -> DispatchResult {
@@ -1014,7 +1014,7 @@ pub mod pallet {
 				order.borrower_address_id,
 				order.lender_address_id,
 				transfer_kind,
-				order.terms.amount + gain,
+				repayment_amount,
 				OrderId::Deal(deal_order_id),
 				blockchain_tx_id,
 			)?;

--- a/pallets/creditcoin/src/lib.rs
+++ b/pallets/creditcoin/src/lib.rs
@@ -54,6 +54,7 @@ pub mod pallet {
 		dispatch::DispatchResult,
 		pallet_prelude::*,
 		traits::{tokens::ExistenceRequirement, Currency},
+		transactional,
 		weights::PostDispatchInfo,
 	};
 	use frame_system::{
@@ -968,94 +969,56 @@ pub mod pallet {
 
 			Ok(())
 		}
+
+		#[transactional]
 		#[pallet::weight(10_000 + T::DbWeight::get().reads_writes(3,1))]
-		pub fn register_transfer(
+		pub fn register_funding_transfer(
 			origin: OriginFor<T>,
 			transfer_kind: TransferKind,
-			gain: ExternalAmount,
-			order_id: OrderId<T::BlockNumber, T::Hash>,
+			deal_order_id: DealOrderId<T::BlockNumber, T::Hash>,
 			blockchain_tx_id: ExternalTxId,
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 
-			let (from_id, to_id, mut amount) = match &order_id {
-				OrderId::Deal(deal_order_id) => {
-					let order = try_get_id!(DealOrders<T>, &deal_order_id, NonExistentDealOrder)?;
+			let order = try_get_id!(DealOrders<T>, &deal_order_id, NonExistentDealOrder)?;
 
-					if gain.is_zero() {
-						// transfer for initial loan
-						(order.lender_address_id, order.borrower_address_id, order.terms.amount)
-					} else {
-						// transfer to repay loan
-						(order.borrower_address_id, order.lender_address_id, order.terms.amount)
-					}
-				},
-				OrderId::Repayment(_) => {
-					ensure!(gain.is_zero(), Error::<T>::RepaymentOrderNonZeroGain);
-					return Err(Error::<T>::RepaymentOrderUnsupported.into());
-				},
-			};
+			let (transfer_id, transfer) = Self::register_transfer_internal(
+				who,
+				order.lender_address_id,
+				order.borrower_address_id,
+				transfer_kind,
+				order.terms.amount,
+				OrderId::Deal(deal_order_id),
+				blockchain_tx_id,
+			)?;
+			Self::deposit_event(Event::<T>::TransferRegistered(transfer_id, transfer));
 
-			let from = Self::get_address(&from_id)?;
-			let to = Self::get_address(&to_id)?;
+			Ok(())
+		}
 
-			ensure!(from.owner == who, Error::<T>::NotAddressOwner);
+		#[transactional]
+		#[pallet::weight(10_000 + T::DbWeight::get().reads_writes(3,1))]
+		pub fn register_repayment_transfer(
+			origin: OriginFor<T>,
+			transfer_kind: TransferKind,
+			gain: ExternalAmount,
+			deal_order_id: DealOrderId<T::BlockNumber, T::Hash>,
+			blockchain_tx_id: ExternalTxId,
+		) -> DispatchResult {
+			let who = ensure_signed(origin)?;
 
-			ensure!(from.blockchain == to.blockchain, Error::<T>::AddressPlatformMismatch);
+			let order = try_get_id!(DealOrders<T>, &deal_order_id, NonExistentDealOrder)?;
 
-			ensure!(from.blockchain.supports(&transfer_kind), Error::<T>::UnsupportedTransferKind);
-
-			let transfer_id = TransferId::new::<T>(&from.blockchain, &blockchain_tx_id);
-			ensure!(
-				!Transfers::<T>::contains_key(&transfer_id),
-				Error::<T>::TransferAlreadyRegistered
-			);
-
-			if *blockchain_tx_id == *b"0" {
-				// this transfer is an exemption, no need to verify it
-				amount = ExternalAmount::zero();
-				let transfer = Transfer {
-					blockchain: from.blockchain,
-					kind: transfer_kind,
-					amount,
-					block: <frame_system::Pallet<T>>::block_number(),
-					from: from_id,
-					to: to_id,
-					order_id,
-					processed: false,
-					sighash: who,
-					tx: blockchain_tx_id,
-				};
-				Self::deposit_event(Event::<T>::TransferRegistered(
-					transfer_id.clone(),
-					transfer.clone(),
-				));
-				Transfers::<T>::insert(transfer_id, transfer);
-			} else {
-				amount += gain;
-				let transfer = Transfer {
-					blockchain: from.blockchain,
-					kind: transfer_kind,
-					amount,
-					block: <frame_system::Pallet<T>>::block_number(),
-					from: from_id,
-					to: to_id,
-					order_id,
-					processed: false,
-					sighash: who,
-					tx: blockchain_tx_id,
-				};
-
-				Self::deposit_event(Event::<T>::TransferRegistered(transfer_id, transfer.clone()));
-
-				let pending = UnverifiedTransfer {
-					from_external: from.value,
-					to_external: to.value,
-					transfer,
-				};
-				UnverifiedTransfers::<T>::try_mutate(|transfers| transfers.try_push(pending))
-					.map_err(|()| Error::<T>::UnverifiedTransferPoolFull)?;
-			}
+			let (transfer_id, transfer) = Self::register_transfer_internal(
+				who,
+				order.borrower_address_id,
+				order.lender_address_id,
+				transfer_kind,
+				order.terms.amount + gain,
+				OrderId::Deal(deal_order_id),
+				blockchain_tx_id,
+			)?;
+			Self::deposit_event(Event::<T>::TransferRegistered(transfer_id, transfer));
 
 			Ok(())
 		}

--- a/pallets/creditcoin/src/tests.rs
+++ b/pallets/creditcoin/src/tests.rs
@@ -1,8 +1,8 @@
 use crate::{
 	mock::*, types::DoubleMapExt, AddressId, AskOrder, AskOrderId, Authorities, BidOrder,
 	BidOrderId, Blockchain, DealOrder, DealOrderId, DealOrders, ExternalAddress, ExternalAmount,
-	Guid, Id, LegacySighash, LoanTerms, Offer, OfferId, OrderId, TransferId, TransferKind,
-	Transfers,
+	Guid, Id, LegacySighash, LoanTerms, Offer, OfferId, OrderId, Transfer, TransferId,
+	TransferKind, Transfers,
 };
 use bstr::B;
 use codec::{Decode, Encode};
@@ -77,10 +77,12 @@ type TestAskOrderId = AskOrderId<u64, H256>;
 type TestBidOrderId = BidOrderId<u64, H256>;
 type TestOfferId = OfferId<u64, H256>;
 type TestDealOrderId = DealOrderId<u64, H256>;
+type TestTransferId = TransferId<H256>;
 type TestAskOrder = (AskOrder<AccountId, u64, H256, u64>, TestAskOrderId);
 type TestBidOrder = (BidOrder<AccountId, u64, H256, u64>, TestBidOrderId);
 type TestOffer = (Offer<AccountId, u64, H256>, TestOfferId);
 type TestDealOrder = (DealOrder<AccountId, u64, H256, u64>, TestDealOrderId);
+type TestTransfer = (Transfer<AccountId, u64, H256>, TestTransferId);
 
 #[derive(Clone, Debug)]
 pub struct TestInfo {
@@ -179,6 +181,63 @@ impl TestInfo {
 		let deal_order_id = DealOrderId::new::<Test>(expiration_block.clone(), &offer_id);
 
 		(Creditcoin::deal_orders(expiration_block, deal_order_id.hash()).unwrap(), deal_order_id)
+	}
+
+	pub fn create_funding_transfer(&self, deal_order_id: &TestDealOrderId) -> TestTransfer {
+		let deal_order =
+			Creditcoin::deal_orders(deal_order_id.expiration(), deal_order_id.hash()).unwrap();
+		let tx = "0xfafafa";
+		assert_ok!(Creditcoin::register_funding_transfer(
+			Origin::signed(self.lender.account_id.clone()),
+			TransferKind::Native,
+			deal_order_id.clone(),
+			tx.as_bytes().into_bounded()
+		));
+		self.mock_transfer(&self.lender, &self.borrower, deal_order.terms.amount, deal_order_id, tx)
+	}
+
+	pub fn create_repayment_transfer(
+		&self,
+		deal_order_id: &TestDealOrderId,
+		amount: impl Into<ExternalAmount>,
+	) -> TestTransfer {
+		let tx = "0xafafaf";
+		let amount = amount.into();
+		assert_ok!(Creditcoin::register_repayment_transfer(
+			Origin::signed(self.borrower.account_id.clone()),
+			TransferKind::Native,
+			amount.clone(),
+			deal_order_id.clone(),
+			tx.as_bytes().into_bounded()
+		));
+
+		self.mock_transfer(&self.borrower, &self.lender, amount, deal_order_id, tx)
+	}
+
+	pub fn mock_transfer(
+		&self,
+		from: &RegisteredAddress,
+		to: &RegisteredAddress,
+		amount: impl Into<ExternalAmount>,
+		deal_order_id: &TestDealOrderId,
+		blockchain_tx_id: impl AsRef<[u8]>,
+	) -> TestTransfer {
+		let tx = blockchain_tx_id.as_ref().into_bounded();
+		let id = TransferId::new::<Test>(&Blockchain::Rinkeby, &tx);
+		let transfer = Transfer {
+			blockchain: self.blockchain.clone(),
+			kind: TransferKind::Native,
+			from: from.address_id.clone(),
+			to: to.address_id.clone(),
+			order_id: OrderId::Deal(deal_order_id.clone()),
+			amount: amount.into(),
+			tx,
+			block: System::block_number(),
+			processed: false,
+			sighash: from.account_id.clone(),
+		};
+		Transfers::<Test>::insert(&id, &transfer);
+		(transfer, id)
 	}
 
 	pub fn get_register_deal_msg(&self) -> Vec<u8> {
@@ -980,7 +1039,7 @@ fn fund_deal_order_should_error_when_transfer_order_id_doesnt_match_deal_order_i
 			expiration_block: 3_333,
 		};
 
-		let (bogus_deal_order, bogus_deal_order_id) = second_test_info.create_deal_order();
+		let (_bogus_deal_order, bogus_deal_order_id) = second_test_info.create_deal_order();
 
 		//  insert as exemption to bypass transfer verification
 		let tx_hash = "0".as_bytes().into_bounded();
@@ -992,8 +1051,8 @@ fn fund_deal_order_should_error_when_transfer_order_id_doesnt_match_deal_order_i
 			bogus_deal_order_id.clone(),
 			tx_hash.clone()
 		));
-
-		let transfer_id = TransferId::new::<Test>(&bogus_deal_order.blockchain, &tx_hash.clone());
+		let (_transfer, transfer_id) =
+			second_test_info.create_funding_transfer(&bogus_deal_order_id);
 
 		// try funding DealOrder from Person1 with the transfer from Person2,
 		// which points to a different order_id
@@ -1012,7 +1071,7 @@ fn fund_deal_order_should_error_when_transfer_order_id_doesnt_match_deal_order_i
 fn fund_deal_order_should_error_when_transfer_amount_doesnt_match() {
 	ExtBuilder::default().build_and_execute(|| {
 		let test_info = TestInfo::new_defaults();
-		let (deal_order, deal_order_id) = test_info.create_deal_order();
+		let (_deal_order, deal_order_id) = test_info.create_deal_order();
 
 		//  insert as exemption to bypass transfer verification
 		let tx_hash = "0".as_bytes().into_bounded();
@@ -1025,7 +1084,7 @@ fn fund_deal_order_should_error_when_transfer_amount_doesnt_match() {
 			tx_hash.clone()
 		));
 
-		let transfer_id = TransferId::new::<Test>(&deal_order.blockchain, &tx_hash.clone());
+		let (_transfer, transfer_id) = test_info.create_funding_transfer(&deal_order_id);
 
 		// modify deal amount in order to cause transfer mismatch
 		crate::DealOrders::<Test>::mutate(
@@ -1065,7 +1124,7 @@ fn fund_deal_order_should_error_when_transfer_sighash_doesnt_match_lender() {
 			tx_hash.clone()
 		));
 
-		let transfer_id = TransferId::new::<Test>(&deal_order.blockchain, &tx_hash.clone());
+		let (_transfer, transfer_id) = test_info.create_funding_transfer(&deal_order_id);
 
 		// modify transfer in order to cause transfer mismatch
 		crate::Transfers::<Test>::mutate(&transfer_id, |transfer_storage| {
@@ -1092,18 +1151,7 @@ fn fund_deal_order_should_error_when_transfer_has_been_processed() {
 		let test_info = TestInfo::new_defaults();
 		let (deal_order, deal_order_id) = test_info.create_deal_order();
 
-		//  insert as exemption to bypass transfer verification
-		let tx_hash = "0".as_bytes().into_bounded();
-		let contract = "0x0ad1439a0e0bfdcd49939f9722866651a4aa9b3c".as_bytes().into_bounded();
-
-		assert_ok!(Creditcoin::register_funding_transfer(
-			Origin::signed(test_info.lender.account_id.clone()),
-			TransferKind::Ethless(contract.clone()),
-			deal_order_id.clone(),
-			tx_hash.clone()
-		));
-
-		let transfer_id = TransferId::new::<Test>(&deal_order.blockchain, &tx_hash.clone());
+		let (_transfer, transfer_id) = test_info.create_funding_transfer(&deal_order_id);
 
 		// modify transfer in order to cause an error
 		crate::Transfers::<Test>::mutate(&transfer_id, |transfer_storage| {
@@ -1141,7 +1189,7 @@ fn fund_deal_order_works() {
 			tx_hash.clone()
 		));
 
-		let transfer_id = TransferId::new::<Test>(&deal_order.blockchain, &tx_hash.clone());
+		let (_transfer, transfer_id) = test_info.create_funding_transfer(&deal_order_id);
 
 		// modify transfer b/c amount above is 0
 		crate::Transfers::<Test>::mutate(&transfer_id, |transfer_storage| {
@@ -1799,23 +1847,10 @@ fn close_deal_order_should_error_when_transfer_order_id_doesnt_match_deal_order_
 			expiration_block: 3_333,
 		};
 
-		let (bogus_deal_order, bogus_deal_order_id) = second_test_info.create_deal_order();
+		let (_bogus_deal_order, bogus_deal_order_id) = second_test_info.create_deal_order();
 
-		//  insert as exemption to bypass transfer verification
-		let tx_hash = "0".as_bytes().into_bounded();
-		let contract = "0x0ad1439a0e0bfdcd49939f9722866651a4aa9b3c".as_bytes().into_bounded();
-
-		assert_ok!(Creditcoin::register_transfer_internal(
-			second_test_info.borrower.account_id.clone(),
-			second_test_info.borrower.address_id.clone(),
-			second_test_info.lender.address_id.clone(),
-			TransferKind::Ethless(contract.clone()),
-			33u64.into(),
-			OrderId::Deal(bogus_deal_order_id.clone()),
-			tx_hash.clone()
-		));
-
-		let transfer_id = TransferId::new::<Test>(&bogus_deal_order.blockchain, &tx_hash.clone());
+		let (_, transfer_id) =
+			second_test_info.create_repayment_transfer(&bogus_deal_order_id, 33u64);
 
 		// Person1 tries closing the deal by using the transfer made by Person2
 		assert_noop!(
@@ -1845,21 +1880,8 @@ fn close_deal_order_should_error_when_transfer_block_is_greater_than_current_blo
 			},
 		);
 
-		//  insert as exemption to bypass transfer verification
-		let tx_hash = "0".as_bytes().into_bounded();
-		let contract = "0x0ad1439a0e0bfdcd49939f9722866651a4aa9b3c".as_bytes().into_bounded();
-
-		assert_ok!(Creditcoin::register_transfer_internal(
-			test_info.borrower.account_id.clone(),
-			test_info.borrower.address_id.clone(),
-			test_info.lender.address_id.clone(),
-			TransferKind::Ethless(contract.clone()),
-			33u64.into(),
-			OrderId::Deal(deal_order_id.clone()),
-			tx_hash.clone()
-		));
-
-		let transfer_id = TransferId::new::<Test>(&deal_order.blockchain, &tx_hash.clone());
+		let (_transfer, transfer_id) =
+			test_info.create_repayment_transfer(&deal_order_id, deal_order.terms.amount.clone());
 
 		// modify transfer in order to cause transfer mismatch
 		crate::Transfers::<Test>::mutate(&transfer_id, |transfer_storage| {
@@ -1896,27 +1918,12 @@ fn close_deal_order_should_error_when_transfer_sighash_doesnt_match_borrower() {
 			},
 		);
 
-		//  insert as exemption to bypass transfer verification
-		let tx_hash = "0".as_bytes().into_bounded();
-		let contract = "0x0ad1439a0e0bfdcd49939f9722866651a4aa9b3c".as_bytes().into_bounded();
-
-		assert_ok!(Creditcoin::register_transfer_internal(
-			test_info.borrower.account_id.clone(),
-			test_info.borrower.address_id.clone(),
-			test_info.lender.address_id.clone(),
-			TransferKind::Ethless(contract.clone()),
-			33u64.into(),
-			OrderId::Deal(deal_order_id.clone()),
-			tx_hash.clone()
-		));
-
-		let transfer_id = TransferId::new::<Test>(&deal_order.blockchain, &tx_hash.clone());
+		let (_, transfer_id) =
+			test_info.create_repayment_transfer(&deal_order_id, deal_order.terms.amount.clone());
 
 		// modify transfer in order to cause transfer mismatch
 		crate::Transfers::<Test>::mutate(&transfer_id, |transfer_storage| {
 			let mut ts = transfer_storage.as_mut().unwrap();
-			// b/c amount above is 0
-			ts.amount = deal_order.terms.amount;
 			ts.sighash = AccountId::new([44; 32]);
 		});
 
@@ -1947,27 +1954,13 @@ fn close_deal_order_should_error_when_transfer_has_already_been_processed() {
 			},
 		);
 
-		//  insert as exemption to bypass transfer verification
-		let tx_hash = "0".as_bytes().into_bounded();
-		let contract = "0x0ad1439a0e0bfdcd49939f9722866651a4aa9b3c".as_bytes().into_bounded();
-
-		assert_ok!(Creditcoin::register_transfer_internal(
-			test_info.borrower.account_id.clone(),
-			test_info.borrower.address_id.clone(),
-			test_info.lender.address_id.clone(),
-			TransferKind::Ethless(contract.clone()),
-			33u64.into(),
-			OrderId::Deal(deal_order_id.clone()),
-			tx_hash.clone()
-		));
-
-		let transfer_id = TransferId::new::<Test>(&deal_order.blockchain, &tx_hash.clone());
+		let (_, transfer_id) =
+			test_info.create_repayment_transfer(&deal_order_id, deal_order.terms.amount.clone());
 
 		// modify transfer in order to cause transfer mismatch
 		crate::Transfers::<Test>::mutate(&transfer_id, |transfer_storage| {
 			let mut ts = transfer_storage.as_mut().unwrap();
 			// b/c amount above is 0
-			ts.amount = deal_order.terms.amount;
 			ts.processed = true;
 		});
 
@@ -1986,7 +1979,7 @@ fn close_deal_order_should_error_when_transfer_has_already_been_processed() {
 fn close_deal_order_should_error_when_transfer_amount_is_not_enough() {
 	ExtBuilder::default().build_and_execute(|| {
 		let test_info = TestInfo::new_defaults();
-		let (deal_order, deal_order_id) = test_info.create_deal_order();
+		let (_deal_order, deal_order_id) = test_info.create_deal_order();
 
 		// lock DealOrder
 		crate::DealOrders::<Test>::mutate(
@@ -1998,28 +1991,7 @@ fn close_deal_order_should_error_when_transfer_amount_is_not_enough() {
 			},
 		);
 
-		//  insert as exemption to bypass transfer verification
-		let tx_hash = "0".as_bytes().into_bounded();
-		let contract = "0x0ad1439a0e0bfdcd49939f9722866651a4aa9b3c".as_bytes().into_bounded();
-
-		assert_ok!(Creditcoin::register_transfer_internal(
-			test_info.borrower.account_id.clone(),
-			test_info.borrower.address_id.clone(),
-			test_info.lender.address_id.clone(),
-			TransferKind::Ethless(contract.clone()),
-			33u64.into(),
-			OrderId::Deal(deal_order_id.clone()),
-			tx_hash.clone()
-		));
-
-		let transfer_id = TransferId::new::<Test>(&deal_order.blockchain, &tx_hash.clone());
-
-		// modify transfer in order to cause transfer mismatch
-		crate::Transfers::<Test>::mutate(&transfer_id, |transfer_storage| {
-			let mut ts = transfer_storage.as_mut().unwrap();
-			// NOTE: amount not enough to repay loan + interest
-			ts.amount = ExternalAmount::from(1u64);
-		});
+		let (_, transfer_id) = test_info.create_repayment_transfer(&deal_order_id, 1);
 
 		assert_noop!(
 			Creditcoin::close_deal_order(
@@ -2064,7 +2036,10 @@ fn close_deal_order_should_succeed() {
 			tx_hash.clone()
 		));
 
-		let transfer_id = TransferId::new::<Test>(&deal_order.blockchain, &tx_hash.clone());
+		let (_, transfer_id) = test_info.create_repayment_transfer(
+			&deal_order_id,
+			deal_order.terms.amount + deal_order.terms.calc_interest() + 1u64,
+		);
 
 		// modify transfer to make sure we have transfered enough funds
 		crate::Transfers::<Test>::mutate(&transfer_id, |transfer_storage| {

--- a/pallets/creditcoin/src/tests.rs
+++ b/pallets/creditcoin/src/tests.rs
@@ -2107,10 +2107,9 @@ fn close_deal_order_should_succeed() {
 fn exempt_should_error_when_not_signed() {
 	ExtBuilder::default().build_and_execute(|| {
 		let test_info = TestInfo::new_defaults();
-		let (deal_order, deal_order_id) = test_info.create_deal_order();
-		let transfer_id = TransferId::new::<Test>(&deal_order.blockchain, b"12345678");
+		let (_deal_order, deal_order_id) = test_info.create_deal_order();
 
-		assert_noop!(Creditcoin::exempt(Origin::none(), deal_order_id, transfer_id,), BadOrigin);
+		assert_noop!(Creditcoin::exempt(Origin::none(), deal_order_id), BadOrigin);
 	});
 }
 
@@ -2119,7 +2118,6 @@ fn exempt_should_error_when_deal_order_has_already_been_repaid() {
 	ExtBuilder::default().build_and_execute(|| {
 		let test_info = TestInfo::new_defaults();
 		let (deal_order, deal_order_id) = test_info.create_deal_order();
-		let transfer_id = TransferId::new::<Test>(&deal_order.blockchain, b"12345678");
 
 		// simulate DealOrder which has been repaid
 		crate::DealOrders::<Test>::mutate(
@@ -2132,11 +2130,7 @@ fn exempt_should_error_when_deal_order_has_already_been_repaid() {
 		);
 
 		assert_noop!(
-			Creditcoin::exempt(
-				Origin::signed(test_info.lender.account_id),
-				deal_order_id,
-				transfer_id,
-			),
+			Creditcoin::exempt(Origin::signed(test_info.lender.account_id), deal_order_id),
 			crate::Error::<Test>::DealOrderAlreadyClosed
 		);
 	});
@@ -2146,109 +2140,11 @@ fn exempt_should_error_when_deal_order_has_already_been_repaid() {
 fn exempt_should_error_for_non_lender() {
 	ExtBuilder::default().build_and_execute(|| {
 		let test_info = TestInfo::new_defaults();
-		let (deal_order, deal_order_id) = test_info.create_deal_order();
-		let transfer_id = TransferId::new::<Test>(&deal_order.blockchain, b"12345678");
+		let (_deal_order, deal_order_id) = test_info.create_deal_order();
 
 		assert_noop!(
-			Creditcoin::exempt(
-				Origin::signed(test_info.borrower.account_id),
-				deal_order_id,
-				transfer_id,
-			),
+			Creditcoin::exempt(Origin::signed(test_info.borrower.account_id), deal_order_id),
 			crate::Error::<Test>::NotLender
-		);
-	});
-}
-
-#[test]
-fn exempt_should_error_when_transfer_order_id_doesnt_match_deal_order_id() {
-	ExtBuilder::default().build_and_execute(|| {
-		let test_info = TestInfo::new_defaults();
-		let (_, deal_order_id) = test_info.create_deal_order();
-
-		let address1 = "0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB".hex_to_address();
-		let address2 = "0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb".hex_to_address();
-		// this is a deal_order from another person
-		let second_test_info = TestInfo {
-			lender: RegisteredAddress::new(address1, 100, Blockchain::Rinkeby),
-			borrower: RegisteredAddress::new(address2, 200, Blockchain::Rinkeby),
-			blockchain: Blockchain::Rinkeby,
-			loan_terms: LoanTerms {
-				amount: 2_000_000u64.into(),
-				interest_rate: 0,
-				maturity: 1_000_000,
-			},
-			ask_guid: "second-ask-guid".as_bytes().into_bounded(),
-			bid_guid: "second-bid-guid".as_bytes().into_bounded(),
-			expiration_block: 3_333,
-		};
-
-		let (bogus_deal_order, bogus_deal_order_id) = second_test_info.create_deal_order();
-
-		//  insert as exemption to bypass transfer verification
-		let tx_hash = "0".as_bytes().into_bounded();
-		let contract = "0x0ad1439a0e0bfdcd49939f9722866651a4aa9b3c".as_bytes().into_bounded();
-
-		assert_ok!(Creditcoin::register_transfer_internal(
-			second_test_info.lender.account_id.clone(),
-			second_test_info.lender.address_id.clone(),
-			second_test_info.borrower.address_id.clone(),
-			TransferKind::Ethless(contract.clone()),
-			0u64.into(),
-			OrderId::Deal(bogus_deal_order_id.clone()),
-			tx_hash.clone()
-		));
-
-		let transfer_id = TransferId::new::<Test>(&bogus_deal_order.blockchain, &tx_hash.clone());
-
-		assert_noop!(
-			Creditcoin::exempt(
-				Origin::signed(test_info.lender.account_id),
-				deal_order_id,
-				transfer_id,
-			),
-			crate::Error::<Test>::TransferMismatch
-		);
-	});
-}
-
-#[test]
-fn exempt_should_error_when_transfer_has_been_processed() {
-	ExtBuilder::default().build_and_execute(|| {
-		let test_info = TestInfo::new_defaults();
-		let (deal_order, deal_order_id) = test_info.create_deal_order();
-
-		//  insert as exemption to bypass transfer verification
-		let tx_hash = "0".as_bytes().into_bounded();
-		let contract = "0x0ad1439a0e0bfdcd49939f9722866651a4aa9b3c".as_bytes().into_bounded();
-
-		assert_ok!(Creditcoin::register_transfer_internal(
-			test_info.lender.account_id.clone(),
-			test_info.lender.address_id.clone(),
-			test_info.borrower.address_id.clone(),
-			TransferKind::Ethless(contract.clone()),
-			0u64.into(),
-			OrderId::Deal(deal_order_id.clone()),
-			tx_hash.clone()
-		));
-
-		let transfer_id = TransferId::new::<Test>(&deal_order.blockchain, &tx_hash.clone());
-
-		// modify transfer in order to cause an error
-		crate::Transfers::<Test>::mutate(&transfer_id, |transfer_storage| {
-			let mut ts = transfer_storage.as_mut().unwrap();
-			// b/c amount above is 0
-			ts.amount = deal_order.terms.amount;
-			ts.processed = true;
-		});
-
-		assert_noop!(
-			Creditcoin::exempt(
-				Origin::signed(test_info.lender.account_id),
-				deal_order_id,
-				transfer_id,
-			),
-			crate::Error::<Test>::TransferAlreadyProcessed
 		);
 	});
 }
@@ -2261,41 +2157,23 @@ fn exempt_should_succeed() {
 		let test_info = TestInfo::new_defaults();
 		let (deal_order, deal_order_id) = test_info.create_deal_order();
 
-		//  insert as exemption to bypass transfer verification
-		let tx_hash = "0".as_bytes().into_bounded();
-		let contract = "0x0ad1439a0e0bfdcd49939f9722866651a4aa9b3c".as_bytes().into_bounded();
-
-		assert_ok!(Creditcoin::register_transfer_internal(
-			test_info.lender.account_id.clone(),
-			test_info.lender.address_id.clone(),
-			test_info.borrower.address_id.clone(),
-			TransferKind::Ethless(contract.clone()),
-			0u64.into(),
-			OrderId::Deal(deal_order_id.clone()),
-			tx_hash.clone()
-		));
-
-		let transfer_id = TransferId::new::<Test>(&deal_order.blockchain, &tx_hash.clone());
-
 		assert_ok!(Creditcoin::exempt(
 			Origin::signed(test_info.lender.account_id),
-			deal_order_id.clone(),
-			transfer_id.clone(),
+			deal_order_id.clone()
 		));
+
+		let transfer_id = TransferId::new::<Test>(&deal_order.blockchain, &*b"0");
 
 		// assert field values were updated in storage
 		let saved_deal_order = DealOrders::<Test>::try_get_id(&deal_order_id).unwrap();
 		assert_eq!(saved_deal_order.repayment_transfer_id, Some(transfer_id.clone()));
-
-		let saved_transfer = Transfers::<Test>::try_get(&transfer_id).unwrap();
-		assert_eq!(saved_transfer.processed, true);
 
 		// assert events in reversed order
 		let mut all_events = <frame_system::Pallet<Test>>::events();
 		let event = all_events.pop().expect("Expected at least one EventRecord to be found").event;
 		assert_eq!(
 			event,
-			crate::mock::Event::Creditcoin(crate::Event::LoanExempted(deal_order_id, transfer_id))
+			crate::mock::Event::Creditcoin(crate::Event::LoanExempted(deal_order_id))
 		);
 	});
 }

--- a/pallets/creditcoin/src/tests.rs
+++ b/pallets/creditcoin/src/tests.rs
@@ -1976,35 +1976,6 @@ fn close_deal_order_should_error_when_transfer_has_already_been_processed() {
 }
 
 #[test]
-fn close_deal_order_should_error_when_transfer_amount_is_not_enough() {
-	ExtBuilder::default().build_and_execute(|| {
-		let test_info = TestInfo::new_defaults();
-		let (_deal_order, deal_order_id) = test_info.create_deal_order();
-
-		// lock DealOrder
-		crate::DealOrders::<Test>::mutate(
-			&deal_order_id.expiration(),
-			&deal_order_id.hash(),
-			|deal_order_storage| {
-				deal_order_storage.as_mut().unwrap().lock =
-					Some(test_info.borrower.account_id.clone());
-			},
-		);
-
-		let (_, transfer_id) = test_info.create_repayment_transfer(&deal_order_id, 1);
-
-		assert_noop!(
-			Creditcoin::close_deal_order(
-				Origin::signed(test_info.borrower.account_id),
-				deal_order_id,
-				transfer_id,
-			),
-			crate::Error::<Test>::TransferAmountInsufficient
-		);
-	});
-}
-
-#[test]
 fn close_deal_order_should_succeed() {
 	ExtBuilder::default().build_and_execute(|| {
 		System::set_block_number(1);

--- a/pallets/creditcoin/src/tests.rs
+++ b/pallets/creditcoin/src/tests.rs
@@ -397,11 +397,10 @@ fn register_transfer_ocw() {
 			expiration
 		));
 
-		assert_ok!(Creditcoin::register_transfer(
+		assert_ok!(Creditcoin::register_funding_transfer(
 			Origin::signed(lender.clone()),
 			TransferKind::Ethless(contract.clone()),
-			0u64.into(),
-			OrderId::Deal(deal_order_id.clone()),
+			deal_order_id.clone(),
 			tx_hash.as_bytes().into_bounded()
 		));
 		let expected_transfer = crate::Transfer {
@@ -987,11 +986,10 @@ fn fund_deal_order_should_error_when_transfer_order_id_doesnt_match_deal_order_i
 		let tx_hash = "0".as_bytes().into_bounded();
 		let contract = "0x0ad1439a0e0bfdcd49939f9722866651a4aa9b3c".as_bytes().into_bounded();
 
-		assert_ok!(Creditcoin::register_transfer(
+		assert_ok!(Creditcoin::register_funding_transfer(
 			Origin::signed(second_test_info.lender.account_id.clone()),
 			TransferKind::Ethless(contract.clone()),
-			0u64.into(),
-			OrderId::Deal(bogus_deal_order_id.clone()),
+			bogus_deal_order_id.clone(),
 			tx_hash.clone()
 		));
 
@@ -1020,11 +1018,10 @@ fn fund_deal_order_should_error_when_transfer_amount_doesnt_match() {
 		let tx_hash = "0".as_bytes().into_bounded();
 		let contract = "0x0ad1439a0e0bfdcd49939f9722866651a4aa9b3c".as_bytes().into_bounded();
 
-		assert_ok!(Creditcoin::register_transfer(
+		assert_ok!(Creditcoin::register_funding_transfer(
 			Origin::signed(test_info.lender.account_id.clone()),
 			TransferKind::Ethless(contract.clone()),
-			0u64.into(),
-			OrderId::Deal(deal_order_id.clone()),
+			deal_order_id.clone(),
 			tx_hash.clone()
 		));
 
@@ -1036,7 +1033,7 @@ fn fund_deal_order_should_error_when_transfer_amount_doesnt_match() {
 			&deal_order_id.hash(),
 			|deal_order_storage| {
 				// note: the transfer above has amount of 0 b/c it is an exemption!
-				deal_order_storage.as_mut().unwrap().terms.amount = ExternalAmount::from(4444);
+				deal_order_storage.as_mut().unwrap().terms.amount = ExternalAmount::from(4444u64);
 			},
 		);
 
@@ -1061,11 +1058,10 @@ fn fund_deal_order_should_error_when_transfer_sighash_doesnt_match_lender() {
 		let tx_hash = "0".as_bytes().into_bounded();
 		let contract = "0x0ad1439a0e0bfdcd49939f9722866651a4aa9b3c".as_bytes().into_bounded();
 
-		assert_ok!(Creditcoin::register_transfer(
+		assert_ok!(Creditcoin::register_funding_transfer(
 			Origin::signed(test_info.lender.account_id.clone()),
 			TransferKind::Ethless(contract.clone()),
-			0u64.into(),
-			OrderId::Deal(deal_order_id.clone()),
+			deal_order_id.clone(),
 			tx_hash.clone()
 		));
 
@@ -1100,11 +1096,10 @@ fn fund_deal_order_should_error_when_transfer_has_been_processed() {
 		let tx_hash = "0".as_bytes().into_bounded();
 		let contract = "0x0ad1439a0e0bfdcd49939f9722866651a4aa9b3c".as_bytes().into_bounded();
 
-		assert_ok!(Creditcoin::register_transfer(
+		assert_ok!(Creditcoin::register_funding_transfer(
 			Origin::signed(test_info.lender.account_id.clone()),
 			TransferKind::Ethless(contract.clone()),
-			0u64.into(),
-			OrderId::Deal(deal_order_id.clone()),
+			deal_order_id.clone(),
 			tx_hash.clone()
 		));
 
@@ -1139,11 +1134,10 @@ fn fund_deal_order_works() {
 		let tx_hash = "0".as_bytes().into_bounded();
 		let contract = "0x0ad1439a0e0bfdcd49939f9722866651a4aa9b3c".as_bytes().into_bounded();
 
-		assert_ok!(Creditcoin::register_transfer(
+		assert_ok!(Creditcoin::register_funding_transfer(
 			Origin::signed(test_info.lender.account_id.clone()),
 			TransferKind::Ethless(contract.clone()),
-			0u64.into(),
-			OrderId::Deal(deal_order_id.clone()),
+			deal_order_id.clone(),
 			tx_hash.clone()
 		));
 
@@ -1811,8 +1805,10 @@ fn close_deal_order_should_error_when_transfer_order_id_doesnt_match_deal_order_
 		let tx_hash = "0".as_bytes().into_bounded();
 		let contract = "0x0ad1439a0e0bfdcd49939f9722866651a4aa9b3c".as_bytes().into_bounded();
 
-		assert_ok!(Creditcoin::register_transfer(
-			Origin::signed(second_test_info.borrower.account_id.clone()),
+		assert_ok!(Creditcoin::register_transfer_internal(
+			second_test_info.borrower.account_id.clone(),
+			second_test_info.borrower.address_id.clone(),
+			second_test_info.lender.address_id.clone(),
 			TransferKind::Ethless(contract.clone()),
 			33u64.into(),
 			OrderId::Deal(bogus_deal_order_id.clone()),
@@ -1853,8 +1849,10 @@ fn close_deal_order_should_error_when_transfer_block_is_greater_than_current_blo
 		let tx_hash = "0".as_bytes().into_bounded();
 		let contract = "0x0ad1439a0e0bfdcd49939f9722866651a4aa9b3c".as_bytes().into_bounded();
 
-		assert_ok!(Creditcoin::register_transfer(
-			Origin::signed(test_info.borrower.account_id.clone()),
+		assert_ok!(Creditcoin::register_transfer_internal(
+			test_info.borrower.account_id.clone(),
+			test_info.borrower.address_id.clone(),
+			test_info.lender.address_id.clone(),
 			TransferKind::Ethless(contract.clone()),
 			33u64.into(),
 			OrderId::Deal(deal_order_id.clone()),
@@ -1902,8 +1900,10 @@ fn close_deal_order_should_error_when_transfer_sighash_doesnt_match_borrower() {
 		let tx_hash = "0".as_bytes().into_bounded();
 		let contract = "0x0ad1439a0e0bfdcd49939f9722866651a4aa9b3c".as_bytes().into_bounded();
 
-		assert_ok!(Creditcoin::register_transfer(
-			Origin::signed(test_info.borrower.account_id.clone()),
+		assert_ok!(Creditcoin::register_transfer_internal(
+			test_info.borrower.account_id.clone(),
+			test_info.borrower.address_id.clone(),
+			test_info.lender.address_id.clone(),
 			TransferKind::Ethless(contract.clone()),
 			33u64.into(),
 			OrderId::Deal(deal_order_id.clone()),
@@ -1951,8 +1951,10 @@ fn close_deal_order_should_error_when_transfer_has_already_been_processed() {
 		let tx_hash = "0".as_bytes().into_bounded();
 		let contract = "0x0ad1439a0e0bfdcd49939f9722866651a4aa9b3c".as_bytes().into_bounded();
 
-		assert_ok!(Creditcoin::register_transfer(
-			Origin::signed(test_info.borrower.account_id.clone()),
+		assert_ok!(Creditcoin::register_transfer_internal(
+			test_info.borrower.account_id.clone(),
+			test_info.borrower.address_id.clone(),
+			test_info.lender.address_id.clone(),
 			TransferKind::Ethless(contract.clone()),
 			33u64.into(),
 			OrderId::Deal(deal_order_id.clone()),
@@ -2000,8 +2002,10 @@ fn close_deal_order_should_error_when_transfer_amount_is_not_enough() {
 		let tx_hash = "0".as_bytes().into_bounded();
 		let contract = "0x0ad1439a0e0bfdcd49939f9722866651a4aa9b3c".as_bytes().into_bounded();
 
-		assert_ok!(Creditcoin::register_transfer(
-			Origin::signed(test_info.borrower.account_id.clone()),
+		assert_ok!(Creditcoin::register_transfer_internal(
+			test_info.borrower.account_id.clone(),
+			test_info.borrower.address_id.clone(),
+			test_info.lender.address_id.clone(),
 			TransferKind::Ethless(contract.clone()),
 			33u64.into(),
 			OrderId::Deal(deal_order_id.clone()),
@@ -2050,8 +2054,10 @@ fn close_deal_order_should_succeed() {
 		let tx_hash = "0".as_bytes().into_bounded();
 		let contract = "0x0ad1439a0e0bfdcd49939f9722866651a4aa9b3c".as_bytes().into_bounded();
 
-		assert_ok!(Creditcoin::register_transfer(
-			Origin::signed(test_info.borrower.account_id.clone()),
+		assert_ok!(Creditcoin::register_transfer_internal(
+			test_info.borrower.account_id.clone(),
+			test_info.borrower.address_id.clone(),
+			test_info.lender.address_id.clone(),
 			TransferKind::Ethless(contract.clone()),
 			33u64.into(),
 			OrderId::Deal(deal_order_id.clone()),
@@ -2183,8 +2189,10 @@ fn exempt_should_error_when_transfer_order_id_doesnt_match_deal_order_id() {
 		let tx_hash = "0".as_bytes().into_bounded();
 		let contract = "0x0ad1439a0e0bfdcd49939f9722866651a4aa9b3c".as_bytes().into_bounded();
 
-		assert_ok!(Creditcoin::register_transfer(
-			Origin::signed(second_test_info.lender.account_id.clone()),
+		assert_ok!(Creditcoin::register_transfer_internal(
+			second_test_info.lender.account_id.clone(),
+			second_test_info.lender.address_id.clone(),
+			second_test_info.borrower.address_id.clone(),
 			TransferKind::Ethless(contract.clone()),
 			0u64.into(),
 			OrderId::Deal(bogus_deal_order_id.clone()),
@@ -2214,8 +2222,10 @@ fn exempt_should_error_when_transfer_has_been_processed() {
 		let tx_hash = "0".as_bytes().into_bounded();
 		let contract = "0x0ad1439a0e0bfdcd49939f9722866651a4aa9b3c".as_bytes().into_bounded();
 
-		assert_ok!(Creditcoin::register_transfer(
-			Origin::signed(test_info.lender.account_id.clone()),
+		assert_ok!(Creditcoin::register_transfer_internal(
+			test_info.lender.account_id.clone(),
+			test_info.lender.address_id.clone(),
+			test_info.borrower.address_id.clone(),
 			TransferKind::Ethless(contract.clone()),
 			0u64.into(),
 			OrderId::Deal(deal_order_id.clone()),
@@ -2255,8 +2265,10 @@ fn exempt_should_succeed() {
 		let tx_hash = "0".as_bytes().into_bounded();
 		let contract = "0x0ad1439a0e0bfdcd49939f9722866651a4aa9b3c".as_bytes().into_bounded();
 
-		assert_ok!(Creditcoin::register_transfer(
-			Origin::signed(test_info.lender.account_id.clone()),
+		assert_ok!(Creditcoin::register_transfer_internal(
+			test_info.lender.account_id.clone(),
+			test_info.lender.address_id.clone(),
+			test_info.borrower.address_id.clone(),
 			TransferKind::Ethless(contract.clone()),
 			0u64.into(),
 			OrderId::Deal(deal_order_id.clone()),


### PR DESCRIPTION
The "0" transaction ID weirdness is still here, I'd like to remove it once we make it so exempt doesn't require a dummy transfer (CSUB-112).