### PR TITLE
[CSUB-147] Explicit transfer verification failure

### DIFF
--- a/javascript/integration-tests/FailTransfer.spec.ts
+++ b/javascript/integration-tests/FailTransfer.spec.ts
@@ -1,0 +1,40 @@
+// Copyright 2022 Gluwa, Inc. & contributors
+// SPDX-License-Identifier: The Unlicense
+
+import { ApiPromise, Keyring, WsProvider } from '@polkadot/api';
+import { KeyringPair } from '@polkadot/keyring/types';
+import * as testUtils from './test-utils';
+import { createFundingTransferId } from 'credal-js/lib/extrinsics/register-transfers';
+import { POINT_01_CTC } from '../src/constants';
+
+describe('FailTransfer', (): void => {
+    let api: ApiPromise;
+    let authority: KeyringPair;
+
+    beforeEach(async () => {
+        process.env.NODE_ENV = 'test';
+
+        const provider = new WsProvider('ws://127.0.0.1:9944');
+        api = await ApiPromise.create({ provider });
+        const keyring = new Keyring({ type: 'sr25519' });
+
+        const lender = keyring.addFromUri('//Alice', { name: 'Alice' });
+
+        authority = await testUtils.setupAuthority(api, lender);
+    });
+
+    it('fee is min 0.01 CTC', async () => {
+        const transferId = createFundingTransferId('Ethereum', '0xffffffffffffffffffffffffffffffffffffffff');
+        const cause = api.createType('PalletCreditcoinOcwErrorsVerificationFailureCause', 'TransferFailed');
+        return new Promise((resolve, reject): void => {
+            const unsubscribe = api.tx.creditcoin
+                .failTransfer(transferId, cause)
+                .signAndSend(authority, { nonce: -1 }, async ({ dispatchError, events, status }) => {
+                    testUtils.extractFee(resolve, reject, unsubscribe, api, dispatchError, events, status);
+                })
+                .catch((reason) => reject(reason));
+        }).then((fee) => {
+            expect(fee).toBeGreaterThanOrEqual(POINT_01_CTC);
+        });
+    });
+});

