### PR TITLE
CSUB-125 - Check nonce when verifying ethless transfer

### DIFF
--- a/pallets/creditcoin/src/lib.rs
+++ b/pallets/creditcoin/src/lib.rs
@@ -106,6 +106,16 @@ pub mod pallet {
 
 		type PublicSigning: From<Self::InternalPublic> + Into<Self::Public>;
 
+		// in order to turn a `Hash` into a U256 for checking the nonces on
+		// ethless transfers we need the `Hash` type to implement
+		// the BigEndianHash trait. This effectively constrains the Hash
+		// type to H256, which sort of defeats the purpose of it being an associated type.
+		// However a lot of code refers to Config::Hash, so right now this is the least invasive way
+		// to get the compiler to let us do the Config::Hash -> U256 conversion
+		type HashIntoNonce: IsType<<Self as frame_system::Config>::Hash>
+			+ ethereum_types::BigEndianHash<Uint = sp_core::U256>
+			+ Clone;
+
 		type UnverifiedTransferLimit: Get<u32>;
 	}
 

--- a/pallets/creditcoin/src/mock.rs
+++ b/pallets/creditcoin/src/mock.rs
@@ -104,6 +104,8 @@ impl pallet_creditcoin::Config for Test {
 
 	type PublicSigning = <Signature as Verify>::Signer;
 
+	type HashIntoNonce = H256;
+
 	type UnverifiedTransferLimit = PendingTxLimit;
 }
 

--- a/pallets/creditcoin/src/ocw.rs
+++ b/pallets/creditcoin/src/ocw.rs
@@ -466,4 +466,31 @@ mod tests {
 			..Default::default()
 		}));
 	}
+
+	#[test]
+	fn ethless_transfer_nonce_mismatch() {
+		let transfer = ethless_transfer_function_abi();
+		let input = transfer
+			.encode_input(&[
+				// from
+				Token::Address(ETHLESS_FROM_ADDR.clone()),
+				// to
+				Token::Address(ETHLESS_TO_ADDR.clone()),
+				// value
+				Token::Uint(U256::from(53688044)),
+				// fee
+				Token::Uint(1.into()),
+				// nonce
+				Token::Uint(1.into()),
+				// sig
+				Token::Bytes(Vec::new()),
+			])
+			.unwrap()
+			.into();
+		let transaction = EthTransaction { input, ..ETH_TRANSACTION.clone() };
+		assert_invalid_transfer(test_validate_ethless_transfer(EthlessTestArgs {
+			transaction,
+			..Default::default()
+		}));
+	}
 }

--- a/pallets/creditcoin/src/tests.rs
+++ b/pallets/creditcoin/src/tests.rs
@@ -6,11 +6,11 @@ use crate::{
 };
 use bstr::B;
 use codec::{Decode, Encode};
-use ethereum_types::H256;
+use ethereum_types::{BigEndianHash, H256};
 use frame_support::{assert_noop, assert_ok, traits::Get, BoundedVec};
 use frame_system::RawOrigin;
 
