### PR TITLE
Only upgrade runtime on dev/QA network if version has been bumped

### DIFF
--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -49,7 +49,7 @@ jobs:
       - run: |
           npm install -g yarn
           pushd ./creditcoin-js && yarn install && yarn pack && popd
-          yarn --cwd ./scripts/js install
+          yarn --cwd ./scripts/js upgrade 'creditcoin-js'
 
       - name: Install Subwasm
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
Description of proposed changes:
Right now we deploy the new runtime on every single push to dev, which is wasteful when the runtime hasn't changed. This PR makes it so we first check if the new runtime is a new version before deploying it to dev/QA.

Additionally fixes the workflow, which was missed in the change from `yarn install` -> `yarn upgrade 'creditcoin-js'`

Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
