### PR TITLE
[CSUB-136] Add interest type to `InterestRate`

### DIFF
--- a/pallets/creditcoin/src/benchmarking.rs
+++ b/pallets/creditcoin/src/benchmarking.rs
@@ -7,7 +7,7 @@ use crate::types::Blockchain;
 use crate::Duration;
 #[allow(unused)]
 use crate::Pallet as Creditcoin;
-use crate::{AskOrderId, InterestRate, LoanTerms};
+use crate::{AskOrderId, InterestRate, InterestType, LoanTerms};
 use frame_benchmarking::{account, benchmarks, whitelist_account, Zero};
 use frame_support::{
 	pallet_prelude::*,
@@ -260,6 +260,7 @@ fn get_all_fit_terms<T: Config>() -> LoanTerms {
 			rate_per_period: 1,
 			decimals: 1,
 			period: Duration::from_millis(100),
+			interest_type: InterestType::Simple,
 		},
 		term_length: Duration::new(1u64, 0u32),
 	}

--- a/pallets/creditcoin/src/lib.rs
+++ b/pallets/creditcoin/src/lib.rs
@@ -52,7 +52,7 @@ pub mod crypto {
 
 pub type BalanceFor<T> = <T as pallet_balances::Config>::Balance;
 
-pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(2);
+pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(3);
 
 #[frame_support::pallet]
 pub mod pallet {

--- a/pallets/creditcoin/src/migrations/mod.rs
+++ b/pallets/creditcoin/src/migrations/mod.rs
@@ -3,6 +3,7 @@ use frame_support::{traits::StorageVersion, weights::Weight};
 
 mod v1;
 mod v2;
+mod v3;
 
 pub(crate) fn migrate<T: Config>() -> Weight {
 	let version = StorageVersion::get::<Pallet<T>>();
@@ -16,6 +17,11 @@ pub(crate) fn migrate<T: Config>() -> Weight {
 	if version < 2 {
 		weight = weight.saturating_add(v2::migrate::<T>());
 		StorageVersion::new(2).put::<Pallet<T>>();
+	}
+
+	if version < 3 {
+		weight = weight.saturating_add(v3::migrate::<T>());
+		StorageVersion::new(3).put::<Pallet<T>>();
 	}
 
 	weight

--- a/pallets/creditcoin/src/migrations/v1.rs
+++ b/pallets/creditcoin/src/migrations/v1.rs
@@ -1,7 +1,6 @@
-use core::convert::TryFrom;
-
 use crate::{
-	loan_terms::Duration, AddressId, Blockchain, Config, ExternalAmount, OfferId, TransferId,
+	loan_terms::{Decimals, Duration},
+	AddressId, Blockchain, Config, ExternalAmount, OfferId, RatePerPeriod, TransferId,
 };
 use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::weights::Weight;
@@ -14,20 +13,20 @@ type OldInterestRate = u64;
 
 const OLD_INTEREST_RATE_DECIMALS: u64 = 4;
 
-#[derive(Clone, Encode, Decode, Eq, PartialEq, TypeInfo, MaxEncodedLen)]
+#[derive(Clone, Encode, Decode, TypeInfo, MaxEncodedLen)]
 struct OldLoanTerms<Moment> {
 	amount: ExternalAmount,
 	interest_rate: OldInterestRate,
 	maturity: Moment,
 }
 
-#[derive(Clone, Encode, Decode, Eq, PartialEq, TypeInfo, MaxEncodedLen)]
+#[derive(Clone, Encode, Decode, TypeInfo, MaxEncodedLen)]
 struct OldAskTerms<Moment>(OldLoanTerms<Moment>);
 
-#[derive(Clone, Encode, Decode, Eq, PartialEq, TypeInfo, MaxEncodedLen)]
+#[derive(Clone, Encode, Decode, TypeInfo, MaxEncodedLen)]
 struct OldBidTerms<Moment>(OldLoanTerms<Moment>);
 
-#[derive(Clone, Encode, Decode, Eq, PartialEq, TypeInfo, MaxEncodedLen)]
+#[derive(Clone, Encode, Decode, TypeInfo, MaxEncodedLen)]
 struct OldAskOrder<AccountId, BlockNum, Hash, Moment> {
 	blockchain: Blockchain,
 	lender_address_id: AddressId<Hash>,
@@ -37,7 +36,7 @@ struct OldAskOrder<AccountId, BlockNum, Hash, Moment> {
 	lender: AccountId,
 }
 
-#[derive(Clone, Encode, Decode, Eq, PartialEq, TypeInfo, MaxEncodedLen)]
+#[derive(Clone, Encode, Decode, TypeInfo, MaxEncodedLen)]
 struct OldBidOrder<AccountId, BlockNum, Hash, Moment> {
 	blockchain: Blockchain,
 	borrower_address_id: AddressId<Hash>,
@@ -47,7 +46,7 @@ struct OldBidOrder<AccountId, BlockNum, Hash, Moment> {
 	borrower: AccountId,
 }
 
-#[derive(Clone, Encode, Decode, Eq, PartialEq, TypeInfo, MaxEncodedLen)]
+#[derive(Clone, Encode, Decode, TypeInfo, MaxEncodedLen)]
 struct OldDealOrder<AccountId, BlockNum, Hash, Moment> {
 	blockchain: Blockchain,
 	offer_id: OfferId<BlockNum, Hash>,
@@ -62,13 +61,13 @@ struct OldDealOrder<AccountId, BlockNum, Hash, Moment> {
 	borrower: AccountId,
 }
 
-#[derive(Clone, Encode, Decode, Eq, PartialEq, TypeInfo, MaxEncodedLen)]
+#[derive(Clone, Encode, Decode, TypeInfo, MaxEncodedLen)]
 pub struct DealOrder<AccountId, BlockNum, Hash, Moment> {
 	pub blockchain: Blockchain,
 	pub offer_id: OfferId<BlockNum, Hash>,
 	pub lender_address_id: AddressId<Hash>,
 	pub borrower_address_id: AddressId<Hash>,
-	pub terms: crate::LoanTerms,
+	pub terms: LoanTerms,
 	pub expiration_block: BlockNum,
 	pub timestamp: Moment,
 	pub funding_transfer_id: Option<TransferId<Hash>>,
@@ -77,61 +76,111 @@ pub struct DealOrder<AccountId, BlockNum, Hash, Moment> {
 	pub borrower: AccountId,
 }
 
+#[derive(Clone, Encode, Decode, TypeInfo, MaxEncodedLen)]
+pub struct InterestRate {
+	pub rate_per_period: RatePerPeriod,
+	pub decimals: Decimals,
+	pub period: Duration,
+}
+
+#[derive(Clone, Encode, Decode, TypeInfo, MaxEncodedLen)]
+pub struct LoanTerms {
+	pub amount: ExternalAmount,
+	pub interest_rate: InterestRate,
+	pub term_length: Duration,
+}
+
+#[derive(Clone, Encode, Decode, TypeInfo, MaxEncodedLen)]
+pub struct AskTerms(pub LoanTerms);
+
+#[derive(Clone, Encode, Decode, TypeInfo, MaxEncodedLen)]
+pub struct BidTerms(pub LoanTerms);
+
+#[derive(Clone, Encode, Decode, TypeInfo, MaxEncodedLen)]
+pub struct AskOrder<AccountId, BlockNum, Hash> {
+	pub blockchain: Blockchain,
+	pub lender_address_id: AddressId<Hash>,
+	pub terms: AskTerms,
+	pub expiration_block: BlockNum,
+	pub block: BlockNum,
+	pub lender: AccountId,
+}
+
+#[derive(Clone, Encode, Decode, TypeInfo, MaxEncodedLen)]
+pub struct BidOrder<AccountId, BlockNum, Hash> {
+	pub blockchain: Blockchain,
+	pub borrower_address_id: AddressId<Hash>,
+	pub terms: BidTerms,
+	pub expiration_block: BlockNum,
+	pub block: BlockNum,
+	pub borrower: AccountId,
+}
+
 generate_storage_alias!(
 	Creditcoin,
 	DealOrders<T: Config> => DoubleMap<(Twox64Concat, T::BlockNumber), (Identity, T::Hash), DealOrder<T::AccountId, T::BlockNumber, T::Hash, T::Moment>>
 );
 
+generate_storage_alias!(
+	Creditcoin,
+	AskOrders<T: Config> => DoubleMap<(Twox64Concat, T::BlockNumber), (Identity, T::Hash), AskOrder<T::AccountId, T::BlockNumber, T::Hash>>
+);
+
+generate_storage_alias!(
+	Creditcoin,
+	BidOrders<T: Config> => DoubleMap<(Twox64Concat, T::BlockNumber), (Identity, T::Hash), BidOrder<T::AccountId, T::BlockNumber, T::Hash>>
+);
+
 pub(crate) fn migrate<T: Config>() -> Weight {
 	let mut weight: Weight = 0;
 	let weight_each = T::DbWeight::get().reads_writes(1, 1);
-	crate::AskOrders::<T>::translate::<
-		OldAskOrder<T::AccountId, T::BlockNumber, T::Hash, T::Moment>,
-		_,
-	>(|_expiration, _hash, ask| {
-		weight = weight.saturating_add(weight_each);
-		Some(crate::AskOrder {
-			block: ask.block,
-			blockchain: ask.blockchain,
-			expiration_block: ask.expiration_block,
-			lender: ask.lender,
-			lender_address_id: ask.lender_address_id,
-			terms: crate::AskTerms::try_from(crate::LoanTerms {
-				amount: ask.terms.0.amount,
-				interest_rate: crate::InterestRate {
-					rate_per_period: ask.terms.0.interest_rate,
-					decimals: OLD_INTEREST_RATE_DECIMALS,
-					period: Duration::from_millis(ask.terms.0.maturity.unique_saturated_into()),
-				},
-				term_length: Duration::from_millis(ask.terms.0.maturity.unique_saturated_into()),
+	AskOrders::<T>::translate::<OldAskOrder<T::AccountId, T::BlockNumber, T::Hash, T::Moment>, _>(
+		|_expiration, _hash, ask| {
+			weight = weight.saturating_add(weight_each);
+			Some(AskOrder {
+				block: ask.block,
+				blockchain: ask.blockchain,
+				expiration_block: ask.expiration_block,
+				lender: ask.lender,
+				lender_address_id: ask.lender_address_id,
+				terms: AskTerms(LoanTerms {
+					amount: ask.terms.0.amount,
+					interest_rate: InterestRate {
+						rate_per_period: ask.terms.0.interest_rate,
+						decimals: OLD_INTEREST_RATE_DECIMALS,
+						period: Duration::from_millis(ask.terms.0.maturity.unique_saturated_into()),
+					},
+					term_length: Duration::from_millis(
+						ask.terms.0.maturity.unique_saturated_into(),
+					),
+				}),
 			})
-			.expect("pre-existing ask orders cannot have invalid terms"),
-		})
-	});
+		},
+	);
 
-	crate::BidOrders::<T>::translate::<
-		OldBidOrder<T::AccountId, T::BlockNumber, T::Hash, T::Moment>,
-		_,
-	>(|_expiration, _hash, bid| {
-		weight = weight.saturating_add(weight_each);
-		Some(crate::BidOrder {
-			block: bid.block,
-			blockchain: bid.blockchain,
-			expiration_block: bid.expiration_block,
-			borrower: bid.borrower,
-			borrower_address_id: bid.borrower_address_id,
-			terms: crate::BidTerms::try_from(crate::LoanTerms {
-				amount: bid.terms.0.amount,
-				interest_rate: crate::InterestRate {
-					rate_per_period: bid.terms.0.interest_rate,
-					decimals: OLD_INTEREST_RATE_DECIMALS,
-					period: Duration::from_millis(bid.terms.0.maturity.unique_saturated_into()),
-				},
-				term_length: Duration::from_millis(bid.terms.0.maturity.unique_saturated_into()),
+	BidOrders::<T>::translate::<OldBidOrder<T::AccountId, T::BlockNumber, T::Hash, T::Moment>, _>(
+		|_expiration, _hash, bid| {
+			weight = weight.saturating_add(weight_each);
+			Some(BidOrder {
+				block: bid.block,
+				blockchain: bid.blockchain,
+				expiration_block: bid.expiration_block,
+				borrower: bid.borrower,
+				borrower_address_id: bid.borrower_address_id,
+				terms: BidTerms(LoanTerms {
+					amount: bid.terms.0.amount,
+					interest_rate: InterestRate {
+						rate_per_period: bid.terms.0.interest_rate,
+						decimals: OLD_INTEREST_RATE_DECIMALS,
+						period: Duration::from_millis(bid.terms.0.maturity.unique_saturated_into()),
+					},
+					term_length: Duration::from_millis(
+						bid.terms.0.maturity.unique_saturated_into(),
+					),
+				}),
 			})
-			.expect("pre-existing bid orders cannot have invalid terms"),
-		})
-	});
+		},
+	);
 
 	DealOrders::<T>::translate::<OldDealOrder<T::AccountId, T::BlockNumber, T::Hash, T::Moment>, _>(
 		|_expiration, _hash, deal| {
@@ -141,9 +190,9 @@ pub(crate) fn migrate<T: Config>() -> Weight {
 				offer_id: deal.offer_id,
 				lender_address_id: deal.lender_address_id,
 				borrower_address_id: deal.borrower_address_id,
-				terms: crate::LoanTerms {
+				terms: LoanTerms {
 					amount: deal.terms.amount,
-					interest_rate: crate::InterestRate {
+					interest_rate: InterestRate {
 						rate_per_period: deal.terms.interest_rate,
 						decimals: OLD_INTEREST_RATE_DECIMALS,
 						period: Duration::from_millis(deal.terms.maturity.unique_saturated_into()),

--- a/pallets/creditcoin/src/migrations/v1.rs
+++ b/pallets/creditcoin/src/migrations/v1.rs
@@ -1,3 +1,6 @@
+// First `LoanTerms` rework. `maturity` is replaced with `term_length`,
+// and `InterestRate` changed from a type alias = u64 to a new struct `InterestRate`
+
 use crate::{
 	loan_terms::{Decimals, Duration},
 	AddressId, Blockchain, Config, ExternalAmount, OfferId, RatePerPeriod, TransferId,
@@ -62,6 +65,7 @@ struct OldDealOrder<AccountId, BlockNum, Hash, Moment> {
 }
 
 #[derive(Clone, Encode, Decode, TypeInfo, MaxEncodedLen)]
+#[cfg_attr(test, derive(Debug, PartialEq))]
 pub struct DealOrder<AccountId, BlockNum, Hash, Moment> {
 	pub blockchain: Blockchain,
 	pub offer_id: OfferId<BlockNum, Hash>,
@@ -77,6 +81,7 @@ pub struct DealOrder<AccountId, BlockNum, Hash, Moment> {
 }
 
 #[derive(Clone, Encode, Decode, TypeInfo, MaxEncodedLen)]
+#[cfg_attr(test, derive(Debug, PartialEq))]
 pub struct InterestRate {
 	pub rate_per_period: RatePerPeriod,
 	pub decimals: Decimals,
@@ -84,6 +89,7 @@ pub struct InterestRate {
 }
 
 #[derive(Clone, Encode, Decode, TypeInfo, MaxEncodedLen)]
+#[cfg_attr(test, derive(Debug, PartialEq))]
 pub struct LoanTerms {
 	pub amount: ExternalAmount,
 	pub interest_rate: InterestRate,
@@ -91,12 +97,15 @@ pub struct LoanTerms {
 }
 
 #[derive(Clone, Encode, Decode, TypeInfo, MaxEncodedLen)]
+#[cfg_attr(test, derive(Debug, PartialEq))]
 pub struct AskTerms(pub LoanTerms);
 
 #[derive(Clone, Encode, Decode, TypeInfo, MaxEncodedLen)]
+#[cfg_attr(test, derive(Debug, PartialEq))]
 pub struct BidTerms(pub LoanTerms);
 
 #[derive(Clone, Encode, Decode, TypeInfo, MaxEncodedLen)]
+#[cfg_attr(test, derive(Debug, PartialEq))]
 pub struct AskOrder<AccountId, BlockNum, Hash> {
 	pub blockchain: Blockchain,
 	pub lender_address_id: AddressId<Hash>,
@@ -107,6 +116,7 @@ pub struct AskOrder<AccountId, BlockNum, Hash> {
 }
 
 #[derive(Clone, Encode, Decode, TypeInfo, MaxEncodedLen)]
+#[cfg_attr(test, derive(Debug, PartialEq))]
 pub struct BidOrder<AccountId, BlockNum, Hash> {
 	pub blockchain: Blockchain,
 	pub borrower_address_id: AddressId<Hash>,
@@ -211,4 +221,192 @@ pub(crate) fn migrate<T: Config>() -> Weight {
 		},
 	);
 	weight
+}
+
+#[cfg(test)]
+mod tests {
+	use sp_core::U256;
+
+	use crate::{
+		mock::{ExtBuilder, Test},
+		tests::TestInfo,
+		AskOrderId, BidOrderId, DealOrderId, DoubleMapExt, OfferId,
+	};
+
+	use super::{
+		generate_storage_alias, AskOrder, AskTerms, BidOrder, BidTerms, Blockchain, Config,
+		Duration, Identity, InterestRate, LoanTerms, OldAskOrder, OldAskTerms, OldBidOrder,
+		OldBidTerms, OldDealOrder, OldLoanTerms, Twox64Concat, OLD_INTEREST_RATE_DECIMALS,
+	};
+
+	generate_storage_alias!(
+		Creditcoin,
+		DealOrders<T: Config> => DoubleMap<(Twox64Concat, T::BlockNumber), (Identity, T::Hash), OldDealOrder<T::AccountId, T::BlockNumber, T::Hash, T::Moment>>
+	);
+
+	type OldDealOrders = DealOrders<Test>;
+
+	generate_storage_alias!(
+		Creditcoin,
+		AskOrders<T: Config> => DoubleMap<(Twox64Concat, T::BlockNumber), (Identity, T::Hash), OldAskOrder<T::AccountId, T::BlockNumber, T::Hash, T::Moment>>
+	);
+
+	type OldAskOrders = AskOrders<Test>;
+
+	generate_storage_alias!(
+		Creditcoin,
+		BidOrders<T: Config> => DoubleMap<(Twox64Concat, T::BlockNumber), (Identity, T::Hash), OldBidOrder<T::AccountId, T::BlockNumber, T::Hash, T::Moment>>
+	);
+
+	type OldBidOrders = BidOrders<Test>;
+
+	#[test]
+	fn ask_order_migrates() {
+		ExtBuilder::default().build_and_execute(|| {
+			let ask_id = AskOrderId::new::<Test>(100, "asdf".as_bytes());
+			let test_info = TestInfo::new_defaults();
+			let old_ask = OldAskOrder {
+				blockchain: Blockchain::Ethereum,
+				lender_address_id: test_info.lender.address_id.clone(),
+				terms: OldAskTerms(OldLoanTerms {
+					amount: 1000u64.into(),
+					interest_rate: 1000,
+					maturity: 2000,
+				}),
+				expiration_block: 100,
+				block: 0,
+				lender: test_info.lender.account_id.clone(),
+			};
+			OldAskOrders::insert_id(ask_id.clone(), old_ask.clone());
+
+			super::migrate::<Test>();
+
+			let ask = super::AskOrders::<Test>::try_get_id(&ask_id).unwrap();
+
+			assert_eq!(
+				ask,
+				AskOrder {
+					blockchain: old_ask.blockchain,
+					lender_address_id: old_ask.lender_address_id,
+					terms: AskTerms(LoanTerms {
+						amount: old_ask.terms.0.amount,
+						interest_rate: InterestRate {
+							rate_per_period: old_ask.terms.0.interest_rate,
+							decimals: OLD_INTEREST_RATE_DECIMALS,
+							period: Duration::from_millis(old_ask.terms.0.maturity)
+						},
+						term_length: Duration::from_millis(old_ask.terms.0.maturity)
+					}),
+					expiration_block: old_ask.expiration_block,
+					block: old_ask.block,
+					lender: old_ask.lender,
+				}
+			)
+		});
+	}
+
+	#[test]
+	fn bid_order_migrates() {
+		ExtBuilder::default().build_and_execute(|| {
+			let bid_id = BidOrderId::new::<Test>(100, "asdf".as_bytes());
+			let test_info = TestInfo::new_defaults();
+			let address_id = test_info.borrower.address_id.clone();
+			let expiration_block = 100;
+			let block = 0;
+			let amount: U256 = 1000u64.into();
+
+			let old_bid = OldBidOrder {
+				blockchain: Blockchain::Ethereum,
+				borrower_address_id: address_id.clone(),
+				terms: OldBidTerms(OldLoanTerms {
+					amount: amount.clone(),
+					interest_rate: 1000,
+					maturity: 2000,
+				}),
+				expiration_block,
+				block,
+				borrower: test_info.borrower.account_id.clone(),
+			};
+			OldBidOrders::insert_id(bid_id.clone(), old_bid.clone());
+
+			super::migrate::<Test>();
+
+			let bid = super::BidOrders::<Test>::try_get_id(&bid_id).unwrap();
+
+			assert_eq!(
+				bid,
+				BidOrder {
+					blockchain: old_bid.blockchain,
+					borrower_address_id: old_bid.borrower_address_id,
+					terms: BidTerms(LoanTerms {
+						amount: amount.clone(),
+						interest_rate: InterestRate {
+							rate_per_period: old_bid.terms.0.interest_rate,
+							decimals: OLD_INTEREST_RATE_DECIMALS,
+							period: Duration::from_millis(old_bid.terms.0.maturity)
+						},
+						term_length: Duration::from_millis(old_bid.terms.0.maturity)
+					}),
+					expiration_block,
+					block,
+					borrower: test_info.borrower.account_id.clone(),
+				}
+			)
+		})
+	}
+
+	#[test]
+	fn deal_order_migrates() {
+		ExtBuilder::default().build_and_execute(|| {
+			let offer_id = OfferId::with_expiration_hash::<Test>(100, [1; 32].into());
+			let deal_id = DealOrderId::with_expiration_hash::<Test>(100, [0; 32].into());
+			let test_info = TestInfo::new_defaults();
+			let old_deal = OldDealOrder {
+				blockchain: Blockchain::Ethereum,
+				lender_address_id: test_info.lender.address_id.clone(),
+				terms: OldLoanTerms { amount: 1000u64.into(), interest_rate: 1000, maturity: 2000 },
+				expiration_block: 100,
+				offer_id: offer_id.clone(),
+				borrower_address_id: test_info.borrower.address_id.clone(),
+				timestamp: 0,
+				funding_transfer_id: None,
+				repayment_transfer_id: None,
+				lock: None,
+				borrower: test_info.borrower.account_id.clone(),
+			};
+
+			OldDealOrders::insert_id(deal_id.clone(), old_deal.clone());
+
+			super::migrate::<Test>();
+
+			let deal = super::DealOrders::<Test>::try_get_id(&deal_id).unwrap();
+
+			assert_eq!(
+				deal,
+				super::DealOrder {
+					blockchain: old_deal.blockchain,
+					lender_address_id: old_deal.lender_address_id,
+					terms: LoanTerms {
+						amount: old_deal.terms.amount,
+						interest_rate: InterestRate {
+							rate_per_period: old_deal.terms.interest_rate,
+							decimals: OLD_INTEREST_RATE_DECIMALS,
+							period: Duration::from_millis(old_deal.terms.maturity)
+						},
+						term_length: Duration::from_millis(
+							old_deal.terms.maturity.saturating_sub(old_deal.timestamp)
+						)
+					},
+					offer_id: old_deal.offer_id,
+					borrower_address_id: old_deal.borrower_address_id,
+					expiration_block: old_deal.expiration_block,
+					timestamp: old_deal.timestamp,
+					funding_transfer_id: old_deal.funding_transfer_id,
+					repayment_transfer_id: old_deal.repayment_transfer_id,
+					lock: old_deal.lock,
+					borrower: old_deal.borrower
+				}
+			);
+		});
+	}
 }

--- a/pallets/creditcoin/src/migrations/v1.rs
+++ b/pallets/creditcoin/src/migrations/v1.rs
@@ -5,31 +5,30 @@ use crate::{
 	loan_terms::{Decimals, Duration},
 	AddressId, Blockchain, Config, ExternalAmount, OfferId, RatePerPeriod, TransferId,
 };
-use codec::{Decode, Encode, MaxEncodedLen};
+use codec::{Decode, Encode};
 use frame_support::weights::Weight;
 use frame_support::{generate_storage_alias, traits::Get};
 use frame_support::{Identity, Twox64Concat};
-use scale_info::TypeInfo;
 use sp_runtime::traits::{Saturating, UniqueSaturatedInto};
 
 type OldInterestRate = u64;
 
 const OLD_INTEREST_RATE_DECIMALS: u64 = 4;
 
-#[derive(Clone, Encode, Decode, TypeInfo, MaxEncodedLen)]
+#[derive(Encode, Decode)]
 struct OldLoanTerms<Moment> {
 	amount: ExternalAmount,
 	interest_rate: OldInterestRate,
 	maturity: Moment,
 }
 
-#[derive(Clone, Encode, Decode, TypeInfo, MaxEncodedLen)]
+#[derive(Encode, Decode)]
 struct OldAskTerms<Moment>(OldLoanTerms<Moment>);
 
-#[derive(Clone, Encode, Decode, TypeInfo, MaxEncodedLen)]
+#[derive(Encode, Decode)]
 struct OldBidTerms<Moment>(OldLoanTerms<Moment>);
 
-#[derive(Clone, Encode, Decode, TypeInfo, MaxEncodedLen)]
+#[derive(Encode, Decode)]
 struct OldAskOrder<AccountId, BlockNum, Hash, Moment> {
 	blockchain: Blockchain,
 	lender_address_id: AddressId<Hash>,
@@ -39,7 +38,7 @@ struct OldAskOrder<AccountId, BlockNum, Hash, Moment> {
 	lender: AccountId,
 }
 
-#[derive(Clone, Encode, Decode, TypeInfo, MaxEncodedLen)]
+#[derive(Encode, Decode)]
 struct OldBidOrder<AccountId, BlockNum, Hash, Moment> {
 	blockchain: Blockchain,
 	borrower_address_id: AddressId<Hash>,
@@ -49,7 +48,7 @@ struct OldBidOrder<AccountId, BlockNum, Hash, Moment> {
 	borrower: AccountId,
 }
 
-#[derive(Clone, Encode, Decode, TypeInfo, MaxEncodedLen)]
+#[derive(Encode, Decode)]
 struct OldDealOrder<AccountId, BlockNum, Hash, Moment> {
 	blockchain: Blockchain,
 	offer_id: OfferId<BlockNum, Hash>,
@@ -64,7 +63,7 @@ struct OldDealOrder<AccountId, BlockNum, Hash, Moment> {
 	borrower: AccountId,
 }
 
-#[derive(Clone, Encode, Decode, TypeInfo, MaxEncodedLen)]
+#[derive(Encode, Decode)]
 #[cfg_attr(test, derive(Debug, PartialEq))]
 pub struct DealOrder<AccountId, BlockNum, Hash, Moment> {
 	pub blockchain: Blockchain,
@@ -80,7 +79,7 @@ pub struct DealOrder<AccountId, BlockNum, Hash, Moment> {
 	pub borrower: AccountId,
 }
 
-#[derive(Clone, Encode, Decode, TypeInfo, MaxEncodedLen)]
+#[derive(Encode, Decode)]
 #[cfg_attr(test, derive(Debug, PartialEq))]
 pub struct InterestRate {
 	pub rate_per_period: RatePerPeriod,
@@ -88,7 +87,7 @@ pub struct InterestRate {
 	pub period: Duration,
 }
 
-#[derive(Clone, Encode, Decode, TypeInfo, MaxEncodedLen)]
+#[derive(Encode, Decode)]
 #[cfg_attr(test, derive(Debug, PartialEq))]
 pub struct LoanTerms {
 	pub amount: ExternalAmount,
@@ -96,15 +95,15 @@ pub struct LoanTerms {
 	pub term_length: Duration,
 }
 
-#[derive(Clone, Encode, Decode, TypeInfo, MaxEncodedLen)]
+#[derive(Encode, Decode)]
 #[cfg_attr(test, derive(Debug, PartialEq))]
 pub struct AskTerms(pub LoanTerms);
 
-#[derive(Clone, Encode, Decode, TypeInfo, MaxEncodedLen)]
+#[derive(Encode, Decode)]
 #[cfg_attr(test, derive(Debug, PartialEq))]
 pub struct BidTerms(pub LoanTerms);
 
-#[derive(Clone, Encode, Decode, TypeInfo, MaxEncodedLen)]
+#[derive(Encode, Decode)]
 #[cfg_attr(test, derive(Debug, PartialEq))]
 pub struct AskOrder<AccountId, BlockNum, Hash> {
 	pub blockchain: Blockchain,
@@ -115,7 +114,7 @@ pub struct AskOrder<AccountId, BlockNum, Hash> {
 	pub lender: AccountId,
 }
 
-#[derive(Clone, Encode, Decode, TypeInfo, MaxEncodedLen)]
+#[derive(Encode, Decode)]
 #[cfg_attr(test, derive(Debug, PartialEq))]
 pub struct BidOrder<AccountId, BlockNum, Hash> {
 	pub blockchain: Blockchain,
@@ -277,7 +276,7 @@ mod tests {
 				block: 0,
 				lender: test_info.lender.account_id.clone(),
 			};
-			OldAskOrders::insert_id(ask_id.clone(), old_ask.clone());
+			OldAskOrders::insert_id(&ask_id, &old_ask);
 
 			super::migrate::<Test>();
 
@@ -327,7 +326,7 @@ mod tests {
 				block,
 				borrower: test_info.borrower.account_id.clone(),
 			};
-			OldBidOrders::insert_id(bid_id.clone(), old_bid.clone());
+			OldBidOrders::insert_id(&bid_id, &old_bid);
 
 			super::migrate::<Test>();
 
@@ -375,7 +374,7 @@ mod tests {
 				borrower: test_info.borrower.account_id.clone(),
 			};
 
-			OldDealOrders::insert_id(deal_id.clone(), old_deal.clone());
+			OldDealOrders::insert_id(&deal_id, &old_deal);
 
 			super::migrate::<Test>();
 

--- a/pallets/creditcoin/src/migrations/v2.rs
+++ b/pallets/creditcoin/src/migrations/v2.rs
@@ -1,3 +1,5 @@
+// `block` added to `DealOrder` and `timestamp` added to `Transfer`
+
 use crate::{
 	AddressId, Blockchain, Config, ExternalAmount, ExternalTxId, OfferId, OrderId, TransferId,
 	TransferKind,
@@ -6,6 +8,8 @@ use frame_support::{generate_storage_alias, pallet_prelude::*, Identity, Twox64C
 
 use super::v1::DealOrder as OldDealOrder;
 use super::v1::LoanTerms;
+
+use crate::Transfer;
 
 #[derive(Clone, Encode, Decode, TypeInfo, MaxEncodedLen)]
 struct OldTransfer<AccountId, BlockNum, Hash> {
@@ -22,6 +26,7 @@ struct OldTransfer<AccountId, BlockNum, Hash> {
 }
 
 #[derive(Clone, Encode, Decode, TypeInfo, MaxEncodedLen)]
+#[cfg_attr(test, derive(Debug, PartialEq))]
 pub struct DealOrder<AccountId, BlockNum, Hash, Moment> {
 	pub blockchain: Blockchain,
 	pub offer_id: OfferId<BlockNum, Hash>,
@@ -44,7 +49,7 @@ generate_storage_alias!(
 
 generate_storage_alias!(
 	Creditcoin,
-	Transfers<T: Config> => Map<(Identity, crate::TransferId<T::Hash>), crate::Transfer<T::AccountId, T::BlockNumber, T::Hash, T::Moment>>
+	Transfers<T: Config> => Map<(Identity, TransferId<T::Hash>), Transfer<T::AccountId, T::BlockNumber, T::Hash, T::Moment>>
 );
 
 pub(crate) fn migrate<T: Config>() -> Weight {
@@ -74,7 +79,7 @@ pub(crate) fn migrate<T: Config>() -> Weight {
 	Transfers::<T>::translate::<OldTransfer<T::AccountId, T::BlockNumber, T::Hash>, _>(
 		|_id, transfer| {
 			weight = weight.saturating_add(weight_each);
-			Some(crate::Transfer {
+			Some(Transfer {
 				blockchain: transfer.blockchain,
 				kind: transfer.kind,
 				from: transfer.from,
@@ -91,4 +96,132 @@ pub(crate) fn migrate<T: Config>() -> Weight {
 	);
 
 	weight
+}
+
+#[cfg(test)]
+mod test {
+	use core::convert::TryInto;
+
+	use super::{Config, DealOrder, Identity, OldDealOrder, OldTransfer, Transfer, Twox64Concat};
+	use crate::{
+		mock::{ExtBuilder, Test},
+		tests::TestInfo,
+		Blockchain, DealOrderId, DoubleMapExt, Duration, OfferId, OrderId, TransferId,
+		TransferKind,
+	};
+	use frame_support::generate_storage_alias;
+
+	generate_storage_alias!(
+		Creditcoin,
+		DealOrders<T: Config> => DoubleMap<(Twox64Concat, T::BlockNumber), (Identity, T::Hash), OldDealOrder<T::AccountId, T::BlockNumber, T::Hash, T::Moment>>
+	);
+
+	type OldDealOrders = DealOrders<Test>;
+
+	generate_storage_alias!(
+		Creditcoin,
+		Transfers<T: Config> => Map<(Identity, TransferId<T::Hash>), OldTransfer<T::AccountId, T::BlockNumber, T::Hash>>
+	);
+
+	type OldTransfers = Transfers<Test>;
+
+	#[test]
+	fn deal_order_migrates() {
+		ExtBuilder::default().build_and_execute(|| {
+			let test_info = TestInfo::new_defaults();
+
+			let deal_id = DealOrderId::with_expiration_hash::<Test>(100, [0u8; 32].into());
+			let offer_id = OfferId::with_expiration_hash::<Test>(100, [1u8; 32].into());
+
+			let old_deal = OldDealOrder {
+				blockchain: Blockchain::Ethereum,
+				offer_id,
+				lender_address_id: test_info.lender.address_id,
+				borrower_address_id: test_info.borrower.address_id,
+				terms: super::LoanTerms {
+					amount: 100u64.into(),
+					interest_rate: super::super::v1::InterestRate {
+						rate_per_period: 100,
+						decimals: 4,
+						period: Duration::from_millis(2000),
+					},
+					term_length: Duration::from_millis(10000),
+				},
+				expiration_block: 100,
+				timestamp: 0,
+				funding_transfer_id: None,
+				repayment_transfer_id: None,
+				lock: None,
+				borrower: test_info.borrower.account_id,
+			};
+
+			OldDealOrders::insert_id(deal_id.clone(), old_deal.clone());
+
+			super::migrate::<Test>();
+
+			let deal = super::DealOrders::<Test>::try_get_id(&deal_id).unwrap();
+
+			assert_eq!(
+				deal,
+				DealOrder {
+					blockchain: old_deal.blockchain,
+					offer_id: old_deal.offer_id,
+					lender_address_id: old_deal.lender_address_id,
+					borrower_address_id: old_deal.borrower_address_id,
+					terms: old_deal.terms,
+					expiration_block: old_deal.expiration_block,
+					timestamp: old_deal.timestamp,
+					funding_transfer_id: old_deal.funding_transfer_id,
+					repayment_transfer_id: old_deal.repayment_transfer_id,
+					lock: old_deal.lock,
+					borrower: old_deal.borrower,
+					block: None,
+				}
+			);
+		});
+	}
+
+	#[test]
+	fn transfer_migrates() {
+		ExtBuilder::default().build_and_execute(|| {
+			let test_info = TestInfo::new_defaults();
+			let blockchain = Blockchain::Ethereum;
+			let transfer_id = TransferId::new::<Test>(&blockchain, &[0]);
+			let old_transfer = OldTransfer {
+				blockchain: Blockchain::Ethereum,
+				kind: TransferKind::Native,
+				from: test_info.lender.address_id,
+				to: test_info.borrower.address_id,
+				order_id: OrderId::Deal(DealOrderId::dummy()),
+				amount: 100u64.into(),
+				tx: vec![0u8; 32].try_into().unwrap(),
+				block: 1,
+				processed: false,
+				sighash: test_info.borrower.account_id,
+			};
+
+			OldTransfers::insert(transfer_id.clone(), old_transfer.clone());
+
+			super::migrate::<Test>();
+
+			let transfer = super::Transfers::<Test>::try_get(&transfer_id).unwrap();
+
+			assert_eq!(
+				transfer,
+				Transfer {
+					blockchain: old_transfer.blockchain,
+					kind: old_transfer.kind,
+					from: old_transfer.from,
+					to: old_transfer.to,
+					order_id: old_transfer.order_id,
+					amount: old_transfer.amount,
+					tx_id: old_transfer.tx,
+					block: old_transfer.block,
+					is_processed: old_transfer.processed,
+					account_id: old_transfer.sighash,
+					timestamp: None,
+				}
+			);
+		});
+	}
 }

--- a/pallets/creditcoin/src/migrations/v2.rs
+++ b/pallets/creditcoin/src/migrations/v2.rs
@@ -11,7 +11,7 @@ use super::v1::LoanTerms;
 
 use crate::Transfer;
 
-#[derive(Clone, Encode, Decode, TypeInfo, MaxEncodedLen)]
+#[derive(Encode, Decode)]
 struct OldTransfer<AccountId, BlockNum, Hash> {
 	blockchain: Blockchain,
 	kind: TransferKind,
@@ -25,7 +25,7 @@ struct OldTransfer<AccountId, BlockNum, Hash> {
 	sighash: AccountId,
 }
 
-#[derive(Clone, Encode, Decode, TypeInfo, MaxEncodedLen)]
+#[derive(Encode, Decode)]
 #[cfg_attr(test, derive(Debug, PartialEq))]
 pub struct DealOrder<AccountId, BlockNum, Hash, Moment> {
 	pub blockchain: Blockchain,
@@ -155,7 +155,7 @@ mod test {
 				borrower: test_info.borrower.account_id,
 			};
 
-			OldDealOrders::insert_id(deal_id.clone(), old_deal.clone());
+			OldDealOrders::insert_id(&deal_id, &old_deal);
 
 			super::migrate::<Test>();
 
@@ -200,7 +200,7 @@ mod test {
 				sighash: test_info.borrower.account_id,
 			};
 
-			OldTransfers::insert(transfer_id.clone(), old_transfer.clone());
+			OldTransfers::insert(&transfer_id, &old_transfer);
 
 			super::migrate::<Test>();
 

--- a/pallets/creditcoin/src/migrations/v3.rs
+++ b/pallets/creditcoin/src/migrations/v3.rs
@@ -1,0 +1,125 @@
+use super::{v1, v2};
+use core::convert::TryFrom;
+use frame_support::dispatch::Weight;
+use frame_support::{generate_storage_alias, traits::Get, Identity, Twox64Concat};
+
+use crate::Config;
+
+use v1::AskOrder as OldAskOrder;
+use v1::AskTerms as OldAskTerms;
+use v1::BidOrder as OldBidOrder;
+use v1::BidTerms as OldBidTerms;
+use v1::InterestRate as OldInterestRate;
+use v1::LoanTerms as OldLoanTerms;
+use v2::DealOrder as OldDealOrder;
+
+use crate::AskOrder;
+use crate::AskTerms;
+use crate::BidOrder;
+use crate::BidTerms;
+use crate::DealOrder;
+use crate::InterestRate;
+use crate::LoanTerms;
+
+impl From<OldInterestRate> for InterestRate {
+	fn from(old: OldInterestRate) -> Self {
+		Self {
+			decimals: old.decimals,
+			rate_per_period: old.rate_per_period,
+			period: old.period,
+			interest_type: crate::InterestType::Simple,
+		}
+	}
+}
+
+impl From<OldLoanTerms> for LoanTerms {
+	fn from(old: OldLoanTerms) -> Self {
+		Self {
+			amount: old.amount,
+			interest_rate: InterestRate::from(old.interest_rate),
+			term_length: old.term_length,
+		}
+	}
+}
+
+impl From<OldAskTerms> for AskTerms {
+	fn from(old: OldAskTerms) -> Self {
+		Self::try_from(LoanTerms::from(old.0)).expect("existing ask terms must be valid")
+	}
+}
+
+impl From<OldBidTerms> for BidTerms {
+	fn from(old: OldBidTerms) -> Self {
+		Self::try_from(LoanTerms::from(old.0)).expect("existing bid terms must be valid")
+	}
+}
+
+generate_storage_alias!(
+	Creditcoin,
+	DealOrders<T: Config> => DoubleMap<(Twox64Concat, T::BlockNumber), (Identity, T::Hash), DealOrder<T::AccountId, T::BlockNumber, T::Hash, T::Moment>>
+);
+
+generate_storage_alias!(
+	Creditcoin,
+	AskOrders<T: Config> => DoubleMap<(Twox64Concat, T::BlockNumber), (Identity, T::Hash), AskOrder<T::AccountId, T::BlockNumber, T::Hash>>
+);
+
+generate_storage_alias!(
+	Creditcoin,
+	BidOrders<T: Config> => DoubleMap<(Twox64Concat, T::BlockNumber), (Identity, T::Hash), BidOrder<T::AccountId, T::BlockNumber, T::Hash>>
+);
+
+pub(crate) fn migrate<T: Config>() -> Weight {
+	let mut weight: Weight = 0;
+	let weight_each = T::DbWeight::get().reads_writes(1, 1);
+
+	DealOrders::<T>::translate::<OldDealOrder<T::AccountId, T::BlockNumber, T::Hash, T::Moment>, _>(
+		|_exp, _hash, old_deal| {
+			weight = weight.saturating_add(weight_each);
+			Some(DealOrder {
+				blockchain: old_deal.blockchain,
+				offer_id: old_deal.offer_id,
+				lender_address_id: old_deal.lender_address_id,
+				borrower_address_id: old_deal.borrower_address_id,
+				terms: LoanTerms::from(old_deal.terms),
+				expiration_block: old_deal.expiration_block,
+				timestamp: old_deal.timestamp,
+				block: old_deal.block,
+				funding_transfer_id: old_deal.funding_transfer_id,
+				repayment_transfer_id: old_deal.repayment_transfer_id,
+				lock: old_deal.lock,
+				borrower: old_deal.borrower,
+			})
+		},
+	);
+
+	AskOrders::<T>::translate::<OldAskOrder<T::AccountId, T::BlockNumber, T::Hash>, _>(
+		|_exp, _hash, old_ask| {
+			weight = weight.saturating_add(weight_each);
+			Some(AskOrder {
+				blockchain: old_ask.blockchain,
+				lender_address_id: old_ask.lender_address_id,
+				terms: AskTerms::from(old_ask.terms),
+				expiration_block: old_ask.expiration_block,
+				block: old_ask.block,
+				lender: old_ask.lender,
+			})
+		},
+	);
+
+    BidOrders::<T>::translate::<OldBidOrder<T::AccountId, T::BlockNumber, T::Hash>, _>(
+        |_exp, _hash, old_bid| {
+            weight = weight.saturating_add(weight_each);
+            Some(BidOrder {
+                blockchain: old_bid.blockchain,
+                borrower_address_id: old_bid.borrower_address_id,
+                terms: BidTerms::from(old_bid.terms),
+                expiration_block: old_bid.expiration_block,
+                block: old_bid.block,
+                borrower: old_bid.borrower,
+            })
+        }
+    );
+
+	weight
+}

--- a/pallets/creditcoin/src/migrations/v3.rs
+++ b/pallets/creditcoin/src/migrations/v3.rs
@@ -1,3 +1,5 @@
+// `interest_type` added to `LoanTerms`
+
 use super::{v1, v2};
 use core::convert::TryFrom;
 use frame_support::dispatch::Weight;
@@ -107,19 +109,229 @@ pub(crate) fn migrate<T: Config>() -> Weight {
 		},
 	);
 
-    BidOrders::<T>::translate::<OldBidOrder<T::AccountId, T::BlockNumber, T::Hash>, _>(
-        |_exp, _hash, old_bid| {
-            weight = weight.saturating_add(weight_each);
-            Some(BidOrder {
-                blockchain: old_bid.blockchain,
-                borrower_address_id: old_bid.borrower_address_id,
-                terms: BidTerms::from(old_bid.terms),
-                expiration_block: old_bid.expiration_block,
-                block: old_bid.block,
-                borrower: old_bid.borrower,
-            })
-        }
-    );
+	BidOrders::<T>::translate::<OldBidOrder<T::AccountId, T::BlockNumber, T::Hash>, _>(
+		|_exp, _hash, old_bid| {
+			weight = weight.saturating_add(weight_each);
+			Some(BidOrder {
+				blockchain: old_bid.blockchain,
+				borrower_address_id: old_bid.borrower_address_id,
+				terms: BidTerms::from(old_bid.terms),
+				expiration_block: old_bid.expiration_block,
+				block: old_bid.block,
+				borrower: old_bid.borrower,
+			})
+		},
+	);
 
 	weight
+}
+
+#[cfg(test)]
+mod tests {
+	use core::convert::TryFrom;
+
+	use crate::{
+		mock::{ExtBuilder, Test},
+		tests::TestInfo,
+		AskOrderId, BidOrderId, Blockchain, DealOrderId, DoubleMapExt, Duration, OfferId,
+	};
+
+	use super::{
+		generate_storage_alias, AskOrder, AskTerms, BidOrder, BidTerms, Config, DealOrder,
+		Identity, InterestRate, LoanTerms, OldAskOrder, OldAskTerms, OldBidOrder, OldBidTerms,
+		OldDealOrder, OldInterestRate, OldLoanTerms, Twox64Concat,
+	};
+
+	generate_storage_alias!(
+		Creditcoin,
+		DealOrders<T: Config> => DoubleMap<(Twox64Concat, T::BlockNumber), (Identity, T::Hash), OldDealOrder<T::AccountId, T::BlockNumber, T::Hash, T::Moment>>
+	);
+
+	type OldDealOrders = DealOrders<Test>;
+
+	generate_storage_alias!(
+		Creditcoin,
+		AskOrders<T: Config> => DoubleMap<(Twox64Concat, T::BlockNumber), (Identity, T::Hash), OldAskOrder<T::AccountId, T::BlockNumber, T::Hash>>
+	);
+
+	type OldAskOrders = AskOrders<Test>;
+
+	generate_storage_alias!(
+		Creditcoin,
+		BidOrders<T: Config> => DoubleMap<(Twox64Concat, T::BlockNumber), (Identity, T::Hash), OldBidOrder<T::AccountId, T::BlockNumber, T::Hash>>
+	);
+
+	type OldBidOrders = BidOrders<Test>;
+
+	#[test]
+	fn ask_order_migrates() {
+		ExtBuilder::default().build_and_execute(|| {
+			let ask_order_id = AskOrderId::new::<Test>(100, "asdf".as_bytes());
+			let test_info = TestInfo::new_defaults();
+
+			let old_ask_order = OldAskOrder {
+				blockchain: crate::Blockchain::Ethereum,
+				lender_address_id: test_info.lender.address_id,
+				terms: OldAskTerms(OldLoanTerms {
+					amount: 100u64.into(),
+					interest_rate: OldInterestRate {
+						rate_per_period: 100,
+						decimals: 4,
+						period: Duration::from_millis(1000),
+					},
+					term_length: Duration::from_millis(2000),
+				}),
+				expiration_block: 100,
+				block: 1,
+				lender: test_info.lender.account_id,
+			};
+
+			OldAskOrders::insert_id(&ask_order_id, &old_ask_order);
+
+			super::migrate::<Test>();
+
+			let ask_order = super::AskOrders::<Test>::try_get_id(&ask_order_id).unwrap();
+
+			assert_eq!(
+				ask_order,
+				AskOrder {
+					blockchain: old_ask_order.blockchain,
+					lender_address_id: old_ask_order.lender_address_id,
+					terms: AskTerms::try_from(LoanTerms {
+						amount: old_ask_order.terms.0.amount,
+						interest_rate: InterestRate {
+							rate_per_period: old_ask_order.terms.0.interest_rate.rate_per_period,
+							decimals: old_ask_order.terms.0.interest_rate.decimals,
+							period: old_ask_order.terms.0.interest_rate.period,
+							interest_type: crate::InterestType::Simple,
+						},
+						term_length: old_ask_order.terms.0.term_length,
+					})
+					.unwrap(),
+					expiration_block: old_ask_order.expiration_block,
+					block: old_ask_order.block,
+					lender: old_ask_order.lender,
+				}
+			);
+		});
+	}
+
+	#[test]
+	fn bid_order_migrates() {
+		ExtBuilder::default().build_and_execute(|| {
+			let bid_order_id = BidOrderId::new::<Test>(100, "asdf".as_bytes());
+			let test_info = TestInfo::new_defaults();
+
+			let old_bid_order = OldBidOrder {
+				blockchain: crate::Blockchain::Ethereum,
+				borrower_address_id: test_info.borrower.address_id,
+				terms: OldBidTerms(OldLoanTerms {
+					amount: 100u64.into(),
+					interest_rate: OldInterestRate {
+						rate_per_period: 100,
+						decimals: 4,
+						period: Duration::from_millis(1000),
+					},
+					term_length: Duration::from_millis(2000),
+				}),
+				expiration_block: 100,
+				block: 1,
+				borrower: test_info.borrower.account_id,
+			};
+
+			OldBidOrders::insert_id(&bid_order_id, &old_bid_order);
+
+			super::migrate::<Test>();
+
+			let bid_order = super::BidOrders::<Test>::try_get_id(&bid_order_id).unwrap();
+
+			assert_eq!(
+				bid_order,
+				BidOrder {
+					blockchain: old_bid_order.blockchain,
+					borrower_address_id: old_bid_order.borrower_address_id,
+					terms: BidTerms::try_from(LoanTerms {
+						amount: old_bid_order.terms.0.amount,
+						interest_rate: InterestRate {
+							rate_per_period: old_bid_order.terms.0.interest_rate.rate_per_period,
+							decimals: old_bid_order.terms.0.interest_rate.decimals,
+							period: old_bid_order.terms.0.interest_rate.period,
+							interest_type: crate::InterestType::Simple,
+						},
+						term_length: old_bid_order.terms.0.term_length,
+					})
+					.unwrap(),
+					expiration_block: old_bid_order.expiration_block,
+					block: old_bid_order.block,
+					borrower: old_bid_order.borrower,
+				}
+			);
+		});
+	}
+
+	#[test]
+	fn deal_order_migrates() {
+		ExtBuilder::default().build_and_execute(|| {
+			let test_info = TestInfo::new_defaults();
+
+			let deal_id = DealOrderId::with_expiration_hash::<Test>(100, [0u8; 32].into());
+			let offer_id = OfferId::with_expiration_hash::<Test>(100, [1u8; 32].into());
+
+			let old_deal = OldDealOrder {
+				blockchain: Blockchain::Ethereum,
+				offer_id,
+				lender_address_id: test_info.lender.address_id,
+				borrower_address_id: test_info.borrower.address_id,
+				terms: OldLoanTerms {
+					amount: 100u64.into(),
+					interest_rate: OldInterestRate {
+						rate_per_period: 100,
+						decimals: 4,
+						period: Duration::from_millis(2000),
+					},
+					term_length: Duration::from_millis(10000),
+				},
+				expiration_block: 100,
+				timestamp: 0,
+				funding_transfer_id: None,
+				repayment_transfer_id: None,
+				lock: None,
+				block: None,
+				borrower: test_info.borrower.account_id,
+			};
+
+			OldDealOrders::insert_id(deal_id.clone(), old_deal.clone());
+
+			super::migrate::<Test>();
+
+			let deal = super::DealOrders::<Test>::try_get_id(&deal_id).unwrap();
+
+			assert_eq!(
+				deal,
+				DealOrder {
+					blockchain: old_deal.blockchain,
+					offer_id: old_deal.offer_id,
+					lender_address_id: old_deal.lender_address_id,
+					borrower_address_id: old_deal.borrower_address_id,
+					terms: LoanTerms {
+						amount: old_deal.terms.amount,
+						interest_rate: InterestRate {
+							rate_per_period: old_deal.terms.interest_rate.rate_per_period,
+							decimals: old_deal.terms.interest_rate.decimals,
+							period: old_deal.terms.interest_rate.period,
+							interest_type: crate::InterestType::Simple
+						},
+						term_length: old_deal.terms.term_length,
+					},
+					expiration_block: old_deal.expiration_block,
+					timestamp: old_deal.timestamp,
+					funding_transfer_id: old_deal.funding_transfer_id,
+					repayment_transfer_id: old_deal.repayment_transfer_id,
+					lock: old_deal.lock,
+					borrower: old_deal.borrower,
+					block: old_deal.block,
+				}
+			);
+		});
+	}
 }

--- a/pallets/creditcoin/src/migrations/v3.rs
+++ b/pallets/creditcoin/src/migrations/v3.rs
@@ -300,7 +300,7 @@ mod tests {
 				borrower: test_info.borrower.account_id,
 			};
 
-			OldDealOrders::insert_id(deal_id.clone(), old_deal.clone());
+			OldDealOrders::insert_id(&deal_id, &old_deal);
 
 			super::migrate::<Test>();
 

--- a/pallets/creditcoin/src/tests.rs
+++ b/pallets/creditcoin/src/tests.rs
@@ -45,8 +45,8 @@ impl<'a> &'a str {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RegisteredAddress {
-	address_id: AddressId<H256>,
-	account_id: AccountId,
+	pub(crate) address_id: AddressId<H256>,
+	pub(crate) account_id: AccountId,
 }
 impl RegisteredAddress {
 	pub fn from_pubkey_distinct_owner(

--- a/pallets/creditcoin/src/types/loan_terms.rs
+++ b/pallets/creditcoin/src/types/loan_terms.rs
@@ -35,6 +35,14 @@ impl Duration {
 	}
 }
 
+#[derive(Clone, Copy, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
+pub enum InterestType {
+	Simple,
+	Compound,
+}
+
 #[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
@@ -42,6 +50,7 @@ pub struct InterestRate {
 	pub rate_per_period: RatePerPeriod,
 	pub decimals: Decimals,
 	pub period: Duration,
+	pub interest_type: InterestType,
 }
 
 #[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
@@ -145,6 +154,11 @@ impl Default for LoanTerms {
 #[cfg(test)]
 impl Default for InterestRate {
 	fn default() -> Self {
-		Self { rate_per_period: 0, decimals: 1, period: Duration::from_millis(100_000) }
+		Self {
+			rate_per_period: 0,
+			decimals: 1,
+			period: Duration::from_millis(100_000),
+			interest_type: InterestType::Simple,
+		}
 	}
 }


### PR DESCRIPTION
Description of proposed changes:
- Adds a field `interest_type` to the `InterestRate` struct. Not sure if `interest_type` is the best name, but `type` is a reserved keyword in rust. We could also do `kind` instead of `type`, I don't have a strong opinion either way.
- Storage migrations

Practical tips for PR review & merge:

- [x] All GitHub Actions report PASS
- [x] Newly added code/functions have unit tests
  - [x] Coverage tools report all newly added lines as covered
  - [x] The positive scenario is exercised
  - [x] Negative scenarios are exercised, e.g. assert on all possible errors
  - [x] Assert on events triggered if applicable
  - [x] Assert on changes made to storage if applicable
- [x] Modified behavior/functions - try to make sure above test items are covered
- [x] Integration tests are added if applicable/needed
