### PR TITLE
Remove registered addresses on runtime upgrade

### DIFF
--- a/pallets/creditcoin/src/lib.rs
+++ b/pallets/creditcoin/src/lib.rs
@@ -52,7 +52,7 @@ pub mod crypto {
 
 pub type BalanceFor<T> = <T as pallet_balances::Config>::Balance;
 
-pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(3);
+pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(4);
 
 #[frame_support::pallet]
 pub mod pallet {

--- a/pallets/creditcoin/src/migrations/mod.rs
+++ b/pallets/creditcoin/src/migrations/mod.rs
@@ -4,6 +4,7 @@ use frame_support::{traits::StorageVersion, weights::Weight};
 mod v1;
 mod v2;
 mod v3;
+mod v4;
 
 pub(crate) fn migrate<T: Config>() -> Weight {
 	let version = StorageVersion::get::<Pallet<T>>();
@@ -22,6 +23,11 @@ pub(crate) fn migrate<T: Config>() -> Weight {
 	if version < 3 {
 		weight = weight.saturating_add(v3::migrate::<T>());
 		StorageVersion::new(3).put::<Pallet<T>>();
+	}
+
+	if version < 4 {
+		weight = weight.saturating_add(v4::migrate::<T>());
+		StorageVersion::new(4).put::<Pallet<T>>();
 	}
 
 	weight

--- a/pallets/creditcoin/src/migrations/v4.rs
+++ b/pallets/creditcoin/src/migrations/v4.rs
@@ -1,0 +1,50 @@
+// address registration now verifies ownership, so removed existing addresses
+
+use frame_support::dispatch::Weight;
+use frame_support::traits::Get;
+use sp_runtime::SaturatedConversion;
+
+use crate::Config;
+
+pub(crate) fn migrate<T: Config>() -> Weight {
+	let count_removed = match crate::Addresses::<T>::remove_all(None) {
+		sp_io::KillStorageResult::AllRemoved(count) => count,
+		sp_io::KillStorageResult::SomeRemaining(count) => count,
+	};
+
+	T::DbWeight::get().writes(count_removed.saturated_into())
+}
+
+#[cfg(test)]
+mod tests {
+	use crate::{
+		mock::{AccountId, ExtBuilder, Test},
+		Address, AddressId,
+	};
+	use sp_core::H256;
+	use sp_std::convert::TryInto;
+
+	#[test]
+	fn migrate_works() {
+		ExtBuilder::default().build_and_execute(|| {
+			let mut ids = Vec::new();
+			for i in 0u8..10u8 {
+				let id =
+					AddressId::<H256>::new::<Test>(&crate::Blockchain::Ethereum, &i.to_be_bytes());
+				let address = Address {
+					blockchain: crate::Blockchain::Ethereum,
+					value: i.to_be_bytes().to_vec().try_into().unwrap(),
+					owner: AccountId::new([i; 32]),
+				};
+				crate::Addresses::<Test>::insert(&id, address);
+				ids.push(id);
+			}
+
+			super::migrate::<Test>();
+
+			for id in ids {
+				assert!(!crate::Addresses::<Test>::contains_key(id));
+			}
+		});
+	}
+}


### PR DESCRIPTION
Description of proposed changes:
"Unregisters" all pre-existing external addresses on the runtime upgrade, to ensure going forward all addresses have verified ownership.

Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