--- a/javascript/integration-tests/RegisterFundingTransfer.spec.ts
+++ b/javascript/integration-tests/RegisterFundingTransfer.spec.ts
@@ -68,7 +68,7 @@ describe('RegisterFundingTransfer', (): void => {
 
         borrower = keyring.addFromUri('//Bob', { name: 'Bob' });
         borrowerWallet = randomEthWallet();
-        const borrowerRegAddr_ = await testUtils.registerAddress(
+        const borrowerRegAddr_ = testUtils.registerAddress(
             api,
             borrowerWallet.address,
             blockchain,
@@ -125,8 +125,6 @@ describe('RegisterFundingTransfer', (): void => {
     }, 30000);
 
     it('failure event is emitted if transfer is invalid', async (): Promise<void> => {
-        const provider = new WsProvider('ws://127.0.0.1:9944');
-        const api = await ApiPromise.create({ provider });
         // wrong amount
         const badLoanTerms = { ...loanTerms, amount: new BN(1) };
 

--- a/javascript/integration-tests/RegisterFundingTransfer.spec.ts
+++ b/javascript/integration-tests/RegisterFundingTransfer.spec.ts
@@ -5,6 +5,7 @@ import { Guid } from 'js-guid';
 
 import { ApiPromise, Keyring, WsProvider } from '@polkadot/api';
 import { KeyringPair } from '@polkadot/keyring/types';
+import type { H256 } from '@polkadot/types/interfaces';
 import { BN } from '@polkadot/util';
 
 import { Blockchain, DealOrderId, LoanTerms, TransferKind } from 'credal-js/lib/model';
@@ -15,6 +16,10 @@ import { POINT_01_CTC } from '../src/constants';
 import { randomEthWallet } from '../src/utils';
 import * as testUtils from './test-utils';
 import { signAccountId } from 'credal-js/lib/utils';
+import { Wallet } from 'ethers';
+import { createFundingTransferId, registerFundingTransferAsync } from 'credal-js/lib/extrinsics/register-transfers';
+import { Vec } from '@polkadot/types-codec';
+import { FrameSystemEventRecord, PalletCreditcoinOcwErrorsVerificationFailureCause } from '@polkadot/types/lookup';
 
 describe('RegisterFundingTransfer', (): void => {
     let api: ApiPromise;
@@ -23,6 +28,8 @@ describe('RegisterFundingTransfer', (): void => {
     let dealOrderId: DealOrderId;
     let transferKind: TransferKind;
     let txHash: string;
+    let lenderWallet: Wallet;
+    let borrowerWallet: Wallet;
 
     const blockchain: Blockchain = 'Ethereum';
     const expirationBlock = 10_000;
@@ -50,8 +57,8 @@ describe('RegisterFundingTransfer', (): void => {
         const keyring = new Keyring({ type: 'sr25519' });
 
         lender = keyring.addFromUri('//Alice', { name: 'Alice' });
-        const lenderWallet = randomEthWallet();
-        const lenderRegAddr = await testUtils.registerAddress(
+        lenderWallet = randomEthWallet();
+        const lenderRegAddr_ = await testUtils.registerAddress(
             api,
             lenderWallet.address,
             blockchain,
@@ -60,14 +67,16 @@ describe('RegisterFundingTransfer', (): void => {
         );
 
         borrower = keyring.addFromUri('//Bob', { name: 'Bob' });
-        const borrowerWallet = randomEthWallet();
-        const borrowerRegAddr = await testUtils.registerAddress(
+        borrowerWallet = randomEthWallet();
+        const borrowerRegAddr_ = await testUtils.registerAddress(
             api,
             borrowerWallet.address,
             blockchain,
             signAccountId(api, borrowerWallet, borrower.address),
             borrower,
         );
+
+        const [lenderRegAddr, borrowerRegAddr] = await Promise.all([lenderRegAddr_, borrowerRegAddr_]);
 
         const askGuid = Guid.newGuid();
         const bidGuid = Guid.newGuid();
@@ -87,6 +96,7 @@ describe('RegisterFundingTransfer', (): void => {
         );
         dealOrderId = result.dealOrder.dealOrderId;
 
+        await testUtils.setupAuthority(api, lender);
         [transferKind, txHash] = await testUtils.prepareEthTransfer(
             lenderWallet,
             borrowerWallet,
@@ -113,4 +123,41 @@ describe('RegisterFundingTransfer', (): void => {
             expect(fee).toBeGreaterThanOrEqual(POINT_01_CTC);
         });
     }, 30000);
+
+    it('failure event is emitted if transfer is invalid', async (): Promise<void> => {
+        const provider = new WsProvider('ws://127.0.0.1:9944');
+        const api = await ApiPromise.create({ provider });
+        // wrong amount
+        const badLoanTerms = { ...loanTerms, amount: new BN(1) };
+
+        const [transferKind, txHash] = await testUtils.prepareEthTransfer(
+            lenderWallet,
+            borrowerWallet,
+            dealOrderId,
+            badLoanTerms,
+        );
+
+        const transferId = createFundingTransferId(blockchain, txHash);
+        await registerFundingTransferAsync(api, transferKind, dealOrderId, txHash, lender);
+
+        return new Promise((resolve, reject): void => {
+            api.query.system
+                .events((events: Vec<FrameSystemEventRecord>) => {
+                    // Loop through the Vec<EventRecord>
+                    events.forEach((record) => {
+                        // Extract the phase, event and the event types
+                        const { event } = record;
+                        if (api.events.creditcoin.TransferFailedVerification.is(event)) {
+                            const failedTransferId = (event.data[0] as H256).toString();
+                            if (failedTransferId === transferId) {
+                                const failureCause = event.data[1] as PalletCreditcoinOcwErrorsVerificationFailureCause;
+                                expect(failureCause.isIncorrectAmount).toBeTruthy();
+                                resolve();
+                            }
+                        }
+                    });
+                })
+                .catch(reject);
+        });
+    }, 60000);
 });

--- a/javascript/integration-tests/test-utils.ts
+++ b/javascript/integration-tests/test-utils.ts
@@ -3,7 +3,7 @@
 
 import { Wallet } from 'ethers';
 import { Guid } from 'js-guid';
-import { ApiPromise } from '@polkadot/api';
+import { ApiPromise, Keyring } from '@polkadot/api';
 import { KeyringPair } from '@polkadot/keyring/types';
 import type { Null, Option } from '@polkadot/types';
 import type { Balance } from '@polkadot/types/interfaces';
@@ -69,6 +69,8 @@ export const setupAuthority = async (api: ApiPromise, sudoSigner: KeyringPair) =
     await setBalance(api, sudoSigner, AUTHORITY_ACCOUNTID, '10000000000000000000');
     // bump balance for Alice b/c we need enough to be able to pay fees
     await setBalance(api, sudoSigner, sudoSigner.address, '10000000000000000000');
+
+    return new Keyring({ type: 'sr25519' }).createFromUri(AUTHORITY_SURI);
 };
 
 export const setBalance = async (

--- a/javascript/src/interfaces/augment-api-events.ts
+++ b/javascript/src/interfaces/augment-api-events.ts
@@ -15,6 +15,7 @@ import type {
     PalletCreditcoinDealOrder,
     PalletCreditcoinDealOrderId,
     PalletCreditcoinLegacySighash,
+    PalletCreditcoinOcwErrorsVerificationFailureCause,
     PalletCreditcoinOffer,
     PalletCreditcoinOfferId,
     PalletCreditcoinTransfer,
@@ -136,6 +137,10 @@ declare module '@polkadot/api-base/types/events' {
              * [offer_id, offer]
              **/
             OfferAdded: AugmentedEvent<ApiType, [PalletCreditcoinOfferId, PalletCreditcoinOffer]>;
+            TransferFailedVerification: AugmentedEvent<
+                ApiType,
+                [H256, PalletCreditcoinOcwErrorsVerificationFailureCause]
+            >;
             /**
              * An external transfer has been processed and marked as part of a loan.
              * [processed_transfer_id, processed_transfer]

--- a/javascript/src/interfaces/augment-api-tx.ts
+++ b/javascript/src/interfaces/augment-api-tx.ts
@@ -11,6 +11,7 @@ import type {
     PalletCreditcoinBlockchain,
     PalletCreditcoinDealOrderId,
     PalletCreditcoinLoanTerms,
+    PalletCreditcoinOcwErrorsVerificationFailureCause,
     PalletCreditcoinOfferId,
     PalletCreditcoinTransfer,
     PalletCreditcoinTransferKind,
@@ -268,6 +269,31 @@ declare module '@polkadot/api-base/types/submittable' {
             exempt: AugmentedSubmittable<
                 (dealOrderId: PalletCreditcoinDealOrderId) => SubmittableExtrinsic<ApiType>,
                 [PalletCreditcoinDealOrderId]
+            >;
+            failTransfer: AugmentedSubmittable<
+                (
+                    transferId: H256 | string | Uint8Array,
+                    cause:
+                        | PalletCreditcoinOcwErrorsVerificationFailureCause
+                        | 'TransferFailed'
+                        | 'TransferPending'
+                        | 'TransferUnconfirmed'
+                        | 'TransferInFuture'
+                        | 'IncorrectContract'
+                        | 'MissingReceiver'
+                        | 'AbiMismatch'
+                        | 'IncorrectInputLength'
+                        | 'IncorrectInputType'
+                        | 'IncorrectAmount'
+                        | 'IncorrectNonce'
+                        | 'IncorrectReceiver'
+                        | 'IncorrectSender'
+                        | 'InvalidAddress'
+                        | 'UnsupportedMethod'
+                        | number
+                        | Uint8Array,
+                ) => SubmittableExtrinsic<ApiType>,
+                [H256, PalletCreditcoinOcwErrorsVerificationFailureCause]
             >;
             fundDealOrder: AugmentedSubmittable<
                 (

--- a/javascript/src/interfaces/lookup.ts
+++ b/javascript/src/interfaces/lookup.ts
@@ -231,6 +231,7 @@ export default {
             DealOrderClosed: '(PalletCreditcoinDealOrderId,PalletCreditcoinDealOrder)',
             LoanExempted: 'PalletCreditcoinDealOrderId',
             LegacyWalletClaimed: '(AccountId32,PalletCreditcoinLegacySighash,u128)',
+            TransferFailedVerification: '(H256,PalletCreditcoinOcwErrorsVerificationFailureCause)',
         },
     },
     /**
@@ -395,7 +396,29 @@ export default {
      **/
     PalletCreditcoinLegacySighash: '[u8;60]',
     /**
-     * Lookup62: pallet_rewards::pallet::Event<T>
+     * Lookup62: pallet_creditcoin::ocw::errors::VerificationFailureCause
+     **/
+    PalletCreditcoinOcwErrorsVerificationFailureCause: {
+        _enum: [
+            'TransferFailed',
+            'TransferPending',
+            'TransferUnconfirmed',
+            'TransferInFuture',
+            'IncorrectContract',
+            'MissingReceiver',
+            'AbiMismatch',
+            'IncorrectInputLength',
+            'IncorrectInputType',
+            'IncorrectAmount',
+            'IncorrectNonce',
+            'IncorrectReceiver',
+            'IncorrectSender',
+            'InvalidAddress',
+            'UnsupportedMethod',
+        ],
+    },
+    /**
+     * Lookup63: pallet_rewards::pallet::Event<T>
      **/
     PalletRewardsEvent: {
         _enum: {
@@ -403,7 +426,7 @@ export default {
         },
     },
     /**
-     * Lookup63: frame_system::Phase
+     * Lookup64: frame_system::Phase
      **/
     FrameSystemPhase: {
         _enum: {
@@ -413,14 +436,14 @@ export default {
         },
     },
     /**
-     * Lookup67: frame_system::LastRuntimeUpgradeInfo
+     * Lookup68: frame_system::LastRuntimeUpgradeInfo
      **/
     FrameSystemLastRuntimeUpgradeInfo: {
         specVersion: 'Compact<u32>',
         specName: 'Text',
     },
     /**
-     * Lookup70: frame_system::pallet::Call<T>
+     * Lookup71: frame_system::pallet::Call<T>
      **/
     FrameSystemCall: {
         _enum: {
@@ -458,7 +481,7 @@ export default {
         },
     },
     /**
-     * Lookup75: frame_system::limits::BlockWeights
+     * Lookup76: frame_system::limits::BlockWeights
      **/
     FrameSystemLimitsBlockWeights: {
         baseBlock: 'u64',
@@ -466,7 +489,7 @@ export default {
         perClass: 'FrameSupportWeightsPerDispatchClassWeightsPerClass',
     },
     /**
-     * Lookup76: frame_support::weights::PerDispatchClass<frame_system::limits::WeightsPerClass>
+     * Lookup77: frame_support::weights::PerDispatchClass<frame_system::limits::WeightsPerClass>
      **/
     FrameSupportWeightsPerDispatchClassWeightsPerClass: {
         normal: 'FrameSystemLimitsWeightsPerClass',
@@ -474,7 +497,7 @@ export default {
         mandatory: 'FrameSystemLimitsWeightsPerClass',
     },
     /**
-     * Lookup77: frame_system::limits::WeightsPerClass
+     * Lookup78: frame_system::limits::WeightsPerClass
      **/
     FrameSystemLimitsWeightsPerClass: {
         baseExtrinsic: 'u64',
@@ -483,13 +506,13 @@ export default {
         reserved: 'Option<u64>',
     },
     /**
-     * Lookup78: frame_system::limits::BlockLength
+     * Lookup79: frame_system::limits::BlockLength
      **/
     FrameSystemLimitsBlockLength: {
         max: 'FrameSupportWeightsPerDispatchClassU32',
     },
     /**
-     * Lookup79: frame_support::weights::PerDispatchClass<T>
+     * Lookup80: frame_support::weights::PerDispatchClass<T>
      **/
     FrameSupportWeightsPerDispatchClassU32: {
         normal: 'u32',
@@ -497,14 +520,14 @@ export default {
         mandatory: 'u32',
     },
     /**
-     * Lookup80: frame_support::weights::RuntimeDbWeight
+     * Lookup81: frame_support::weights::RuntimeDbWeight
      **/
     FrameSupportWeightsRuntimeDbWeight: {
         read: 'u64',
         write: 'u64',
     },
     /**
-     * Lookup81: sp_version::RuntimeVersion
+     * Lookup82: sp_version::RuntimeVersion
      **/
     SpVersionRuntimeVersion: {
         specName: 'Text',
@@ -517,7 +540,7 @@ export default {
         stateVersion: 'u8',
     },
     /**
-     * Lookup87: frame_system::pallet::Error<T>
+     * Lookup88: frame_system::pallet::Error<T>
      **/
     FrameSystemError: {
         _enum: [
@@ -530,7 +553,7 @@ export default {
         ],
     },
     /**
-     * Lookup88: pallet_timestamp::pallet::Call<T>
+     * Lookup89: pallet_timestamp::pallet::Call<T>
      **/
     PalletTimestampCall: {
         _enum: {
@@ -540,7 +563,7 @@ export default {
         },
     },
     /**
-     * Lookup91: pallet_balances::BalanceLock<Balance>
+     * Lookup92: pallet_balances::BalanceLock<Balance>
      **/
     PalletBalancesBalanceLock: {
         id: '[u8;8]',
@@ -548,26 +571,26 @@ export default {
         reasons: 'PalletBalancesReasons',
     },
     /**
-     * Lookup92: pallet_balances::Reasons
+     * Lookup93: pallet_balances::Reasons
      **/
     PalletBalancesReasons: {
         _enum: ['Fee', 'Misc', 'All'],
     },
     /**
-     * Lookup95: pallet_balances::ReserveData<ReserveIdentifier, Balance>
+     * Lookup96: pallet_balances::ReserveData<ReserveIdentifier, Balance>
      **/
     PalletBalancesReserveData: {
         id: '[u8;8]',
         amount: 'u128',
     },
     /**
-     * Lookup97: pallet_balances::Releases
+     * Lookup98: pallet_balances::Releases
      **/
     PalletBalancesReleases: {
         _enum: ['V1_0_0', 'V2_0_0'],
     },
     /**
-     * Lookup98: pallet_balances::pallet::Call<T, I>
+     * Lookup99: pallet_balances::pallet::Call<T, I>
      **/
     PalletBalancesCall: {
         _enum: {
@@ -600,7 +623,7 @@ export default {
         },
     },
     /**
-     * Lookup103: pallet_balances::pallet::Error<T, I>
+     * Lookup104: pallet_balances::pallet::Error<T, I>
      **/
     PalletBalancesError: {
         _enum: [
@@ -615,13 +638,13 @@ export default {
         ],
     },
     /**
-     * Lookup105: pallet_transaction_payment::Releases
+     * Lookup106: pallet_transaction_payment::Releases
      **/
     PalletTransactionPaymentReleases: {
         _enum: ['V1Ancient', 'V2'],
     },
     /**
-     * Lookup107: frame_support::weights::WeightToFeeCoefficient<Balance>
+     * Lookup108: frame_support::weights::WeightToFeeCoefficient<Balance>
      **/
     FrameSupportWeightsWeightToFeeCoefficient: {
         coeffInteger: 'u128',
@@ -630,7 +653,7 @@ export default {
         degree: 'u8',
     },
     /**
-     * Lookup108: pallet_sudo::pallet::Call<T>
+     * Lookup109: pallet_sudo::pallet::Call<T>
      **/
     PalletSudoCall: {
         _enum: {
@@ -654,7 +677,7 @@ export default {
         },
     },
     /**
-     * Lookup110: pallet_creditcoin::pallet::Call<T>
+     * Lookup111: pallet_creditcoin::pallet::Call<T>
      **/
     PalletCreditcoinCall: {
         _enum: {
@@ -725,21 +748,25 @@ export default {
             verify_transfer: {
                 transfer: 'PalletCreditcoinTransfer',
             },
+            fail_transfer: {
+                transferId: 'H256',
+                cause: 'PalletCreditcoinOcwErrorsVerificationFailureCause',
+            },
             add_authority: {
                 who: 'AccountId32',
             },
         },
     },
     /**
-     * Lookup111: sp_core::ecdsa::Public
+     * Lookup112: sp_core::ecdsa::Public
      **/
     SpCoreEcdsaPublic: '[u8;33]',
     /**
-     * Lookup113: sp_core::ecdsa::Signature
+     * Lookup114: sp_core::ecdsa::Signature
      **/
     SpCoreEcdsaSignature: '[u8;65]',
     /**
-     * Lookup115: sp_runtime::MultiSigner
+     * Lookup116: sp_runtime::MultiSigner
      **/
     SpRuntimeMultiSigner: {
         _enum: {
@@ -749,15 +776,15 @@ export default {
         },
     },
     /**
-     * Lookup116: sp_core::ed25519::Public
+     * Lookup117: sp_core::ed25519::Public
      **/
     SpCoreEd25519Public: '[u8;32]',
     /**
-     * Lookup117: sp_core::sr25519::Public
+     * Lookup118: sp_core::sr25519::Public
      **/
     SpCoreSr25519Public: '[u8;32]',
     /**
-     * Lookup118: sp_runtime::MultiSignature
+     * Lookup119: sp_runtime::MultiSignature
      **/
     SpRuntimeMultiSignature: {
         _enum: {
@@ -767,15 +794,15 @@ export default {
         },
     },
     /**
-     * Lookup119: sp_core::ed25519::Signature
+     * Lookup120: sp_core::ed25519::Signature
      **/
     SpCoreEd25519Signature: '[u8;64]',
     /**
-     * Lookup121: sp_core::sr25519::Signature
+     * Lookup122: sp_core::sr25519::Signature
      **/
     SpCoreSr25519Signature: '[u8;64]',
     /**
-     * Lookup122: pallet_difficulty::pallet::Call<T>
+     * Lookup123: pallet_difficulty::pallet::Call<T>
      **/
     PalletDifficultyCall: {
         _enum: {
@@ -788,13 +815,13 @@ export default {
         },
     },
     /**
-     * Lookup124: pallet_sudo::pallet::Error<T>
+     * Lookup125: pallet_sudo::pallet::Error<T>
      **/
     PalletSudoError: {
         _enum: ['RequireSudo'],
     },
     /**
-     * Lookup126: pallet_creditcoin::types::UnverifiedTransfer<sp_core::crypto::AccountId32, BlockNum, primitive_types::H256, Moment>
+     * Lookup127: pallet_creditcoin::types::UnverifiedTransfer<sp_core::crypto::AccountId32, BlockNum, primitive_types::H256, Moment>
      **/
     PalletCreditcoinUnverifiedTransfer: {
         transfer: 'PalletCreditcoinTransfer',
@@ -802,7 +829,7 @@ export default {
         toExternal: 'Bytes',
     },
     /**
-     * Lookup129: pallet_creditcoin::pallet::Error<T>
+     * Lookup130: pallet_creditcoin::pallet::Error<T>
      **/
     PalletCreditcoinError: {
         _enum: [
@@ -859,44 +886,44 @@ export default {
         ],
     },
     /**
-     * Lookup131: pallet_difficulty::DifficultyAndTimestamp<Moment>
+     * Lookup132: pallet_difficulty::DifficultyAndTimestamp<Moment>
      **/
     PalletDifficultyDifficultyAndTimestamp: {
         difficulty: 'U256',
         timestamp: 'u64',
     },
     /**
-     * Lookup133: pallet_difficulty::pallet::Error<T>
+     * Lookup134: pallet_difficulty::pallet::Error<T>
      **/
     PalletDifficultyError: {
         _enum: ['ZeroTargetTime', 'ZeroAdjustmentPeriod', 'NegativeAdjustmentPeriod'],
     },
     /**
-     * Lookup136: frame_system::extensions::check_spec_version::CheckSpecVersion<T>
+     * Lookup137: frame_system::extensions::check_spec_version::CheckSpecVersion<T>
      **/
     FrameSystemExtensionsCheckSpecVersion: 'Null',
     /**
-     * Lookup137: frame_system::extensions::check_tx_version::CheckTxVersion<T>
+     * Lookup138: frame_system::extensions::check_tx_version::CheckTxVersion<T>
      **/
     FrameSystemExtensionsCheckTxVersion: 'Null',
     /**
-     * Lookup138: frame_system::extensions::check_genesis::CheckGenesis<T>
+     * Lookup139: frame_system::extensions::check_genesis::CheckGenesis<T>
      **/
     FrameSystemExtensionsCheckGenesis: 'Null',
     /**
-     * Lookup141: frame_system::extensions::check_nonce::CheckNonce<T>
+     * Lookup142: frame_system::extensions::check_nonce::CheckNonce<T>
      **/
     FrameSystemExtensionsCheckNonce: 'Compact<u32>',
     /**
-     * Lookup142: frame_system::extensions::check_weight::CheckWeight<T>
+     * Lookup143: frame_system::extensions::check_weight::CheckWeight<T>
      **/
     FrameSystemExtensionsCheckWeight: 'Null',
     /**
-     * Lookup143: pallet_transaction_payment::ChargeTransactionPayment<T>
+     * Lookup144: pallet_transaction_payment::ChargeTransactionPayment<T>
      **/
     PalletTransactionPaymentChargeTransactionPayment: 'Compact<u128>',
     /**
-     * Lookup144: creditcoin_node_runtime::Runtime
+     * Lookup145: creditcoin_node_runtime::Runtime
      **/
     CreditcoinNodeRuntimeRuntime: 'Null',
 };

--- a/javascript/src/interfaces/registry.ts
+++ b/javascript/src/interfaces/registry.ts
@@ -52,6 +52,7 @@ import type {
     PalletCreditcoinLoanTermsBidTerms,
     PalletCreditcoinLoanTermsDuration,
     PalletCreditcoinLoanTermsInterestRate,
+    PalletCreditcoinOcwErrorsVerificationFailureCause,
     PalletCreditcoinOffer,
     PalletCreditcoinOfferId,
     PalletCreditcoinOrderId,
@@ -137,6 +138,7 @@ declare module '@polkadot/types/types/registry' {
         PalletCreditcoinLoanTermsBidTerms: PalletCreditcoinLoanTermsBidTerms;
         PalletCreditcoinLoanTermsDuration: PalletCreditcoinLoanTermsDuration;
         PalletCreditcoinLoanTermsInterestRate: PalletCreditcoinLoanTermsInterestRate;
+        PalletCreditcoinOcwErrorsVerificationFailureCause: PalletCreditcoinOcwErrorsVerificationFailureCause;
         PalletCreditcoinOffer: PalletCreditcoinOffer;
         PalletCreditcoinOfferId: PalletCreditcoinOfferId;
         PalletCreditcoinOrderId: PalletCreditcoinOrderId;

--- a/javascript/src/interfaces/types-lookup.ts
+++ b/javascript/src/interfaces/types-lookup.ts
@@ -308,6 +308,8 @@ declare module '@polkadot/types/lookup' {
         readonly asLoanExempted: PalletCreditcoinDealOrderId;
         readonly isLegacyWalletClaimed: boolean;
         readonly asLegacyWalletClaimed: ITuple<[AccountId32, PalletCreditcoinLegacySighash, u128]>;
+        readonly isTransferFailedVerification: boolean;
+        readonly asTransferFailedVerification: ITuple<[H256, PalletCreditcoinOcwErrorsVerificationFailureCause]>;
         readonly type:
             | 'AddressRegistered'
             | 'TransferRegistered'
@@ -321,7 +323,8 @@ declare module '@polkadot/types/lookup' {
             | 'DealOrderLocked'
             | 'DealOrderClosed'
             | 'LoanExempted'
-            | 'LegacyWalletClaimed';
+            | 'LegacyWalletClaimed'
+            | 'TransferFailedVerification';
     }
 
     /** @name PalletCreditcoinAddress (33) */
@@ -468,14 +471,49 @@ declare module '@polkadot/types/lookup' {
     /** @name PalletCreditcoinLegacySighash (60) */
     export interface PalletCreditcoinLegacySighash extends U8aFixed {}
 
-    /** @name PalletRewardsEvent (62) */
+    /** @name PalletCreditcoinOcwErrorsVerificationFailureCause (62) */
+    export interface PalletCreditcoinOcwErrorsVerificationFailureCause extends Enum {
+        readonly isTransferFailed: boolean;
+        readonly isTransferPending: boolean;
+        readonly isTransferUnconfirmed: boolean;
+        readonly isTransferInFuture: boolean;
+        readonly isIncorrectContract: boolean;
+        readonly isMissingReceiver: boolean;
+        readonly isAbiMismatch: boolean;
+        readonly isIncorrectInputLength: boolean;
+        readonly isIncorrectInputType: boolean;
+        readonly isIncorrectAmount: boolean;
+        readonly isIncorrectNonce: boolean;
+        readonly isIncorrectReceiver: boolean;
+        readonly isIncorrectSender: boolean;
+        readonly isInvalidAddress: boolean;
+        readonly isUnsupportedMethod: boolean;
+        readonly type:
+            | 'TransferFailed'
+            | 'TransferPending'
+            | 'TransferUnconfirmed'
+            | 'TransferInFuture'
+            | 'IncorrectContract'
+            | 'MissingReceiver'
+            | 'AbiMismatch'
+            | 'IncorrectInputLength'
+            | 'IncorrectInputType'
+            | 'IncorrectAmount'
+            | 'IncorrectNonce'
+            | 'IncorrectReceiver'
+            | 'IncorrectSender'
+            | 'InvalidAddress'
+            | 'UnsupportedMethod';
+    }
+
+    /** @name PalletRewardsEvent (63) */
     export interface PalletRewardsEvent extends Enum {
         readonly isRewardIssued: boolean;
         readonly asRewardIssued: ITuple<[AccountId32, u128]>;
         readonly type: 'RewardIssued';
     }
 
-    /** @name FrameSystemPhase (63) */
+    /** @name FrameSystemPhase (64) */
     export interface FrameSystemPhase extends Enum {
         readonly isApplyExtrinsic: boolean;
         readonly asApplyExtrinsic: u32;
@@ -484,13 +522,13 @@ declare module '@polkadot/types/lookup' {
         readonly type: 'ApplyExtrinsic' | 'Finalization' | 'Initialization';
     }
 
-    /** @name FrameSystemLastRuntimeUpgradeInfo (67) */
+    /** @name FrameSystemLastRuntimeUpgradeInfo (68) */
     export interface FrameSystemLastRuntimeUpgradeInfo extends Struct {
         readonly specVersion: Compact<u32>;
         readonly specName: Text;
     }
 
-    /** @name FrameSystemCall (70) */
+    /** @name FrameSystemCall (71) */
     export interface FrameSystemCall extends Enum {
         readonly isFillBlock: boolean;
         readonly asFillBlock: {
@@ -541,21 +579,21 @@ declare module '@polkadot/types/lookup' {
             | 'RemarkWithEvent';
     }
 
-    /** @name FrameSystemLimitsBlockWeights (75) */
+    /** @name FrameSystemLimitsBlockWeights (76) */
     export interface FrameSystemLimitsBlockWeights extends Struct {
         readonly baseBlock: u64;
         readonly maxBlock: u64;
         readonly perClass: FrameSupportWeightsPerDispatchClassWeightsPerClass;
     }
 
-    /** @name FrameSupportWeightsPerDispatchClassWeightsPerClass (76) */
+    /** @name FrameSupportWeightsPerDispatchClassWeightsPerClass (77) */
     export interface FrameSupportWeightsPerDispatchClassWeightsPerClass extends Struct {
         readonly normal: FrameSystemLimitsWeightsPerClass;
         readonly operational: FrameSystemLimitsWeightsPerClass;
         readonly mandatory: FrameSystemLimitsWeightsPerClass;
     }
 
-    /** @name FrameSystemLimitsWeightsPerClass (77) */
+    /** @name FrameSystemLimitsWeightsPerClass (78) */
     export interface FrameSystemLimitsWeightsPerClass extends Struct {
         readonly baseExtrinsic: u64;
         readonly maxExtrinsic: Option<u64>;
@@ -563,25 +601,25 @@ declare module '@polkadot/types/lookup' {
         readonly reserved: Option<u64>;
     }
 
-    /** @name FrameSystemLimitsBlockLength (78) */
+    /** @name FrameSystemLimitsBlockLength (79) */
     export interface FrameSystemLimitsBlockLength extends Struct {
         readonly max: FrameSupportWeightsPerDispatchClassU32;
     }
 
-    /** @name FrameSupportWeightsPerDispatchClassU32 (79) */
+    /** @name FrameSupportWeightsPerDispatchClassU32 (80) */
     export interface FrameSupportWeightsPerDispatchClassU32 extends Struct {
         readonly normal: u32;
         readonly operational: u32;
         readonly mandatory: u32;
     }
 
-    /** @name FrameSupportWeightsRuntimeDbWeight (80) */
+    /** @name FrameSupportWeightsRuntimeDbWeight (81) */
     export interface FrameSupportWeightsRuntimeDbWeight extends Struct {
         readonly read: u64;
         readonly write: u64;
     }
 
-    /** @name SpVersionRuntimeVersion (81) */
+    /** @name SpVersionRuntimeVersion (82) */
     export interface SpVersionRuntimeVersion extends Struct {
         readonly specName: Text;
         readonly implName: Text;
@@ -593,7 +631,7 @@ declare module '@polkadot/types/lookup' {
         readonly stateVersion: u8;
     }
 
-    /** @name FrameSystemError (87) */
+    /** @name FrameSystemError (88) */
     export interface FrameSystemError extends Enum {
         readonly isInvalidSpecName: boolean;
         readonly isSpecVersionNeedsToIncrease: boolean;
@@ -610,7 +648,7 @@ declare module '@polkadot/types/lookup' {
             | 'CallFiltered';
     }
 
-    /** @name PalletTimestampCall (88) */
+    /** @name PalletTimestampCall (89) */
     export interface PalletTimestampCall extends Enum {
         readonly isSet: boolean;
         readonly asSet: {
@@ -619,14 +657,14 @@ declare module '@polkadot/types/lookup' {
         readonly type: 'Set';
     }
 
-    /** @name PalletBalancesBalanceLock (91) */
+    /** @name PalletBalancesBalanceLock (92) */
     export interface PalletBalancesBalanceLock extends Struct {
         readonly id: U8aFixed;
         readonly amount: u128;
         readonly reasons: PalletBalancesReasons;
     }
 
-    /** @name PalletBalancesReasons (92) */
+    /** @name PalletBalancesReasons (93) */
     export interface PalletBalancesReasons extends Enum {
         readonly isFee: boolean;
         readonly isMisc: boolean;
@@ -634,20 +672,20 @@ declare module '@polkadot/types/lookup' {
         readonly type: 'Fee' | 'Misc' | 'All';
     }
 
-    /** @name PalletBalancesReserveData (95) */
+    /** @name PalletBalancesReserveData (96) */
     export interface PalletBalancesReserveData extends Struct {
         readonly id: U8aFixed;
         readonly amount: u128;
     }
 
-    /** @name PalletBalancesReleases (97) */
+    /** @name PalletBalancesReleases (98) */
     export interface PalletBalancesReleases extends Enum {
         readonly isV100: boolean;
         readonly isV200: boolean;
         readonly type: 'V100' | 'V200';
     }
 
-    /** @name PalletBalancesCall (98) */
+    /** @name PalletBalancesCall (99) */
     export interface PalletBalancesCall extends Enum {
         readonly isTransfer: boolean;
         readonly asTransfer: {
@@ -690,7 +728,7 @@ declare module '@polkadot/types/lookup' {
             | 'ForceUnreserve';
     }
 
-    /** @name PalletBalancesError (103) */
+    /** @name PalletBalancesError (104) */
     export interface PalletBalancesError extends Enum {
         readonly isVestingBalance: boolean;
         readonly isLiquidityRestrictions: boolean;
@@ -711,14 +749,14 @@ declare module '@polkadot/types/lookup' {
             | 'TooManyReserves';
     }
 
-    /** @name PalletTransactionPaymentReleases (105) */
+    /** @name PalletTransactionPaymentReleases (106) */
     export interface PalletTransactionPaymentReleases extends Enum {
         readonly isV1Ancient: boolean;
         readonly isV2: boolean;
         readonly type: 'V1Ancient' | 'V2';
     }
 
-    /** @name FrameSupportWeightsWeightToFeeCoefficient (107) */
+    /** @name FrameSupportWeightsWeightToFeeCoefficient (108) */
     export interface FrameSupportWeightsWeightToFeeCoefficient extends Struct {
         readonly coeffInteger: u128;
         readonly coeffFrac: Perbill;
@@ -726,7 +764,7 @@ declare module '@polkadot/types/lookup' {
         readonly degree: u8;
     }
 
-    /** @name PalletSudoCall (108) */
+    /** @name PalletSudoCall (109) */
     export interface PalletSudoCall extends Enum {
         readonly isSudo: boolean;
         readonly asSudo: {
@@ -749,7 +787,7 @@ declare module '@polkadot/types/lookup' {
         readonly type: 'Sudo' | 'SudoUncheckedWeight' | 'SetKey' | 'SudoAs';
     }
 
-    /** @name PalletCreditcoinCall (110) */
+    /** @name PalletCreditcoinCall (111) */
     export interface PalletCreditcoinCall extends Enum {
         readonly isClaimLegacyWallet: boolean;
         readonly asClaimLegacyWallet: {
@@ -832,6 +870,11 @@ declare module '@polkadot/types/lookup' {
         readonly asVerifyTransfer: {
             readonly transfer: PalletCreditcoinTransfer;
         } & Struct;
+        readonly isFailTransfer: boolean;
+        readonly asFailTransfer: {
+            readonly transferId: H256;
+            readonly cause: PalletCreditcoinOcwErrorsVerificationFailureCause;
+        } & Struct;
         readonly isAddAuthority: boolean;
         readonly asAddAuthority: {
             readonly who: AccountId32;
@@ -851,16 +894,17 @@ declare module '@polkadot/types/lookup' {
             | 'RegisterRepaymentTransfer'
             | 'Exempt'
             | 'VerifyTransfer'
+            | 'FailTransfer'
             | 'AddAuthority';
     }
 
-    /** @name SpCoreEcdsaPublic (111) */
+    /** @name SpCoreEcdsaPublic (112) */
     export interface SpCoreEcdsaPublic extends U8aFixed {}
 
-    /** @name SpCoreEcdsaSignature (113) */
+    /** @name SpCoreEcdsaSignature (114) */
     export interface SpCoreEcdsaSignature extends U8aFixed {}
 
-    /** @name SpRuntimeMultiSigner (115) */
+    /** @name SpRuntimeMultiSigner (116) */
     export interface SpRuntimeMultiSigner extends Enum {
         readonly isEd25519: boolean;
         readonly asEd25519: SpCoreEd25519Public;
@@ -871,13 +915,13 @@ declare module '@polkadot/types/lookup' {
         readonly type: 'Ed25519' | 'Sr25519' | 'Ecdsa';
     }
 
-    /** @name SpCoreEd25519Public (116) */
+    /** @name SpCoreEd25519Public (117) */
     export interface SpCoreEd25519Public extends U8aFixed {}
 
-    /** @name SpCoreSr25519Public (117) */
+    /** @name SpCoreSr25519Public (118) */
     export interface SpCoreSr25519Public extends U8aFixed {}
 
-    /** @name SpRuntimeMultiSignature (118) */
+    /** @name SpRuntimeMultiSignature (119) */
     export interface SpRuntimeMultiSignature extends Enum {
         readonly isEd25519: boolean;
         readonly asEd25519: SpCoreEd25519Signature;
@@ -888,13 +932,13 @@ declare module '@polkadot/types/lookup' {
         readonly type: 'Ed25519' | 'Sr25519' | 'Ecdsa';
     }
 
-    /** @name SpCoreEd25519Signature (119) */
+    /** @name SpCoreEd25519Signature (120) */
     export interface SpCoreEd25519Signature extends U8aFixed {}
 
-    /** @name SpCoreSr25519Signature (121) */
+    /** @name SpCoreSr25519Signature (122) */
     export interface SpCoreSr25519Signature extends U8aFixed {}
 
-    /** @name PalletDifficultyCall (122) */
+    /** @name PalletDifficultyCall (123) */
     export interface PalletDifficultyCall extends Enum {
         readonly isSetTargetBlockTime: boolean;
         readonly asSetTargetBlockTime: {
@@ -907,20 +951,20 @@ declare module '@polkadot/types/lookup' {
         readonly type: 'SetTargetBlockTime' | 'SetAdjustmentPeriod';
     }
 
-    /** @name PalletSudoError (124) */
+    /** @name PalletSudoError (125) */
     export interface PalletSudoError extends Enum {
         readonly isRequireSudo: boolean;
         readonly type: 'RequireSudo';
     }
 
-    /** @name PalletCreditcoinUnverifiedTransfer (126) */
+    /** @name PalletCreditcoinUnverifiedTransfer (127) */
     export interface PalletCreditcoinUnverifiedTransfer extends Struct {
         readonly transfer: PalletCreditcoinTransfer;
         readonly fromExternal: Bytes;
         readonly toExternal: Bytes;
     }
 
-    /** @name PalletCreditcoinError (129) */
+    /** @name PalletCreditcoinError (130) */
     export interface PalletCreditcoinError extends Enum {
         readonly isAddressAlreadyRegistered: boolean;
         readonly isNonExistentAddress: boolean;
@@ -1025,13 +1069,13 @@ declare module '@polkadot/types/lookup' {
             | 'OwnershipNotSatisfied';
     }
 
-    /** @name PalletDifficultyDifficultyAndTimestamp (131) */
+    /** @name PalletDifficultyDifficultyAndTimestamp (132) */
     export interface PalletDifficultyDifficultyAndTimestamp extends Struct {
         readonly difficulty: U256;
         readonly timestamp: u64;
     }
 
-    /** @name PalletDifficultyError (133) */
+    /** @name PalletDifficultyError (134) */
     export interface PalletDifficultyError extends Enum {
         readonly isZeroTargetTime: boolean;
         readonly isZeroAdjustmentPeriod: boolean;
@@ -1039,24 +1083,24 @@ declare module '@polkadot/types/lookup' {
         readonly type: 'ZeroTargetTime' | 'ZeroAdjustmentPeriod' | 'NegativeAdjustmentPeriod';
     }
 
-    /** @name FrameSystemExtensionsCheckSpecVersion (136) */
+    /** @name FrameSystemExtensionsCheckSpecVersion (137) */
     export type FrameSystemExtensionsCheckSpecVersion = Null;
 
-    /** @name FrameSystemExtensionsCheckTxVersion (137) */
+    /** @name FrameSystemExtensionsCheckTxVersion (138) */
     export type FrameSystemExtensionsCheckTxVersion = Null;
 
-    /** @name FrameSystemExtensionsCheckGenesis (138) */
+    /** @name FrameSystemExtensionsCheckGenesis (139) */
     export type FrameSystemExtensionsCheckGenesis = Null;
 
-    /** @name FrameSystemExtensionsCheckNonce (141) */
+    /** @name FrameSystemExtensionsCheckNonce (142) */
     export interface FrameSystemExtensionsCheckNonce extends Compact<u32> {}
 
-    /** @name FrameSystemExtensionsCheckWeight (142) */
+    /** @name FrameSystemExtensionsCheckWeight (143) */
     export type FrameSystemExtensionsCheckWeight = Null;
 
-    /** @name PalletTransactionPaymentChargeTransactionPayment (143) */
+    /** @name PalletTransactionPaymentChargeTransactionPayment (144) */
     export interface PalletTransactionPaymentChargeTransactionPayment extends Compact<u128> {}
 
-    /** @name CreditcoinNodeRuntimeRuntime (144) */
+    /** @name CreditcoinNodeRuntimeRuntime (145) */
     export type CreditcoinNodeRuntimeRuntime = Null;
 } // declare module

--- a/pallets/creditcoin/src/benchmarking.rs
+++ b/pallets/creditcoin/src/benchmarking.rs
@@ -178,6 +178,15 @@ benchmarks! {
 
 	}: _(RawOrigin::Signed(authority), transfer)
 
+	fail_transfer {
+		<Timestamp<T>>::set_timestamp(1u32.into());
+		let authority = authority_account::<T>(true);
+		<Creditcoin<T>>::add_authority(RawOrigin::Root.into(), authority.clone()).unwrap();
+		let deal_id = generate_deal::<T>(true,0u8).unwrap();
+		let (transfer_id, _)= generate_transfer::<T>(deal_id,false,false,true,0u8);
+		let cause = crate::ocw::VerificationFailureCause::TransferFailed;
+	}: _(RawOrigin::Signed(authority), transfer_id, cause)
+
 	fund_deal_order {
 		<Timestamp<T>>::set_timestamp(1u32.into());
 		let lender: T::AccountId = lender_account::<T>(true);

--- a/pallets/creditcoin/src/lib.rs
+++ b/pallets/creditcoin/src/lib.rs
@@ -140,6 +140,7 @@ pub mod pallet {
 		fn add_deal_order() -> Weight;
 		fn add_authority() -> Weight;
 		fn verify_transfer() -> Weight;
+		fn fail_transfer() -> Weight;
 		fn fund_deal_order() -> Weight;
 		fn lock_deal_order() -> Weight;
 		fn register_transfer_ocw() -> Weight;
@@ -1244,7 +1245,7 @@ pub mod pallet {
 			Ok(PostDispatchInfo { actual_weight: None, pays_fee: Pays::No })
 		}
 
-		#[pallet::weight(T::DbWeight::get().reads_writes(1, 1))]
+		#[pallet::weight(<T as Config>::WeightInfo::fail_transfer())]
 		pub fn fail_transfer(
 			origin: OriginFor<T>,
 			transfer_id: TransferId<T::Hash>,

--- a/pallets/creditcoin/src/lib.rs
+++ b/pallets/creditcoin/src/lib.rs
@@ -1254,6 +1254,11 @@ pub mod pallet {
 
 			ensure!(Authorities::<T>::contains_key(&who), Error::<T>::InsufficientAuthority);
 
+			ensure!(
+				!Transfers::<T>::contains_key(&transfer_id),
+				Error::<T>::TransferAlreadyRegistered
+			);
+
 			Self::deposit_event(Event::<T>::TransferFailedVerification(transfer_id, cause));
 			Ok(PostDispatchInfo { actual_weight: None, pays_fee: Pays::No })
 		}

--- a/pallets/creditcoin/src/mock.rs
+++ b/pallets/creditcoin/src/mock.rs
@@ -1,9 +1,11 @@
 use crate::{
 	self as pallet_creditcoin,
 	ocw::rpc::{JsonRpcRequest, JsonRpcResponse},
-	LegacySighash,
+	Blockchain, LegacySighash,
 };
+use ethereum_types::U256;
 use frame_support::{
+	once_cell::sync::Lazy,
 	parameter_types,
 	traits::{ConstU32, ConstU64, GenesisBuild, Hooks},
 };
@@ -13,6 +15,7 @@ use sp_core::H256;
 use sp_keystore::{testing::KeyStore, KeystoreExt, SyncCryptoStore};
 use sp_runtime::{
 	offchain::{
+		storage::StorageValueRef,
 		testing::{
 			OffchainState, PendingRequest, PoolState, TestOffchainExt, TestTransactionPoolExt,
 		},
@@ -22,7 +25,7 @@ use sp_runtime::{
 	traits::{BlakeTwo256, Extrinsic as ExtrinsicT, IdentifyAccount, IdentityLookup, Verify},
 	MultiSignature, RuntimeAppPublic,
 };
-use std::{collections::HashMap, sync::Arc};
+use std::{cell::Cell, collections::HashMap, sync::Arc};
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
@@ -114,6 +117,19 @@ impl pallet_creditcoin::Config for Test {
 	type WeightInfo = super::weights::WeightInfo<Test>;
 }
 
+thread_local! {
+	pub static CREATE_TRANSACTION_FAIL: Cell<bool> = Cell::new(false);
+}
+
+pub(crate) fn with_failing_create_transaction<R>(f: impl FnOnce() -> R) -> R {
+	CREATE_TRANSACTION_FAIL.with(|c| {
+		c.set(true);
+		let result = f();
+		c.set(false);
+		result
+	})
+}
+
 impl system::offchain::CreateSignedTransaction<pallet_creditcoin::Call<Test>> for Test {
 	fn create_transaction<C: system::offchain::AppCrypto<Self::Public, Self::Signature>>(
 		call: Self::OverarchingCall,
@@ -121,7 +137,15 @@ impl system::offchain::CreateSignedTransaction<pallet_creditcoin::Call<Test>> fo
 		_account: Self::AccountId,
 		nonce: Self::Index,
 	) -> Option<(Call, <Extrinsic as ExtrinsicT>::SignaturePayload)> {
-		Some((call, (nonce, ())))
+		CREATE_TRANSACTION_FAIL.with(|should_fail| {
+			if should_fail.get() {
+				eprintln!("Failing!");
+				None
+			} else {
+				eprintln!("Not failing!");
+				Some((call, (nonce, ())))
+			}
+		})
 	}
 }
 
@@ -278,15 +302,20 @@ pub fn roll_to_with_ocw(n: BlockNumber) {
 pub fn roll_by_with_ocw(n: BlockNumber) {
 	let mut now = System::block_number();
 	for _ in 0..n {
-		if now == 0 {
-			Creditcoin::offchain_worker(now);
-		}
+		Creditcoin::offchain_worker(now);
 		now += 1;
 		System::set_block_number(now);
 		Creditcoin::on_initialize(now);
-		Creditcoin::offchain_worker(now);
 		Creditcoin::on_finalize(now);
 	}
+}
+
+// must be called in an externalities-provided environment
+pub fn set_rpc_uri(blockchain: &Blockchain, value: impl AsRef<[u8]>) {
+	let mut key = Vec::from(blockchain.as_bytes());
+	key.extend(b"-rpc-uri");
+	let rpc_url_storage = StorageValueRef::persistent(&key);
+	rpc_url_storage.set(&value.as_ref());
 }
 
 pub fn pending_rpc_request(
@@ -307,6 +336,169 @@ pub fn pending_rpc_request(
 		response_headers: vec![("Content-Type".into(), "application/json".into())],
 		sent: true,
 		..Default::default()
+	}
+}
+
+pub(crate) static ETHLESS_RESPONSES: Lazy<HashMap<String, JsonRpcResponse<serde_json::Value>>> =
+	Lazy::new(|| serde_json::from_slice(include_bytes!("tests/ethlessTransfer.json")).unwrap());
+
+pub(crate) fn get_mock_tx_hash() -> String {
+	let responses = &*ETHLESS_RESPONSES;
+	responses["eth_getTransactionByHash"].result.clone().unwrap()["hash"]
+		.clone()
+		.as_str()
+		.unwrap()
+		.to_string()
+}
+
+pub(crate) fn get_mock_contract() -> String {
+	let responses = &*ETHLESS_RESPONSES;
+
+	responses["eth_getTransactionByHash"].result.clone().unwrap()["to"]
+		.clone()
+		.as_str()
+		.unwrap()
+		.to_string()
+}
+
+pub(crate) fn get_mock_tx_block_num() -> String {
+	let responses = &*ETHLESS_RESPONSES;
+
+	responses["eth_getTransactionByHash"].result.clone().unwrap()["blockNumber"]
+		.clone()
+		.as_str()
+		.unwrap()
+		.to_string()
+}
+
+pub(crate) fn get_mock_from_address() -> String {
+	format!("{:?}", get_mock_contract_input(0, ethabi::Token::into_address))
+}
+
+fn get_mock_contract_input<T>(index: usize, convert: impl FnOnce(ethabi::Token) -> Option<T>) -> T {
+	let responses = &*ETHLESS_RESPONSES;
+
+	let abi = crate::ocw::ethless_transfer_function_abi();
+	let input = responses["eth_getTransactionByHash"].result.clone().unwrap()["input"]
+		.clone()
+		.as_str()
+		.unwrap()
+		.to_string();
+	let input_bytes = hex::decode(&input.trim_start_matches("0x")).unwrap();
+	let inputs = abi.decode_input(&input_bytes[4..]).unwrap();
+	convert(inputs[index].clone()).unwrap()
+}
+
+pub(crate) fn get_mock_input_data() -> String {
+	let responses = &*ETHLESS_RESPONSES;
+
+	responses["eth_getTransactionByHash"].result.clone().unwrap()["input"]
+		.clone()
+		.as_str()
+		.unwrap()
+		.to_string()
+}
+
+pub(crate) fn get_mock_to_address() -> String {
+	format!("{:?}", get_mock_contract_input(1, ethabi::Token::into_address))
+}
+
+pub(crate) fn get_mock_amount() -> U256 {
+	get_mock_contract_input(2, ethabi::Token::into_uint)
+}
+
+pub(crate) fn get_mock_nonce() -> U256 {
+	get_mock_contract_input(4, ethabi::Token::into_uint)
+}
+
+pub(crate) fn get_mock_timestamp() -> u64 {
+	let responses = &*ETHLESS_RESPONSES;
+
+	let timestamp_hex = responses["eth_getBlockByNumber"].result.clone().unwrap()["timestamp"]
+		.clone()
+		.as_str()
+		.unwrap()
+		.to_string();
+	u64::from_str_radix(&timestamp_hex.trim_start_matches("0x"), 16).unwrap()
+}
+
+pub(crate) struct MockedRpcRequests {
+	pub(crate) get_transaction: Option<PendingRequest>,
+	pub(crate) get_transaction_receipt: Option<PendingRequest>,
+	pub(crate) get_block_number: Option<PendingRequest>,
+	pub(crate) get_block_by_number: Option<PendingRequest>,
+}
+
+impl Default for MockedRpcRequests {
+	fn default() -> Self {
+		let rpc_uri = "http://localhost:8545";
+		let tx_hash = get_mock_tx_hash();
+		let tx_block_number = get_mock_tx_block_num();
+
+		Self::new(rpc_uri, &tx_hash, &tx_block_number)
+	}
+}
+
+impl MockedRpcRequests {
+	pub(crate) fn new<'a>(
+		rpc_uri: impl Into<Option<&'a str>>,
+		tx_hash: &str,
+		tx_block_number: &str,
+	) -> Self {
+		let responses = &*ETHLESS_RESPONSES;
+		let uri = rpc_uri.into().unwrap_or("dummy");
+		let get_transaction = Some(pending_rpc_request(
+			"eth_getTransactionByHash",
+			vec![tx_hash.into()],
+			uri,
+			responses,
+		));
+		let get_transaction_receipt = Some(pending_rpc_request(
+			"eth_getTransactionReceipt",
+			vec![tx_hash.into()],
+			uri,
+			&responses,
+		));
+		let get_block_number = Some(pending_rpc_request("eth_blockNumber", None, uri, &responses));
+		let get_block_by_number = Some(pending_rpc_request(
+			"eth_getBlockByNumber",
+			vec![tx_block_number.into(), false.into()],
+			uri,
+			&responses,
+		));
+		Self { get_transaction, get_transaction_receipt, get_block_number, get_block_by_number }
+	}
+
+	/// Mocks only the RPC response for get_transaction
+	pub(crate) fn mock_get_transaction(&mut self, state: &mut OffchainState) {
+		let get_transaction = self.get_transaction.take().unwrap();
+		state.expect_request(get_transaction);
+	}
+
+	/// Mocks the RPC responses up to (inclusive) get_transaction_receipt
+	pub(crate) fn mock_get_transaction_receipt(&mut self, state: &mut OffchainState) {
+		self.mock_get_transaction(state);
+		let get_transaction_receipt = self.get_transaction_receipt.take().unwrap();
+		state.expect_request(get_transaction_receipt);
+	}
+
+	/// Mocks the RPC responses up to (inclusive) get_block_number
+	pub(crate) fn mock_get_block_number(&mut self, state: &mut OffchainState) {
+		self.mock_get_transaction_receipt(state);
+		let get_block_number = self.get_block_number.take().unwrap();
+		state.expect_request(get_block_number);
+	}
+
+	/// Mocks the RPC responses up to (inclusive) get_block_by_number
+	pub(crate) fn mock_get_block_by_number(mut self, state: &mut OffchainState) {
+		self.mock_get_block_number(state);
+		let get_block_by_number = self.get_block_by_number.take().unwrap();
+		state.expect_request(get_block_by_number);
+	}
+
+	/// Mocks all of the RPC responses
+	pub(crate) fn mock_all(self, state: &mut OffchainState) {
+		self.mock_get_block_by_number(state);
 	}
 }
 

--- a/pallets/creditcoin/src/ocw.rs
+++ b/pallets/creditcoin/src/ocw.rs
@@ -1,9 +1,10 @@
 pub mod errors;
 pub mod rpc;
 use crate::{Blockchain, Call, Id, Transfer, TransferKind, UnverifiedTransfer};
+pub use errors::{OffchainError, VerificationFailureCause, VerificationResult};
 
 use self::{
-	errors::{OffchainError, RpcUrlError, VerificationFailureCause, VerificationResult},
+	errors::RpcUrlError,
 	rpc::{Address, EthBlock, EthTransaction, EthTransactionReceipt},
 };
 

--- a/pallets/creditcoin/src/ocw/errors.rs
+++ b/pallets/creditcoin/src/ocw/errors.rs
@@ -57,7 +57,7 @@ impl VerificationFailureCause {
 	}
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum RpcUrlError {
 	StorageFailure(StorageRetrievalError),
 	InvalidUrl(FromUtf8Error),

--- a/pallets/creditcoin/src/ocw/rpc.rs
+++ b/pallets/creditcoin/src/ocw/rpc.rs
@@ -201,14 +201,14 @@ impl JsonRpcRequest {
 	}
 }
 
-#[derive(serde::Deserialize, Clone, Debug)]
+#[derive(serde::Deserialize, serde::Serialize, Clone, Debug)]
 pub struct JsonRpcResponse<T> {
 	#[allow(dead_code)]
-	jsonrpc: VecString,
+	pub jsonrpc: VecString,
 	#[allow(dead_code)]
-	id: u64,
-	error: Option<JsonRpcError>,
-	result: Option<T>,
+	pub id: u64,
+	pub error: Option<JsonRpcError>,
+	pub result: Option<T>,
 }
 
 impl<T> JsonRpcResponse<T> {
@@ -225,7 +225,7 @@ impl<T> JsonRpcResponse<T> {
 }
 
 #[allow(dead_code)]
-#[derive(serde::Deserialize, Clone, Debug)]
+#[derive(serde::Deserialize, serde::Serialize, Clone, Debug)]
 pub struct JsonRpcError {
 	code: i32,
 	message: String,

--- a/pallets/creditcoin/src/tests.rs
+++ b/pallets/creditcoin/src/tests.rs
@@ -478,7 +478,6 @@ fn verify_ethless_transfer() {
 		));
 		let amount = U256::from(100);
 		let tx_id = tx_hash.hex_to_address();
-		let mut timestamp = None;
 
 		assert_ok!(Creditcoin::verify_ethless_transfer(
 			&Blockchain::Rinkeby,
@@ -488,7 +487,6 @@ fn verify_ethless_transfer() {
 			&order_id,
 			&amount,
 			&tx_id,
-			&mut timestamp
 		));
 	});
 }

--- a/pallets/creditcoin/src/tests/ethlessTransfer.json
+++ b/pallets/creditcoin/src/tests/ethlessTransfer.json
@@ -108,6 +108,5 @@
       "uncles": [],
       "baseFeePerGas": "0x7"
     }
-  },
-  "network": "ethereum"
+  }
 }

--- a/pallets/creditcoin/src/weights.rs
+++ b/pallets/creditcoin/src/weights.rs
@@ -120,6 +120,12 @@ impl<T: frame_system::Config> super::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(2 as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
+	// Storage: Creditcoin Authorities (r:1 w:0)
+	// Storage: Creditcoin Transfers (r:1 w:0)
+	fn fail_transfer() -> Weight {
+		(12_000_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(2 as Weight))
+	}
 	// Storage: Creditcoin DealOrders (r:1 w:1)
 	// Storage: Creditcoin Addresses (r:1 w:0)
 	// Storage: Timestamp Now (r:1 w:0)


### PR DESCRIPTION
Description of proposed changes:

- Separates "hard" errors from "soft" errors
- Separates the notion of failing to verify the transfer from encountering an error (e.g. a timeout) during the process
- Adds an extrinsic `fail_transfer` which is called by the off-chain-worker and emits an event indicating the transfer failed
- Adds unit tests for most of `ocw.rs` (improves region coverage from  79.78% to 89.03%)
- Cleans up the RPC request mocking so now we don't hardcode values (e.g. the addresses and amount), instead pulling it from the JSON file. So now if we update the mocked responses we can just update the JSON, the tests shouldn't have to change.

Todo:
- [x] Benchmarks for `fail_transfer`
- [x] Integration test

Practical tips for PR review & merge:

- [x] All GitHub Actions report PASS
- [x] Newly added code/functions have unit tests
  - [x] Coverage tools report all newly added lines as covered
  - [x] The positive scenario is exercised
  - [x] Negative scenarios are exercised, e.g. assert on all possible errors
  - [x] Assert on events triggered if applicable
  - [x] Assert on changes made to storage if applicable
- [x] Modified behavior/functions - try to make sure above test items are covered
- [x] Integration tests are added if applicable/needed
