### PR TITLE
Modify ci-linux container build script and Dockerfile to shorten buil…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
-FROM gluwa/ci-linux:production AS builder
+FROM ctc/ci-linux:latest AS builder
 ENV DEBIAN_FRONTEND=noninteractive
-RUN source ~/.cargo/env && rustup default stable && rustup update nightly && rustup update stable && rustup target add wasm32-unknown-unknown --toolchain nightly
 WORKDIR /creditcoin-node
 COPY Cargo.toml .
 COPY Cargo.lock .
@@ -9,7 +8,8 @@ ADD pallets /creditcoin-node/pallets
 ADD primitives /creditcoin-node/primitives
 ADD runtime /creditcoin-node/runtime
 ADD sha3pow /creditcoin-node/sha3pow
-RUN source ~/.cargo/env && cargo build --release
+ADD chainspecs /creditcoin-node/chainspecs
+RUN cargo build --release
 
 FROM ubuntu:latest
 EXPOSE 30333/tcp

--- a/ci-linux/ci-linux.Dockerfile
+++ b/ci-linux/ci-linux.Dockerfile
@@ -1,9 +1,7 @@
-#Build the image and tag it creditcoin/ci-linux:production
-FROM debian:bullseye-slim
+FROM rust:slim-bullseye AS builder
 ENV DEBIAN_FRONTEND=noninteractive
-SHELL ["/bin/bash", "-c"]
-RUN apt-get update && apt-get install -y \
-    cmake \
+RUN apt-get update
+RUN apt-get install -y cmake \
     pkg-config \
     libssl-dev \
     git \
@@ -12,4 +10,23 @@ RUN apt-get update && apt-get install -y \
     libclang-dev \
     curl \
     && rm -rf /var/lib/apt/lists/*
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+RUN rustup default stable
+RUN rustup update
+RUN rustup update nightly
+RUN rustup target add wasm32-unknown-unknown --toolchain nightly
+WORKDIR /creditcoin-node
+COPY Cargo.toml .
+COPY Cargo.lock .
+ADD node /creditcoin-node/node
+ADD pallets /creditcoin-node/pallets
+ADD primitives /creditcoin-node/primitives
+ADD runtime /creditcoin-node/runtime
+ADD sha3pow /creditcoin-node/sha3pow
+ADD chainspecs /creditcoin-node/chainspecs
+RUN cargo fetch
+RUN rm -rf /creditcoin-node/node
+RUN rm -rf /creditcoin-node/pallets
+RUN rm -rf /creditcoin-node/primitives
+RUN rm -rf /creditcoin-node/runtime
+RUN rm -rf /creditcoin-node/sha3pow
+RUN rm -rf /creditcoin-node/chainspecs


### PR DESCRIPTION
…d time

Description of proposed changes:

I've found that building Dockerfiles with container images made with ci-linux takes too long.
So, ci-linux includes the rust environment part and rust fetch part suggested by the substrate so that it can be built a little faster when building the Dockerfile.

Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