-use sp_core::Pair;
+use sp_core::{Pair, U256};
 use sp_runtime::{
 	offchain::storage::StorageValueRef,
 	traits::{BadOrigin, IdentifyAccount},
@@ -335,8 +335,16 @@ fn verify_ethless_transfer() {
 
 		let from = hex::decode("f04349B4A760F5Aed02131e0dAA9bB99a1d1d1e5").unwrap().into_bounded();
 		let to = hex::decode("BBb8bbAF43fE8b9E5572B1860d5c94aC7ed87Bb9").unwrap().into_bounded();
-		let order_id = crate::OrderId::Deal(crate::DealOrderId::dummy());
-		let amount = sp_core::U256::from(53688044u64);
+		let order_id = crate::OrderId::Deal(crate::DealOrderId::with_expiration_hash::<Test>(
+			10000,
+			H256::from_uint(
+				&U256::from_dec_str(
+					"979732326222468652918279417612319888321218652914508214827914231471334244789",
+				)
+				.unwrap(),
+			),
+		));
+		let amount = U256::from(53688044u64);
 		let tx_id = tx_hash.hex_to_address();
 
 		assert_ok!(Creditcoin::verify_ethless_transfer(
@@ -449,11 +457,30 @@ fn register_transfer_ocw() {
 			expiration
 		));
 
+		let deal_id_hash = H256::from_uint(
+			&U256::from_dec_str(
+				"979732326222468652918279417612319888321218652914508214827914231471334244789",
+			)
+			.unwrap(),
+		);
+
+		// this is kind of a gross hack, basically when I made the test transfer on luniverse to pull the mock responses
+		// I didn't pass the proper `nonce` to the smart contract, and it's a pain to redo the transaction and update all the tests,
+		// so here we just "change" the deal_order_id to one with a `hash` that matches the expected nonce so that the transfer
+		// verification logic is happy
+		let deal = crate::DealOrders::<Test>::try_get_id(&deal_order_id).unwrap();
+		crate::DealOrders::<Test>::remove(deal_order_id.expiration(), deal_order_id.hash());
+		let fake_deal_order_id = crate::DealOrderId::with_expiration_hash::<Test>(
+			deal_order_id.expiration(),
+			deal_id_hash,
+		);
+		crate::DealOrders::<Test>::insert_id(fake_deal_order_id.clone(), deal);
+
 		assert_ok!(Creditcoin::register_funding_transfer(
 			Origin::signed(lender.clone()),
 			TransferKind::Ethless(contract.clone()),
-			deal_order_id.clone(),
-			tx_hash.hex_to_address()
+			fake_deal_order_id.clone(),
+			tx_hash.hex_to_address(),
 		));
 		let expected_transfer = crate::Transfer {
 			blockchain,
@@ -462,7 +489,7 @@ fn register_transfer_ocw() {
 			block: System::block_number(),
 			from: lender_address_id.clone(),
 			to: debtor_address_id.clone(),
-			order_id: OrderId::Deal(deal_order_id.clone()),
+			order_id: OrderId::Deal(fake_deal_order_id.clone()),
 			processed: false,
 			sighash: lender.clone(),
 			tx: tx_hash.hex_to_address(),

--- a/pallets/creditcoin/src/types.rs
+++ b/pallets/creditcoin/src/types.rs
@@ -398,6 +398,39 @@ impl_id!(BidOrderId);
 impl_id!(OfferId);
 impl_id!(RepaymentOrderId);
 
+impl<'a, B, H> Id<B, H> for &'a OrderId<B, H>
+where
+	B: Clone,
+	H: Clone,
+{
+	fn expiration(&self) -> B {
+		match self {
+			OrderId::Deal(deal) => deal.expiration(),
+			OrderId::Repayment(repay) => repay.expiration(),
+		}
+	}
+
+	fn hash(&self) -> H {
+		match self {
+			OrderId::Deal(deal) => deal.hash(),
+			OrderId::Repayment(repay) => repay.hash(),
+		}
+	}
+}
+impl<B, H> Id<B, H> for OrderId<B, H>
+where
+	B: Clone,
+	H: Clone,
+{
+	fn expiration(&self) -> B {
+		(&self).expiration()
+	}
+
+	fn hash(&self) -> H {
+		(&self).hash()
+	}
+}
+
 #[ext(name = DoubleMapExt)]
 pub(crate) impl<Prefix, Hasher1, Key1, Hasher2, Key2, Value, QueryKind, OnEmpty, MaxValues, IdTy>
 	frame_support::storage::types::StorageDoubleMap<

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -281,6 +281,7 @@ impl pallet_creditcoin::Config for Runtime {
 	type FromAccountId = AccountId;
 	type PublicSigning = <Signature as Verify>::Signer;
 	type InternalPublic = sp_core::sr25519::Public;
+	type HashIntoNonce = Hash;
 	type UnverifiedTransferLimit = ConstU32<10000>;
 }
 


### PR DESCRIPTION
Fixes a bug where we weren't ensuring that the `nonce` passed to an ethless transfer matches the hash on the deal order ID.