### PR TITLE
Migrate to using new datatypes (Blockchain, Currency, TransferKind, etc.)

### DIFF
--- a/pallets/creditcoin/src/benchmarking.rs
+++ b/pallets/creditcoin/src/benchmarking.rs
@@ -238,7 +238,7 @@ benchmarks! {
 		let lender: T::AccountId = lender_account::<T>(true);
 		let deal_id = generate_deal::<T>(true,0u8).unwrap();
 		let (_,transfer) = generate_transfer::<T>(deal_id.clone(),false,false,true,0u8);
-	}: register_funding_transfer(RawOrigin::Signed(lender),transfer.kind,deal_id,transfer.tx_id)
+	}: register_funding_transfer_new(RawOrigin::Signed(lender),transfer.kind,deal_id,transfer.tx_id)
 
 	close_deal_order {
 		<Timestamp<T>>::set_timestamp(1u32.into());
@@ -734,7 +734,7 @@ fn insert_fake_unverified_transfer<T: Config>(
 			from: fake_address_id::<T>(seed - 1),
 			to: fake_address_id::<T>(seed),
 			is_processed: false,
-			kind: LegacyTransferKind::Native,
+			kind: crate::TransferKind::Evm(crate::EvmTransferKind::Ethless),
 			deal_order_id: fake_deal_id::<T>(
 				deadline,
 				&fake_offer_id::<T>(

--- a/pallets/creditcoin/src/benchmarking.rs
+++ b/pallets/creditcoin/src/benchmarking.rs
@@ -238,7 +238,7 @@ benchmarks! {
 		let lender: T::AccountId = lender_account::<T>(true);
 		let deal_id = generate_deal::<T>(true,0u8).unwrap();
 		let (_,transfer) = generate_transfer::<T>(deal_id.clone(),false,false,true,0u8);
-	}: register_funding_transfer_new(RawOrigin::Signed(lender),transfer.kind,deal_id,transfer.tx_id)
+	}: register_funding_transfer(RawOrigin::Signed(lender),transfer.kind,deal_id,transfer.tx_id)
 
 	close_deal_order {
 		<Timestamp<T>>::set_timestamp(1u32.into());
@@ -378,7 +378,7 @@ fn generate_transfer<T: Config>(
 	let contract = "0x0ad1439a0e0bfdcd49939f9722866651a4aa9b3c".as_bytes().into_bounded();
 
 	if swap_sender {
-		Creditcoin::<T>::register_repayment_transfer(
+		Creditcoin::<T>::register_repayment_transfer_legacy(
 			RawOrigin::Signed(who).into(),
 			LegacyTransferKind::Ethless(contract),
 			gain.into(),
@@ -387,7 +387,7 @@ fn generate_transfer<T: Config>(
 		)
 		.unwrap();
 	} else {
-		Creditcoin::<T>::register_funding_transfer(
+		Creditcoin::<T>::register_funding_transfer_legacy(
 			RawOrigin::Signed(who).into(),
 			LegacyTransferKind::Ethless(contract),
 			deal_id,

--- a/pallets/creditcoin/src/benchmarking.rs
+++ b/pallets/creditcoin/src/benchmarking.rs
@@ -5,7 +5,6 @@ use crate::benchmarking::alloc::format;
 use crate::helpers::{EVMAddress, PublicToAddress};
 use crate::ocw::errors::VerificationFailureCause as Cause;
 use crate::ocw::tasks::collect_coins::CONTRACT_CHAIN;
-use crate::types::OldBlockchain;
 use crate::Duration;
 #[allow(unused)]
 use crate::Pallet as Creditcoin;
@@ -123,7 +122,7 @@ benchmarks! {
 		let message = sp_io::hashing::sha2_256(who.encode().as_slice());
 		let signature = ecdsa_sign(ktypeid, &pkey, &message).expect("ecdsa signature");
 
-	}: _(RawOrigin::Signed(who), OldBlockchain::Ethereum, address,signature)
+	}: _(RawOrigin::Signed(who), Blockchain::ETHEREUM, address,signature)
 
 	claim_legacy_wallet {
 		let pubkey = {
@@ -373,7 +372,7 @@ fn generate_transfer<T: Config>(
 		)
 	};
 	let tx = raw_tx.as_bytes().into_bounded();
-	let transfer_id = TransferId::new::<T>(&OldBlockchain::Ethereum, &tx);
+	let transfer_id = TransferId::new::<T>(&Blockchain::ETHEREUM, &tx);
 
 	let contract = "0x0ad1439a0e0bfdcd49939f9722866651a4aa9b3c".as_bytes().into_bounded();
 
@@ -525,13 +524,13 @@ fn register_eth_addr<T: Config>(who: &T::AccountId, seed: &str) -> AddressId<<T>
 	let ktypeid = KeyTypeId(*b"dumy");
 	let pkey = ecdsa_generate(ktypeid, Some(format!("//{}", seed).as_bytes().to_vec()));
 	let address = EVMAddress::from_public(&pkey);
-	let address_id = crate::AddressId::new::<T>(&OldBlockchain::Ethereum, &address);
+	let address_id = crate::AddressId::new::<T>(&Blockchain::ETHEREUM, &address);
 
 	let message = sp_io::hashing::sha2_256(who.encode().as_slice());
 	let signature = ecdsa_sign(ktypeid, &pkey, &message).expect("ecdsa signature");
 
 	let origin = RawOrigin::Signed(who.clone());
-	Creditcoin::<T>::register_address(origin.into(), OldBlockchain::Ethereum, address, signature)
+	Creditcoin::<T>::register_address(origin.into(), Blockchain::ETHEREUM, address, signature)
 		.unwrap();
 
 	address_id
@@ -596,7 +595,7 @@ fn generate_bid<T: Config>(
 
 fn fake_address_id<T: Config>(seed: u32) -> AddressId<T::Hash> {
 	let address = format!("somefakeaddress{}", seed);
-	crate::AddressId::new::<T>(&OldBlockchain::Ethereum, address.as_bytes())
+	crate::AddressId::new::<T>(&Blockchain::ETHEREUM, address.as_bytes())
 }
 
 fn fake_ask_id<T: Config>(
@@ -680,7 +679,7 @@ fn fake_deal_id<T: Config>(
 
 fn fake_transfer_id<T: Config>(seed: u32) -> TransferId<T::Hash> {
 	let tx_id = format!("somefaketransfertxid{}", seed);
-	crate::TransferId::new::<T>(&OldBlockchain::Ethereum, tx_id.as_bytes())
+	crate::TransferId::new::<T>(&Blockchain::ETHEREUM, tx_id.as_bytes())
 }
 
 fn insert_fake_deal<T: Config>(
@@ -730,7 +729,7 @@ fn insert_fake_unverified_transfer<T: Config>(
 			account_id: who.clone(),
 			amount: ExternalAmount::from(1),
 			block: System::<T>::block_number(),
-			blockchain: OldBlockchain::Ethereum,
+			blockchain: Blockchain::ETHEREUM,
 			from: fake_address_id::<T>(seed - 1),
 			to: fake_address_id::<T>(seed),
 			is_processed: false,

--- a/pallets/creditcoin/src/benchmarking.rs
+++ b/pallets/creditcoin/src/benchmarking.rs
@@ -319,7 +319,7 @@ benchmarks! {
 }
 
 //impl_benchmark_test_suite!(Creditcoin, crate::mock::new_test_ext(), crate::mock::Test);
-fn get_all_fit_terms<T: Config>() -> LoanTerms {
+fn get_all_fit_terms<T: Config>() -> LoanTerms<T::Hash> {
 	LoanTerms {
 		amount: 10u64.into(),
 		interest_rate: InterestRate {
@@ -329,6 +329,7 @@ fn get_all_fit_terms<T: Config>() -> LoanTerms {
 			interest_type: InterestType::Simple,
 		},
 		term_length: Duration::new(1u64, 0u32),
+		currency: CurrencyId::placeholder(),
 	}
 }
 
@@ -487,7 +488,7 @@ fn generate_deal<T: Config>(
 
 fn generate_offer<T: Config>(
 	who: &T::AccountId,
-	loan_terms: &LoanTerms,
+	loan_terms: &LoanTerms<T::Hash>,
 	expiration_block: &T::BlockNumber,
 	call: bool,
 	seed: u8,
@@ -538,7 +539,7 @@ fn register_eth_addr<T: Config>(who: &T::AccountId, seed: &str) -> AddressId<<T>
 
 fn generate_ask<T: Config>(
 	who: &T::AccountId,
-	loan_terms: &LoanTerms,
+	loan_terms: &LoanTerms<T::Hash>,
 	expiration_block: &T::BlockNumber,
 	call: bool,
 	seed: u8,
@@ -566,7 +567,7 @@ fn generate_ask<T: Config>(
 
 fn generate_bid<T: Config>(
 	who: &T::AccountId,
-	loan_terms: &LoanTerms,
+	loan_terms: &LoanTerms<T::Hash>,
 	expiration_block: &T::BlockNumber,
 	call: bool,
 	seed: u8,

--- a/pallets/creditcoin/src/benchmarking.rs
+++ b/pallets/creditcoin/src/benchmarking.rs
@@ -5,7 +5,7 @@ use crate::benchmarking::alloc::format;
 use crate::helpers::{EVMAddress, PublicToAddress};
 use crate::ocw::errors::VerificationFailureCause as Cause;
 use crate::ocw::tasks::collect_coins::CONTRACT_CHAIN;
-use crate::types::Blockchain;
+use crate::types::OldBlockchain;
 use crate::Duration;
 #[allow(unused)]
 use crate::Pallet as Creditcoin;
@@ -123,7 +123,7 @@ benchmarks! {
 		let message = sp_io::hashing::sha2_256(who.encode().as_slice());
 		let signature = ecdsa_sign(ktypeid, &pkey, &message).expect("ecdsa signature");
 
-	}: _(RawOrigin::Signed(who), Blockchain::Ethereum, address,signature)
+	}: _(RawOrigin::Signed(who), OldBlockchain::Ethereum, address,signature)
 
 	claim_legacy_wallet {
 		let pubkey = {
@@ -373,7 +373,7 @@ fn generate_transfer<T: Config>(
 		)
 	};
 	let tx = raw_tx.as_bytes().into_bounded();
-	let transfer_id = TransferId::new::<T>(&Blockchain::Ethereum, &tx);
+	let transfer_id = TransferId::new::<T>(&OldBlockchain::Ethereum, &tx);
 
 	let contract = "0x0ad1439a0e0bfdcd49939f9722866651a4aa9b3c".as_bytes().into_bounded();
 
@@ -525,13 +525,13 @@ fn register_eth_addr<T: Config>(who: &T::AccountId, seed: &str) -> AddressId<<T>
 	let ktypeid = KeyTypeId(*b"dumy");
 	let pkey = ecdsa_generate(ktypeid, Some(format!("//{}", seed).as_bytes().to_vec()));
 	let address = EVMAddress::from_public(&pkey);
-	let address_id = crate::AddressId::new::<T>(&Blockchain::Ethereum, &address);
+	let address_id = crate::AddressId::new::<T>(&OldBlockchain::Ethereum, &address);
 
 	let message = sp_io::hashing::sha2_256(who.encode().as_slice());
 	let signature = ecdsa_sign(ktypeid, &pkey, &message).expect("ecdsa signature");
 
 	let origin = RawOrigin::Signed(who.clone());
-	Creditcoin::<T>::register_address(origin.into(), Blockchain::Ethereum, address, signature)
+	Creditcoin::<T>::register_address(origin.into(), OldBlockchain::Ethereum, address, signature)
 		.unwrap();
 
 	address_id
@@ -596,7 +596,7 @@ fn generate_bid<T: Config>(
 
 fn fake_address_id<T: Config>(seed: u32) -> AddressId<T::Hash> {
 	let address = format!("somefakeaddress{}", seed);
-	crate::AddressId::new::<T>(&Blockchain::Ethereum, address.as_bytes())
+	crate::AddressId::new::<T>(&OldBlockchain::Ethereum, address.as_bytes())
 }
 
 fn fake_ask_id<T: Config>(
@@ -612,7 +612,6 @@ fn insert_fake_ask<T: Config>(who: &T::AccountId, expiration_block: BlockNumberF
 	let ask_id = fake_ask_id::<T>(seed, expiration_block);
 	let ask = crate::AskOrder {
 		block: System::<T>::block_number(),
-		blockchain: Blockchain::Ethereum,
 		expiration_block,
 		lender: who.clone(),
 		lender_address_id: address_id,
@@ -635,7 +634,6 @@ fn insert_fake_bid<T: Config>(who: &T::AccountId, expiration_block: BlockNumberF
 	let bid_id = fake_bid_id::<T>(seed, expiration_block);
 	let bid = crate::BidOrder {
 		block: System::<T>::block_number(),
-		blockchain: Blockchain::Ethereum,
 		expiration_block,
 		borrower: who.clone(),
 		borrower_address_id: address_id,
@@ -666,7 +664,6 @@ fn insert_fake_offer<T: Config>(
 		ask_id,
 		bid_id,
 		block: System::<T>::block_number(),
-		blockchain: Blockchain::Ethereum,
 		expiration_block,
 		lender: who.clone(),
 	};
@@ -683,7 +680,7 @@ fn fake_deal_id<T: Config>(
 
 fn fake_transfer_id<T: Config>(seed: u32) -> TransferId<T::Hash> {
 	let tx_id = format!("somefaketransfertxid{}", seed);
-	crate::TransferId::new::<T>(&Blockchain::Ethereum, tx_id.as_bytes())
+	crate::TransferId::new::<T>(&OldBlockchain::Ethereum, tx_id.as_bytes())
 }
 
 fn insert_fake_deal<T: Config>(
@@ -699,7 +696,6 @@ fn insert_fake_deal<T: Config>(
 	let deal_id = fake_deal_id::<T>(expiration_block, &offer_id);
 	let deal = crate::DealOrder::<_, _, _, T::Moment> {
 		block: None,
-		blockchain: Blockchain::Ethereum,
 		borrower: who.clone(),
 		borrower_address_id: address_id.clone(),
 		lender_address_id: address_id,
@@ -734,7 +730,7 @@ fn insert_fake_unverified_transfer<T: Config>(
 			account_id: who.clone(),
 			amount: ExternalAmount::from(1),
 			block: System::<T>::block_number(),
-			blockchain: Blockchain::Ethereum,
+			blockchain: OldBlockchain::Ethereum,
 			from: fake_address_id::<T>(seed - 1),
 			to: fake_address_id::<T>(seed),
 			is_processed: false,

--- a/pallets/creditcoin/src/benchmarking.rs
+++ b/pallets/creditcoin/src/benchmarking.rs
@@ -380,7 +380,7 @@ fn generate_transfer<T: Config>(
 	if swap_sender {
 		Creditcoin::<T>::register_repayment_transfer(
 			RawOrigin::Signed(who).into(),
-			TransferKind::Ethless(contract),
+			LegacyTransferKind::Ethless(contract),
 			gain.into(),
 			deal_id,
 			tx,
@@ -389,7 +389,7 @@ fn generate_transfer<T: Config>(
 	} else {
 		Creditcoin::<T>::register_funding_transfer(
 			RawOrigin::Signed(who).into(),
-			TransferKind::Ethless(contract),
+			LegacyTransferKind::Ethless(contract),
 			deal_id,
 			tx,
 		)
@@ -738,15 +738,15 @@ fn insert_fake_unverified_transfer<T: Config>(
 			from: fake_address_id::<T>(seed - 1),
 			to: fake_address_id::<T>(seed),
 			is_processed: false,
-			kind: TransferKind::Native,
-			deal_order_id: OrderId::Deal(fake_deal_id::<T>(
+			kind: LegacyTransferKind::Native,
+			deal_order_id: fake_deal_id::<T>(
 				deadline,
 				&fake_offer_id::<T>(
 					deadline,
 					&fake_ask_id::<T>(seed, deadline),
 					&fake_bid_id::<T>(seed, deadline),
 				),
-			)),
+			),
 			tx_id: format!("{:03x}", seed).as_bytes().into_bounded(),
 			timestamp: None,
 		},

--- a/pallets/creditcoin/src/benchmarking.rs
+++ b/pallets/creditcoin/src/benchmarking.rs
@@ -739,7 +739,7 @@ fn insert_fake_unverified_transfer<T: Config>(
 			to: fake_address_id::<T>(seed),
 			is_processed: false,
 			kind: TransferKind::Native,
-			order_id: OrderId::Deal(fake_deal_id::<T>(
+			deal_order_id: OrderId::Deal(fake_deal_id::<T>(
 				deadline,
 				&fake_offer_id::<T>(
 					deadline,

--- a/pallets/creditcoin/src/benchmarking.rs
+++ b/pallets/creditcoin/src/benchmarking.rs
@@ -746,6 +746,9 @@ fn insert_fake_unverified_transfer<T: Config>(
 			tx_id: format!("{:03x}", seed).as_bytes().into_bounded(),
 			timestamp: None,
 		},
+		currency_to_check: crate::CurrencyOrLegacyTransferKind::TransferKind(
+			LegacyTransferKind::Native,
+		),
 	};
 
 	let task_id = TaskId::VerifyTransfer(transfer_id);

--- a/pallets/creditcoin/src/helpers.rs
+++ b/pallets/creditcoin/src/helpers.rs
@@ -118,7 +118,7 @@ impl<T: Config> Pallet<T> {
 		Ok(())
 	}
 
-	pub fn register_transfer_internal(
+	pub fn register_transfer_internal_legacy(
 		who: T::AccountId,
 		from_id: AddressId<T::Hash>,
 		to_id: AddressId<T::Hash>,

--- a/pallets/creditcoin/src/helpers.rs
+++ b/pallets/creditcoin/src/helpers.rs
@@ -7,8 +7,8 @@ pub use external_address::{EVMAddress, PublicToAddress};
 use crate::{
 	pallet::*,
 	types::{Address, AddressId},
-	DealOrderId, Error, ExternalAmount, ExternalTxId, Guid, Id, OrderId, Task, TaskId, Transfer,
-	TransferId, TransferKind, UnverifiedTransfer,
+	DealOrderId, Error, ExternalAmount, ExternalTxId, Guid, Id, Task, TaskId, Transfer, TransferId,
+	TransferKind, UnverifiedTransfer,
 };
 
 use frame_support::{ensure, traits::Get};
@@ -124,7 +124,7 @@ impl<T: Config> Pallet<T> {
 		to_id: AddressId<T::Hash>,
 		transfer_kind: TransferKind,
 		amount: ExternalAmount,
-		order_id: OrderId<T::BlockNumber, T::Hash>,
+		deal_order_id: DealOrderId<T::BlockNumber, T::Hash>,
 		blockchain_tx_id: ExternalTxId,
 	) -> Result<
 		(TransferId<T::Hash>, Transfer<T::AccountId, BlockNumberFor<T>, T::Hash, T::Moment>),
@@ -151,7 +151,7 @@ impl<T: Config> Pallet<T> {
 			block,
 			from: from_id,
 			to: to_id,
-			order_id,
+			deal_order_id,
 			is_processed: false,
 			account_id: who,
 			tx_id: blockchain_tx_id,

--- a/pallets/creditcoin/src/helpers.rs
+++ b/pallets/creditcoin/src/helpers.rs
@@ -8,7 +8,7 @@ use crate::{
 	pallet::*,
 	types::{Address, AddressId},
 	DealOrderId, Error, ExternalAmount, ExternalTxId, Guid, Id, LegacyTransferKind, Task, TaskId,
-	Transfer, TransferId, UnverifiedTransfer,
+	Transfer, TransferId, TransferKind, UnverifiedTransfer, CurrencyId,
 };
 
 use frame_support::{ensure, traits::Get};
@@ -118,6 +118,65 @@ impl<T: Config> Pallet<T> {
 		Ok(())
 	}
 
+	pub fn register_transfer_internal(
+		who: T::AccountId,
+		from_id: AddressId<T::Hash>,
+		to_id: AddressId<T::Hash>,
+		transfer_kind: TransferKind,
+		amount: ExternalAmount,
+		deal_order_id: DealOrderId<T::BlockNumber, T::Hash>,
+		blockchain_tx_id: ExternalTxId,
+		currency: &CurrencyId<T::Hash>,
+	) -> Result<
+		(TransferId<T::Hash>, Transfer<T::AccountId, BlockNumberFor<T>, T::Hash, T::Moment>),
+		crate::Error<T>,
+	> {
+		let from = Self::get_address(&from_id)?;
+		let to = Self::get_address(&to_id)?;
+
+		ensure!(from.owner == who, Error::<T>::NotAddressOwner);
+
+		ensure!(from.blockchain == to.blockchain, Error::<T>::AddressPlatformMismatch);
+
+		// ensure!(from.blockchain.supports(&transfer_kind), Error::<T>::UnsupportedTransferKind);
+
+		let transfer_id = TransferId::new::<T>(&from.blockchain, &blockchain_tx_id);
+		ensure!(!Transfers::<T>::contains_key(&transfer_id), Error::<T>::TransferAlreadyRegistered);
+
+		let currency = Currencies::<T>::get(&currency).ok_or(Error::<T>::CurrencyNotRegistered)?;
+
+		let block = Self::block_number();
+
+		let transfer = Transfer {
+			blockchain: from.blockchain,
+			kind: LegacyTransferKind::Native,
+			amount,
+			block,
+			from: from_id,
+			to: to_id,
+			deal_order_id,
+			is_processed: false,
+			account_id: who,
+			tx_id: blockchain_tx_id,
+			timestamp: None,
+		};
+
+		let deadline = block.saturating_add(T::UnverifiedTaskTimeout::get());
+
+		let pending = UnverifiedTransfer {
+			from_external: from.value,
+			to_external: to.value,
+			transfer: transfer.clone(),
+			deadline,
+			currency_to_check: crate::CurrencyOrLegacyTransferKind::Currency(currency),
+		};
+		let task_id = TaskId::from(transfer_id.clone());
+		let pending = Task::from(pending);
+		PendingTasks::<T>::insert(&deadline, &task_id, &pending);
+
+		Ok((transfer_id, transfer))
+	}
+
 	pub fn register_transfer_internal_legacy(
 		who: T::AccountId,
 		from_id: AddressId<T::Hash>,
@@ -146,7 +205,7 @@ impl<T: Config> Pallet<T> {
 
 		let transfer = Transfer {
 			blockchain: from.blockchain,
-			kind: transfer_kind,
+			kind: transfer_kind.clone(),
 			amount,
 			block,
 			from: from_id,
@@ -165,6 +224,7 @@ impl<T: Config> Pallet<T> {
 			to_external: to.value,
 			transfer: transfer.clone(),
 			deadline,
+			currency_to_check: crate::CurrencyOrLegacyTransferKind::TransferKind(transfer_kind),
 		};
 		let task_id = TaskId::from(transfer_id.clone());
 		let pending = Task::from(pending);

--- a/pallets/creditcoin/src/helpers.rs
+++ b/pallets/creditcoin/src/helpers.rs
@@ -7,8 +7,8 @@ pub use external_address::{EVMAddress, PublicToAddress};
 use crate::{
 	pallet::*,
 	types::{Address, AddressId},
-	DealOrderId, Error, ExternalAmount, ExternalTxId, Guid, Id, Task, TaskId, Transfer, TransferId,
-	TransferKind, UnverifiedTransfer,
+	DealOrderId, Error, ExternalAmount, ExternalTxId, Guid, Id, LegacyTransferKind, Task, TaskId,
+	Transfer, TransferId, UnverifiedTransfer,
 };
 
 use frame_support::{ensure, traits::Get};
@@ -122,7 +122,7 @@ impl<T: Config> Pallet<T> {
 		who: T::AccountId,
 		from_id: AddressId<T::Hash>,
 		to_id: AddressId<T::Hash>,
-		transfer_kind: TransferKind,
+		transfer_kind: LegacyTransferKind,
 		amount: ExternalAmount,
 		deal_order_id: DealOrderId<T::BlockNumber, T::Hash>,
 		blockchain_tx_id: ExternalTxId,

--- a/pallets/creditcoin/src/helpers.rs
+++ b/pallets/creditcoin/src/helpers.rs
@@ -7,8 +7,9 @@ pub use external_address::{EVMAddress, PublicToAddress};
 use crate::{
 	pallet::*,
 	types::{Address, AddressId},
-	DealOrderId, Error, ExternalAmount, ExternalTxId, Guid, Id, LegacyTransferKind, Task, TaskId,
-	Transfer, TransferId, TransferKind, UnverifiedTransfer, CurrencyId,
+	Blockchain, Currency, CurrencyId, DealOrderId, Error, EvmCurrencyType,
+	EvmSupportedTransferKinds, EvmTransferKind, ExternalAmount, ExternalTxId, Guid, Id,
+	LegacyTransferKind, Task, TaskId, Transfer, TransferId, TransferKind, UnverifiedTransfer,
 };
 
 use frame_support::{ensure, traits::Get};
@@ -138,18 +139,18 @@ impl<T: Config> Pallet<T> {
 
 		ensure!(from.blockchain == to.blockchain, Error::<T>::AddressPlatformMismatch);
 
-		// ensure!(from.blockchain.supports(&transfer_kind), Error::<T>::UnsupportedTransferKind);
-
 		let transfer_id = TransferId::new::<T>(&from.blockchain, &blockchain_tx_id);
 		ensure!(!Transfers::<T>::contains_key(&transfer_id), Error::<T>::TransferAlreadyRegistered);
 
 		let currency = Currencies::<T>::get(&currency).ok_or(Error::<T>::CurrencyNotRegistered)?;
 
+		ensure!(currency.supports(&transfer_kind), Error::<T>::UnsupportedTransferKind);
+
 		let block = Self::block_number();
 
 		let transfer = Transfer {
 			blockchain: from.blockchain,
-			kind: LegacyTransferKind::Native,
+			kind: transfer_kind,
 			amount,
 			block,
 			from: from_id,
@@ -203,9 +204,44 @@ impl<T: Config> Pallet<T> {
 
 		let block = Self::block_number();
 
+		DealOrders::<T>::mutate(
+			deal_order_id.expiration(),
+			&deal_order_id.hash(),
+			|deal_order| -> Result<(), crate::Error<T>> {
+				let mut deal_order = deal_order.as_mut().ok_or(Error::<T>::NonExistentDealOrder)?;
+				let currency = match &from.blockchain {
+					Blockchain::Evm(info) => match transfer_kind.clone() {
+						LegacyTransferKind::Ethless(contract) => Currency::Evm(
+							EvmCurrencyType::SmartContract(
+								contract,
+								EvmSupportedTransferKinds::try_from(vec![EvmTransferKind::Ethless])
+									.expect("length 1 is less than the bound 2; qed"),
+							),
+							info.clone(),
+						),
+						LegacyTransferKind::Erc20(contract) => Currency::Evm(
+							EvmCurrencyType::SmartContract(
+								contract,
+								EvmSupportedTransferKinds::try_from(vec![EvmTransferKind::Erc20])
+									.expect("length 1 is less than the bound 2; qed"),
+							),
+							info.clone(),
+						),
+						_ => return Err(Error::<T>::UnsupportedTransferKind),
+					},
+				};
+				let currency_id = CurrencyId::new::<T>(&currency);
+				deal_order.terms.currency = currency_id;
+				Ok(())
+			},
+		)?;
+
 		let transfer = Transfer {
 			blockchain: from.blockchain,
-			kind: transfer_kind.clone(),
+			kind: transfer_kind
+				.clone()
+				.try_into()
+				.map_err(|()| Error::<T>::UnsupportedTransferKind)?,
 			amount,
 			block,
 			from: from_id,

--- a/pallets/creditcoin/src/helpers/external_address.rs
+++ b/pallets/creditcoin/src/helpers/external_address.rs
@@ -1,4 +1,4 @@
-use crate::{Blockchain, ExternalAddress};
+use crate::{ExternalAddress, OldBlockchain};
 use base58::FromBase58;
 use core::convert::TryFrom;
 use frame_support::BoundedVec;
@@ -7,18 +7,18 @@ use sp_io::hashing::keccak_256;
 use sp_io::hashing::sha2_256;
 
 pub fn generate_external_address(
-	blockchain: &Blockchain,
+	blockchain: &OldBlockchain,
 	reference: &ExternalAddress,
 	public_key: Public,
 ) -> Option<ExternalAddress> {
 	match blockchain {
-		Blockchain::Luniverse | Blockchain::Ethereum | Blockchain::Rinkeby
+		OldBlockchain::Luniverse | OldBlockchain::Ethereum | OldBlockchain::Rinkeby
 			if EVMAddress::try_extract_addresss_type(reference).is_some() =>
 		{
 			Some(EVMAddress::from_public(&public_key))
 		},
-		Blockchain::Bitcoin => None,
-		Blockchain::Other(_) => None,
+		OldBlockchain::Bitcoin => None,
+		OldBlockchain::Other(_) => None,
 		_ => None,
 	}
 }
@@ -51,13 +51,13 @@ impl PublicToAddress for EVMAddress {
 	}
 }
 
-pub fn address_is_well_formed(blockchain: &Blockchain, address: &ExternalAddress) -> bool {
+pub fn address_is_well_formed(blockchain: &OldBlockchain, address: &ExternalAddress) -> bool {
 	match blockchain {
-		Blockchain::Bitcoin => btc_address_is_well_formed(address),
-		Blockchain::Ethereum | Blockchain::Luniverse | Blockchain::Rinkeby => {
+		OldBlockchain::Bitcoin => btc_address_is_well_formed(address),
+		OldBlockchain::Ethereum | OldBlockchain::Luniverse | OldBlockchain::Rinkeby => {
 			eth_address_is_well_formed(address)
 		},
-		Blockchain::Other(_) => false,
+		OldBlockchain::Other(_) => false,
 	}
 }
 
@@ -171,11 +171,11 @@ mod tests {
 
 	#[test]
 	fn address_is_well_formed_works() {
-		let ethereum = Blockchain::Ethereum;
-		let bitcoin = Blockchain::Bitcoin;
-		let rinkeby = Blockchain::Rinkeby;
-		let luniverse = Blockchain::Luniverse;
-		let other = Blockchain::Other(BoundedVec::try_from(b"other".to_vec()).unwrap());
+		let ethereum = OldBlockchain::Ethereum;
+		let bitcoin = OldBlockchain::Bitcoin;
+		let rinkeby = OldBlockchain::Rinkeby;
+		let luniverse = OldBlockchain::Luniverse;
+		let other = OldBlockchain::Other(BoundedVec::try_from(b"other".to_vec()).unwrap());
 
 		let eth_addr = hex::decode("5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed")
 			.unwrap()

--- a/pallets/creditcoin/src/helpers/external_address.rs
+++ b/pallets/creditcoin/src/helpers/external_address.rs
@@ -12,7 +12,7 @@ pub fn generate_external_address(
 	public_key: Public,
 ) -> Option<ExternalAddress> {
 	match blockchain {
-		Blockchain::Evm(_) if EVMAddress::try_extract_addresss_type(reference).is_some() => {
+		Blockchain::Evm(_) if EVMAddress::try_extract_address_type(reference).is_some() => {
 			Some(EVMAddress::from_public(&public_key))
 		},
 		_ => None,
@@ -21,7 +21,7 @@ pub fn generate_external_address(
 
 pub trait PublicToAddress {
 	type AddressType;
-	fn try_extract_addresss_type(addr: &ExternalAddress) -> Option<Self::AddressType>;
+	fn try_extract_address_type(addr: &ExternalAddress) -> Option<Self::AddressType>;
 	fn from_public(pkey: &Public) -> ExternalAddress;
 }
 
@@ -29,7 +29,7 @@ pub struct EVMAddress;
 
 impl PublicToAddress for EVMAddress {
 	type AddressType = ();
-	fn try_extract_addresss_type(addr: &ExternalAddress) -> Option<Self::AddressType> {
+	fn try_extract_address_type(addr: &ExternalAddress) -> Option<Self::AddressType> {
 		if eth_address_is_well_formed(addr) {
 			Some(())
 		} else {

--- a/pallets/creditcoin/src/lib.rs
+++ b/pallets/creditcoin/src/lib.rs
@@ -716,7 +716,7 @@ pub mod pallet {
 		#[pallet::weight(<T as Config>::WeightInfo::register_address())]
 		pub fn register_address(
 			origin: OriginFor<T>,
-			blockchain: Blockchain,
+			blockchain: OldBlockchain,
 			address: ExternalAddress,
 			ownership_proof: sp_core::ecdsa::Signature,
 		) -> DispatchResult {
@@ -775,7 +775,6 @@ pub mod pallet {
 			ensure!(address.owner == who, Error::<T>::NotAddressOwner);
 
 			let ask_order = AskOrder {
-				blockchain: address.blockchain,
 				lender_address_id: address_id,
 				terms: terms.try_into().map_err(Error::<T>::from)?,
 				expiration_block,
@@ -810,7 +809,6 @@ pub mod pallet {
 			ensure!(address.owner == who, Error::<T>::NotAddressOwner);
 
 			let bid_order = BidOrder {
-				blockchain: address.blockchain,
 				borrower_address_id: address_id,
 				terms: terms.try_into().map_err(Error::<T>::from)?,
 				expiration_block,
@@ -849,8 +847,11 @@ pub mod pallet {
 
 			ensure!(bid_order.expiration_block >= head, Error::<T>::BidOrderExpired);
 
+			let lender_address = Self::get_address(&ask_order.lender_address_id)?;
+			let borrower_address = Self::get_address(&bid_order.borrower_address_id)?;
+
 			ensure!(
-				ask_order.blockchain == bid_order.blockchain,
+				lender_address.blockchain == borrower_address.blockchain,
 				Error::<T>::AddressPlatformMismatch
 			);
 
@@ -864,7 +865,6 @@ pub mod pallet {
 				ask_id: ask_order_id,
 				bid_id: bid_order_id,
 				block: Self::block_number(),
-				blockchain: ask_order.blockchain,
 				expiration_block,
 				lender: who,
 			};
@@ -904,7 +904,6 @@ pub mod pallet {
 				.ok_or(Error::<T>::AskBidMismatch)?;
 
 			let deal_order = DealOrder {
-				blockchain: offer.blockchain,
 				offer_id,
 				lender_address_id: ask_order.lender_address_id,
 				borrower_address_id: bid_order.borrower_address_id,
@@ -1056,7 +1055,6 @@ pub mod pallet {
 			let current_block = Self::block_number();
 
 			let ask_order = AskOrder {
-				blockchain: lender.blockchain.clone(),
 				lender_address_id: lender_address_id.clone(),
 				terms: terms.clone().try_into().map_err(Error::<T>::from)?,
 				expiration_block,
@@ -1065,7 +1063,6 @@ pub mod pallet {
 			};
 
 			let bid_order = BidOrder {
-				blockchain: lender.blockchain.clone(),
 				borrower_address_id: borrower_address_id.clone(),
 				terms: terms.clone().try_into().map_err(Error::<T>::from)?,
 				expiration_block,
@@ -1077,13 +1074,11 @@ pub mod pallet {
 				ask_id: ask_order_id.clone(),
 				bid_id: bid_order_id.clone(),
 				block: current_block,
-				blockchain: lender.blockchain.clone(),
 				expiration_block,
 				lender: lender_account,
 			};
 
 			let deal_order = DealOrder {
-				blockchain: lender.blockchain,
 				offer_id: offer_id.clone(),
 				lender_address_id,
 				borrower_address_id,

--- a/pallets/creditcoin/src/lib.rs
+++ b/pallets/creditcoin/src/lib.rs
@@ -1215,7 +1215,7 @@ pub mod pallet {
 
 			let order = try_get_id!(DealOrders<T>, &deal_order_id, NonExistentDealOrder)?;
 
-			let (transfer_id, transfer) = Self::register_transfer_internal(
+			let (transfer_id, transfer) = Self::register_transfer_internal_legacy(
 				who,
 				order.lender_address_id,
 				order.borrower_address_id,
@@ -1242,7 +1242,7 @@ pub mod pallet {
 
 			let order = try_get_id!(DealOrders<T>, &deal_order_id, NonExistentDealOrder)?;
 
-			let (transfer_id, transfer) = Self::register_transfer_internal(
+			let (transfer_id, transfer) = Self::register_transfer_internal_legacy(
 				who,
 				order.borrower_address_id,
 				order.lender_address_id,

--- a/pallets/creditcoin/src/lib.rs
+++ b/pallets/creditcoin/src/lib.rs
@@ -1207,7 +1207,7 @@ pub mod pallet {
 		#[pallet::weight(<T as Config>::WeightInfo::register_transfer_ocw())]
 		pub fn register_funding_transfer(
 			origin: OriginFor<T>,
-			transfer_kind: TransferKind,
+			transfer_kind: LegacyTransferKind,
 			deal_order_id: DealOrderId<T::BlockNumber, T::Hash>,
 			blockchain_tx_id: ExternalTxId,
 		) -> DispatchResult {
@@ -1233,7 +1233,7 @@ pub mod pallet {
 		#[pallet::weight(<T as Config>::WeightInfo::register_transfer_ocw())]
 		pub fn register_repayment_transfer(
 			origin: OriginFor<T>,
-			transfer_kind: TransferKind,
+			transfer_kind: LegacyTransferKind,
 			repayment_amount: ExternalAmount,
 			deal_order_id: DealOrderId<T::BlockNumber, T::Hash>,
 			blockchain_tx_id: ExternalTxId,
@@ -1283,7 +1283,7 @@ pub mod pallet {
 						account_id: who,
 						amount: ExternalAmount::zero(),
 						is_processed: true,
-						kind: TransferKind::Native,
+						kind: crate::LegacyTransferKind::Native,
 						tx_id: ExternalTxId::try_from(b"0".to_vec()).expect(
 							"0 is a length of one which will always be < size bound of ExternalTxId",
 						),

--- a/pallets/creditcoin/src/lib.rs
+++ b/pallets/creditcoin/src/lib.rs
@@ -1279,7 +1279,7 @@ pub mod pallet {
 				order.terms.amount,
 				deal_order_id,
 				blockchain_tx_id,
-				&order.terms.currency
+				&order.terms.currency,
 			)?;
 			Self::deposit_event(Event::<T>::TransferRegistered(transfer_id, transfer));
 
@@ -1313,7 +1313,7 @@ pub mod pallet {
 						account_id: who,
 						amount: ExternalAmount::zero(),
 						is_processed: true,
-						kind: crate::LegacyTransferKind::Native,
+						kind: TransferKind::Evm(EvmTransferKind::Ethless),
 						tx_id: ExternalTxId::try_from(b"0".to_vec()).expect(
 							"0 is a length of one which will always be < size bound of ExternalTxId",
 						),

--- a/pallets/creditcoin/src/lib.rs
+++ b/pallets/creditcoin/src/lib.rs
@@ -780,6 +780,13 @@ pub mod pallet {
 			let address = Self::get_address(&address_id)?;
 			ensure!(address.owner == who, Error::<T>::NotAddressOwner);
 
+			let currency =
+				Currencies::<T>::get(&terms.currency).ok_or(Error::<T>::CurrencyNotRegistered)?;
+			ensure!(
+				address.blockchain == currency.blockchain(),
+				Error::<T>::AddressPlatformMismatch
+			);
+
 			let ask_order = AskOrder {
 				lender_address_id: address_id,
 				terms: terms.try_into().map_err(Error::<T>::from)?,
@@ -813,6 +820,13 @@ pub mod pallet {
 
 			let address = Self::get_address(&address_id)?;
 			ensure!(address.owner == who, Error::<T>::NotAddressOwner);
+
+			let currency =
+				Currencies::<T>::get(&terms.currency).ok_or(Error::<T>::CurrencyNotRegistered)?;
+			ensure!(
+				address.blockchain == currency.blockchain(),
+				Error::<T>::AddressPlatformMismatch
+			);
 
 			let bid_order = BidOrder {
 				borrower_address_id: address_id,

--- a/pallets/creditcoin/src/lib.rs
+++ b/pallets/creditcoin/src/lib.rs
@@ -987,7 +987,7 @@ pub mod pallet {
 				},
 				|transfer, deal_order| {
 					ensure!(
-						transfer.order_id == OrderId::Deal(deal_order_id.clone()),
+						transfer.deal_order_id == deal_order_id.clone(),
 						Error::<T>::TransferDealOrderMismatch
 					);
 					ensure!(
@@ -1147,7 +1147,7 @@ pub mod pallet {
 				},
 				|transfer, _deal_order| {
 					ensure!(
-						transfer.order_id == OrderId::Deal(deal_order_id.clone()),
+						transfer.deal_order_id == deal_order_id.clone(),
 						Error::<T>::TransferDealOrderMismatch
 					);
 
@@ -1221,7 +1221,7 @@ pub mod pallet {
 				order.borrower_address_id,
 				transfer_kind,
 				order.terms.amount,
-				OrderId::Deal(deal_order_id),
+				deal_order_id,
 				blockchain_tx_id,
 			)?;
 			Self::deposit_event(Event::<T>::TransferRegistered(transfer_id, transfer));
@@ -1248,7 +1248,7 @@ pub mod pallet {
 				order.lender_address_id,
 				transfer_kind,
 				repayment_amount,
-				OrderId::Deal(deal_order_id),
+				deal_order_id,
 				blockchain_tx_id,
 			)?;
 			Self::deposit_event(Event::<T>::TransferRegistered(transfer_id, transfer));
@@ -1278,7 +1278,7 @@ pub mod pallet {
 					ensure!(who == lender.owner, Error::<T>::NotLender);
 
 					let fake_transfer = Transfer {
-						order_id: OrderId::Deal(deal_order_id.clone()),
+						deal_order_id: deal_order_id.clone(),
 						block: Self::block_number(),
 						account_id: who,
 						amount: ExternalAmount::zero(),

--- a/pallets/creditcoin/src/lib.rs
+++ b/pallets/creditcoin/src/lib.rs
@@ -1245,6 +1245,8 @@ pub mod pallet {
 
 			let order = try_get_id!(DealOrders<T>, &deal_order_id, NonExistentDealOrder)?;
 
+			ensure!(order.terms.currency.is_placeholder(), Error::<T>::DeprecatedExtrinsic);
+
 			let (transfer_id, transfer) = Self::register_transfer_internal_legacy(
 				who,
 				order.borrower_address_id,
@@ -1277,6 +1279,34 @@ pub mod pallet {
 				order.borrower_address_id,
 				transfer_kind,
 				order.terms.amount,
+				deal_order_id,
+				blockchain_tx_id,
+				&order.terms.currency,
+			)?;
+			Self::deposit_event(Event::<T>::TransferRegistered(transfer_id, transfer));
+
+			Ok(())
+		}
+
+		#[transactional]
+		#[pallet::weight(<T as Config>::WeightInfo::register_transfer_ocw())]
+		pub fn register_repayment_transfer_new(
+			origin: OriginFor<T>,
+			transfer_kind: TransferKind,
+			repayment_amount: ExternalAmount,
+			deal_order_id: DealOrderId<T::BlockNumber, T::Hash>,
+			blockchain_tx_id: ExternalTxId,
+		) -> DispatchResult {
+			let who = ensure_signed(origin)?;
+
+			let order = try_get_id!(DealOrders<T>, &deal_order_id, NonExistentDealOrder)?;
+
+			let (transfer_id, transfer) = Self::register_transfer_internal(
+				who,
+				order.borrower_address_id,
+				order.lender_address_id,
+				transfer_kind,
+				repayment_amount,
 				deal_order_id,
 				blockchain_tx_id,
 				&order.terms.currency,

--- a/pallets/creditcoin/src/lib.rs
+++ b/pallets/creditcoin/src/lib.rs
@@ -519,6 +519,12 @@ pub mod pallet {
 
 		/// The currency has already been registered.
 		CurrencyAlreadyRegistered,
+
+		/// The legacy/deprecated version of an extrinsic was called, the new version should be used instead.
+		DeprecatedExtrinsic,
+
+		/// The currency with the given ID has not been registered.
+		CurrencyNotRegistered,
 	}
 
 	#[pallet::genesis_config]
@@ -1210,6 +1216,8 @@ pub mod pallet {
 
 			let order = try_get_id!(DealOrders<T>, &deal_order_id, NonExistentDealOrder)?;
 
+			ensure!(order.terms.currency.is_placeholder(), Error::<T>::DeprecatedExtrinsic);
+
 			let (transfer_id, transfer) = Self::register_transfer_internal_legacy(
 				who,
 				order.lender_address_id,
@@ -1245,6 +1253,33 @@ pub mod pallet {
 				repayment_amount,
 				deal_order_id,
 				blockchain_tx_id,
+			)?;
+			Self::deposit_event(Event::<T>::TransferRegistered(transfer_id, transfer));
+
+			Ok(())
+		}
+
+		#[transactional]
+		#[pallet::weight(<T as Config>::WeightInfo::register_transfer_ocw())]
+		pub fn register_funding_transfer_new(
+			origin: OriginFor<T>,
+			transfer_kind: TransferKind,
+			deal_order_id: DealOrderId<T::BlockNumber, T::Hash>,
+			blockchain_tx_id: ExternalTxId,
+		) -> DispatchResult {
+			let who = ensure_signed(origin)?;
+
+			let order = try_get_id!(DealOrders<T>, &deal_order_id, NonExistentDealOrder)?;
+
+			let (transfer_id, transfer) = Self::register_transfer_internal(
+				who,
+				order.lender_address_id,
+				order.borrower_address_id,
+				transfer_kind,
+				order.terms.amount,
+				deal_order_id,
+				blockchain_tx_id,
+				&order.terms.currency
 			)?;
 			Self::deposit_event(Event::<T>::TransferRegistered(transfer_id, transfer));
 

--- a/pallets/creditcoin/src/lib.rs
+++ b/pallets/creditcoin/src/lib.rs
@@ -759,7 +759,7 @@ pub mod pallet {
 		pub fn add_ask_order(
 			origin: OriginFor<T>,
 			address_id: AddressId<T::Hash>,
-			terms: LoanTerms,
+			terms: LoanTerms<T::Hash>,
 			expiration_block: BlockNumberFor<T>,
 			guid: Guid,
 		) -> DispatchResult {
@@ -793,7 +793,7 @@ pub mod pallet {
 		pub fn add_bid_order(
 			origin: OriginFor<T>,
 			address_id: AddressId<T::Hash>,
-			terms: LoanTerms,
+			terms: LoanTerms<T::Hash>,
 			expiration_block: BlockNumberFor<T>,
 			guid: Guid,
 		) -> DispatchResult {
@@ -1009,7 +1009,7 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			lender_address_id: AddressId<T::Hash>,
 			borrower_address_id: AddressId<T::Hash>,
-			terms: LoanTerms,
+			terms: LoanTerms<T::Hash>,
 			expiration_block: BlockNumberFor<T>,
 			ask_guid: Guid,
 			bid_guid: Guid,

--- a/pallets/creditcoin/src/lib.rs
+++ b/pallets/creditcoin/src/lib.rs
@@ -1206,7 +1206,7 @@ pub mod pallet {
 
 		#[transactional]
 		#[pallet::weight(<T as Config>::WeightInfo::register_transfer_ocw())]
-		pub fn register_funding_transfer(
+		pub fn register_funding_transfer_legacy(
 			origin: OriginFor<T>,
 			transfer_kind: LegacyTransferKind,
 			deal_order_id: DealOrderId<T::BlockNumber, T::Hash>,
@@ -1234,7 +1234,7 @@ pub mod pallet {
 
 		#[transactional]
 		#[pallet::weight(<T as Config>::WeightInfo::register_transfer_ocw())]
-		pub fn register_repayment_transfer(
+		pub fn register_repayment_transfer_legacy(
 			origin: OriginFor<T>,
 			transfer_kind: LegacyTransferKind,
 			repayment_amount: ExternalAmount,
@@ -1263,7 +1263,7 @@ pub mod pallet {
 
 		#[transactional]
 		#[pallet::weight(<T as Config>::WeightInfo::register_transfer_ocw())]
-		pub fn register_funding_transfer_new(
+		pub fn register_funding_transfer(
 			origin: OriginFor<T>,
 			transfer_kind: TransferKind,
 			deal_order_id: DealOrderId<T::BlockNumber, T::Hash>,
@@ -1290,7 +1290,7 @@ pub mod pallet {
 
 		#[transactional]
 		#[pallet::weight(<T as Config>::WeightInfo::register_transfer_ocw())]
-		pub fn register_repayment_transfer_new(
+		pub fn register_repayment_transfer(
 			origin: OriginFor<T>,
 			transfer_kind: TransferKind,
 			repayment_amount: ExternalAmount,

--- a/pallets/creditcoin/src/lib.rs
+++ b/pallets/creditcoin/src/lib.rs
@@ -716,7 +716,7 @@ pub mod pallet {
 		#[pallet::weight(<T as Config>::WeightInfo::register_address())]
 		pub fn register_address(
 			origin: OriginFor<T>,
-			blockchain: OldBlockchain,
+			blockchain: Blockchain,
 			address: ExternalAddress,
 			ownership_proof: sp_core::ecdsa::Signature,
 		) -> DispatchResult {

--- a/pallets/creditcoin/src/migrations/mod.rs
+++ b/pallets/creditcoin/src/migrations/mod.rs
@@ -6,6 +6,7 @@ mod v2;
 mod v3;
 mod v4;
 mod v5;
+mod v6;
 
 pub(crate) fn migrate<T: Config>() -> Weight {
 	let version = StorageVersion::get::<Pallet<T>>();
@@ -34,6 +35,11 @@ pub(crate) fn migrate<T: Config>() -> Weight {
 	if version < 5 {
 		weight = weight.saturating_add(v5::migrate::<T>());
 		StorageVersion::new(5).put::<Pallet<T>>();
+	}
+
+	if version < 6 {
+		weight = weight.saturating_add(v6::migrate::<T>());
+		StorageVersion::new(6).put::<Pallet<T>>();
 	}
 
 	weight

--- a/pallets/creditcoin/src/migrations/v1.rs
+++ b/pallets/creditcoin/src/migrations/v1.rs
@@ -3,11 +3,11 @@
 
 use crate::{
 	loan_terms::{Decimals, Duration},
-	AddressId, Blockchain, Config, ExternalAmount, OfferId, RatePerPeriod, TransferId,
+	AddressId, Config, ExternalAmount, OfferId, RatePerPeriod, TransferId,
 };
 use codec::{Decode, Encode};
-use frame_support::weights::Weight;
-use frame_support::{generate_storage_alias, traits::Get};
+use frame_support::generate_storage_alias;
+use frame_support::pallet_prelude::*;
 use frame_support::{Identity, Twox64Concat};
 use sp_runtime::traits::{Saturating, UniqueSaturatedInto};
 
@@ -123,6 +123,32 @@ pub struct BidOrder<AccountId, BlockNum, Hash> {
 	pub expiration_block: BlockNum,
 	pub block: BlockNum,
 	pub borrower: AccountId,
+}
+
+type OtherChainLen = ConstU32<256>;
+pub type OtherChain = BoundedVec<u8, OtherChainLen>;
+
+#[derive(Encode, Decode)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
+pub enum Blockchain {
+	Ethereum,
+	Rinkeby,
+	Luniverse,
+	Bitcoin,
+	Other(OtherChain),
+}
+
+impl Blockchain {
+	#[allow(dead_code)]
+	pub fn as_bytes(&self) -> &[u8] {
+		match self {
+			Blockchain::Ethereum => b"ethereum",
+			Blockchain::Rinkeby => b"rinkeby",
+			Blockchain::Luniverse => b"luniverse",
+			Blockchain::Bitcoin => b"bitcoin",
+			Blockchain::Other(chain) => chain.as_slice(),
+		}
+	}
 }
 
 generate_storage_alias!(

--- a/pallets/creditcoin/src/migrations/v1.rs
+++ b/pallets/creditcoin/src/migrations/v1.rs
@@ -129,7 +129,7 @@ type OtherChainLen = ConstU32<256>;
 pub type OtherChain = BoundedVec<u8, OtherChainLen>;
 
 #[derive(Encode, Decode)]
-#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq, Clone))]
 pub enum Blockchain {
 	Ethereum,
 	Rinkeby,

--- a/pallets/creditcoin/src/migrations/v2.rs
+++ b/pallets/creditcoin/src/migrations/v2.rs
@@ -17,7 +17,7 @@ pub use super::v1::{AskOrder, AskTerms, BidOrder, BidTerms, InterestRate};
 type OtherTransferKindLen = ConstU32<256>;
 pub type OtherTransferKind = BoundedVec<u8, OtherTransferKindLen>;
 
-#[derive(Encode, Decode, RuntimeDebug)]
+#[derive(Encode, Decode, RuntimeDebug, Clone)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
 pub enum TransferKind {
 	Erc20(ExternalAddress),

--- a/pallets/creditcoin/src/migrations/v2.rs
+++ b/pallets/creditcoin/src/migrations/v2.rs
@@ -10,7 +10,7 @@ use frame_support::{generate_storage_alias, pallet_prelude::*, Identity, Twox64C
 pub use super::v1::Blockchain;
 pub use super::v1::DealOrder as OldDealOrder;
 pub use super::v1::LoanTerms;
-pub use super::v1::*;
+pub use super::v1::{AskOrder, AskTerms, BidOrder, BidTerms, InterestRate};
 
 type OtherTransferKindLen = ConstU32<256>;
 pub type OtherTransferKind = BoundedVec<u8, OtherTransferKindLen>;

--- a/pallets/creditcoin/src/migrations/v2.rs
+++ b/pallets/creditcoin/src/migrations/v2.rs
@@ -5,7 +5,9 @@ use crate::{
 	AddressId, Config, DealOrderId, ExternalAmount, ExternalTxId, OfferId, RepaymentOrderId,
 	TransferId,
 };
-use frame_support::{generate_storage_alias, pallet_prelude::*, Identity, Twox64Concat};
+use frame_support::{
+	generate_storage_alias, pallet_prelude::*, Identity, RuntimeDebug, Twox64Concat,
+};
 
 pub use super::v1::Blockchain;
 pub use super::v1::DealOrder as OldDealOrder;
@@ -15,8 +17,8 @@ pub use super::v1::{AskOrder, AskTerms, BidOrder, BidTerms, InterestRate};
 type OtherTransferKindLen = ConstU32<256>;
 pub type OtherTransferKind = BoundedVec<u8, OtherTransferKindLen>;
 
-#[derive(Encode, Decode)]
-#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
+#[derive(Encode, Decode, RuntimeDebug)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub enum TransferKind {
 	Erc20(ExternalAddress),
 	Ethless(ExternalAddress),

--- a/pallets/creditcoin/src/migrations/v3.rs
+++ b/pallets/creditcoin/src/migrations/v3.rs
@@ -15,7 +15,7 @@ pub use v2::Blockchain;
 pub use v2::DealOrder as OldDealOrder;
 pub use v2::InterestRate as OldInterestRate;
 pub use v2::LoanTerms as OldLoanTerms;
-pub use v2::*;
+pub use v2::{OrderId, Transfer, TransferKind};
 
 use crate::InterestRate;
 
@@ -29,10 +29,10 @@ pub struct LoanTerms {
 
 #[derive(Encode, Decode)]
 #[cfg_attr(test, derive(Debug, PartialEq, Eq))]
-pub struct AskTerms(LoanTerms);
+pub struct AskTerms(pub(super) LoanTerms);
 #[derive(Encode, Decode)]
 #[cfg_attr(test, derive(Debug, PartialEq, Eq))]
-pub struct BidTerms(LoanTerms);
+pub struct BidTerms(pub(super) LoanTerms);
 
 #[derive(Encode, Decode)]
 #[cfg_attr(test, derive(Debug, PartialEq, Eq))]

--- a/pallets/creditcoin/src/migrations/v3.rs
+++ b/pallets/creditcoin/src/migrations/v3.rs
@@ -1,27 +1,77 @@
 // `interest_type` added to `LoanTerms`
 
-use super::{v1, v2};
-use core::convert::TryFrom;
+use super::v2;
+use codec::{Decode, Encode};
 use frame_support::dispatch::Weight;
 use frame_support::{generate_storage_alias, traits::Get, Identity, Twox64Concat};
 
-use crate::Config;
+use crate::{AddressId, Config, Duration, ExternalAmount, OfferId, TransferId};
 
-use v1::AskOrder as OldAskOrder;
-use v1::AskTerms as OldAskTerms;
-use v1::BidOrder as OldBidOrder;
-use v1::BidTerms as OldBidTerms;
-use v1::InterestRate as OldInterestRate;
-use v1::LoanTerms as OldLoanTerms;
-use v2::DealOrder as OldDealOrder;
+pub use v2::AskOrder as OldAskOrder;
+pub use v2::AskTerms as OldAskTerms;
+pub use v2::BidOrder as OldBidOrder;
+pub use v2::BidTerms as OldBidTerms;
+pub use v2::Blockchain;
+pub use v2::DealOrder as OldDealOrder;
+pub use v2::InterestRate as OldInterestRate;
+pub use v2::LoanTerms as OldLoanTerms;
+pub use v2::*;
 
-use crate::AskOrder;
-use crate::AskTerms;
-use crate::BidOrder;
-use crate::BidTerms;
-use crate::DealOrder;
 use crate::InterestRate;
-use crate::LoanTerms;
+
+#[derive(Encode, Decode)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
+pub struct LoanTerms {
+	pub amount: ExternalAmount,
+	pub interest_rate: InterestRate,
+	pub term_length: Duration,
+}
+
+#[derive(Encode, Decode)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
+pub struct AskTerms(LoanTerms);
+#[derive(Encode, Decode)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
+pub struct BidTerms(LoanTerms);
+
+#[derive(Encode, Decode)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
+pub struct AskOrder<AccountId, BlockNum, Hash> {
+	pub blockchain: Blockchain,
+	pub lender_address_id: AddressId<Hash>,
+	pub terms: AskTerms,
+	pub expiration_block: BlockNum,
+	pub block: BlockNum,
+	pub lender: AccountId,
+}
+
+#[derive(Encode, Decode)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
+pub struct BidOrder<AccountId, BlockNum, Hash> {
+	pub blockchain: Blockchain,
+	pub borrower_address_id: AddressId<Hash>,
+	pub terms: BidTerms,
+	pub expiration_block: BlockNum,
+	pub block: BlockNum,
+	pub borrower: AccountId,
+}
+
+#[derive(Encode, Decode)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
+pub struct DealOrder<AccountId, BlockNum, Hash, Moment> {
+	pub blockchain: Blockchain,
+	pub offer_id: OfferId<BlockNum, Hash>,
+	pub lender_address_id: AddressId<Hash>,
+	pub borrower_address_id: AddressId<Hash>,
+	pub terms: LoanTerms,
+	pub expiration_block: BlockNum,
+	pub timestamp: Moment,
+	pub block: Option<BlockNum>,
+	pub funding_transfer_id: Option<TransferId<Hash>>,
+	pub repayment_transfer_id: Option<TransferId<Hash>>,
+	pub lock: Option<AccountId>,
+	pub borrower: AccountId,
+}
 
 impl From<OldInterestRate> for InterestRate {
 	fn from(old: OldInterestRate) -> Self {
@@ -44,15 +94,27 @@ impl From<OldLoanTerms> for LoanTerms {
 	}
 }
 
+impl From<LoanTerms> for AskTerms {
+	fn from(terms: LoanTerms) -> Self {
+		Self(terms)
+	}
+}
+
+impl From<LoanTerms> for BidTerms {
+	fn from(terms: LoanTerms) -> Self {
+		Self(terms)
+	}
+}
+
 impl From<OldAskTerms> for AskTerms {
 	fn from(old: OldAskTerms) -> Self {
-		Self::try_from(LoanTerms::from(old.0)).expect("existing ask terms must be valid")
+		AskTerms(LoanTerms::from(old.0))
 	}
 }
 
 impl From<OldBidTerms> for BidTerms {
 	fn from(old: OldBidTerms) -> Self {
-		Self::try_from(LoanTerms::from(old.0)).expect("existing bid terms must be valid")
+		BidTerms(LoanTerms::from(old.0))
 	}
 }
 
@@ -133,12 +195,12 @@ mod tests {
 	use crate::{
 		mock::{ExtBuilder, Test},
 		tests::TestInfo,
-		AskOrderId, BidOrderId, Blockchain, DealOrderId, DoubleMapExt, Duration, OfferId,
+		AskOrderId, BidOrderId, DealOrderId, DoubleMapExt, Duration, InterestRate, OfferId,
 	};
 
 	use super::{
-		generate_storage_alias, AskOrder, AskTerms, BidOrder, BidTerms, Config, DealOrder,
-		Identity, InterestRate, LoanTerms, OldAskOrder, OldAskTerms, OldBidOrder, OldBidTerms,
+		generate_storage_alias, AskOrder, AskTerms, BidOrder, BidTerms, Blockchain, Config,
+		DealOrder, Identity, LoanTerms, OldAskOrder, OldAskTerms, OldBidOrder, OldBidTerms,
 		OldDealOrder, OldInterestRate, OldLoanTerms, Twox64Concat,
 	};
 
@@ -170,7 +232,7 @@ mod tests {
 			let test_info = TestInfo::new_defaults();
 
 			let old_ask_order = OldAskOrder {
-				blockchain: crate::Blockchain::Ethereum,
+				blockchain: Blockchain::Ethereum,
 				lender_address_id: test_info.lender.address_id,
 				terms: OldAskTerms(OldLoanTerms {
 					amount: 100u64.into(),
@@ -223,7 +285,7 @@ mod tests {
 			let test_info = TestInfo::new_defaults();
 
 			let old_bid_order = OldBidOrder {
-				blockchain: crate::Blockchain::Ethereum,
+				blockchain: Blockchain::Ethereum,
 				borrower_address_id: test_info.borrower.address_id,
 				terms: OldBidTerms(OldLoanTerms {
 					amount: 100u64.into(),

--- a/pallets/creditcoin/src/migrations/v4.rs
+++ b/pallets/creditcoin/src/migrations/v4.rs
@@ -11,6 +11,7 @@ pub use v3::*;
 
 use crate::AddressId;
 use v3::Blockchain as OldBlockchain;
+
 #[derive(Encode, Decode)]
 #[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub struct Address<AccountId> {

--- a/pallets/creditcoin/src/migrations/v4.rs
+++ b/pallets/creditcoin/src/migrations/v4.rs
@@ -4,6 +4,8 @@ use frame_support::dispatch::Weight;
 use frame_support::traits::Get;
 use sp_runtime::SaturatedConversion;
 
+pub use super::v3::*;
+
 use crate::Config;
 
 pub(crate) fn migrate<T: Config>() -> Weight {

--- a/pallets/creditcoin/src/migrations/v4.rs
+++ b/pallets/creditcoin/src/migrations/v4.rs
@@ -56,7 +56,7 @@ mod tests {
 			AddressId::make(T::Hashing::hash(&key))
 		}
 	}
-	#[allow(unreachable_code, unused)]
+
 	#[test]
 	fn migrate_works() {
 		ExtBuilder::default().build_and_execute(|| {

--- a/pallets/creditcoin/src/migrations/v4.rs
+++ b/pallets/creditcoin/src/migrations/v4.rs
@@ -19,22 +19,36 @@ pub(crate) fn migrate<T: Config>() -> Weight {
 
 #[cfg(test)]
 mod tests {
+	use super::Blockchain;
 	use crate::{
+		concatenate,
 		mock::{AccountId, ExtBuilder, Test},
 		Address, AddressId,
 	};
 	use sp_core::H256;
+	use sp_runtime::traits::Hash as HashT;
 	use sp_std::convert::TryInto;
 
+	#[extend::ext]
+	impl<H> AddressId<H> {
+		fn new_old<T: frame_system::Config>(blockchain: &Blockchain, address: &[u8]) -> AddressId<H>
+		where
+			<T as frame_system::Config>::Hashing: HashT<Output = H>,
+		{
+			let key = concatenate!(blockchain.as_bytes(), address);
+			AddressId::make(T::Hashing::hash(&key))
+		}
+	}
+	#[allow(unreachable_code, unused)]
 	#[test]
 	fn migrate_works() {
 		ExtBuilder::default().build_and_execute(|| {
 			let mut ids = Vec::new();
 			for i in 0u8..10u8 {
 				let id =
-					AddressId::<H256>::new::<Test>(&crate::Blockchain::Ethereum, &i.to_be_bytes());
+					AddressId::<H256>::new_old::<Test>(&Blockchain::Ethereum, &i.to_be_bytes());
 				let address = Address {
-					blockchain: crate::Blockchain::Ethereum,
+					blockchain: todo!(),
 					value: i.to_be_bytes().to_vec().try_into().unwrap(),
 					owner: AccountId::new([i; 32]),
 				};

--- a/pallets/creditcoin/src/migrations/v5.rs
+++ b/pallets/creditcoin/src/migrations/v5.rs
@@ -78,7 +78,7 @@ mod tests {
 					kind: crate::TransferKind::Native,
 					from: crate::AddressId::new::<Test>(&eth, b"fromaddr"),
 					to: crate::AddressId::new::<Test>(&eth, b"toaddr"),
-					order_id: crate::OrderId::Deal(crate::DealOrderId::dummy()),
+					deal_order_id: crate::DealOrderId::dummy(),
 					amount: 1.into(),
 					tx_id: tx_id.clone(),
 					block: 1,

--- a/pallets/creditcoin/src/migrations/v5.rs
+++ b/pallets/creditcoin/src/migrations/v5.rs
@@ -2,6 +2,8 @@
 use crate::{CollectedCoinsId, Config, TransferId, UnverifiedTransfer};
 use frame_support::{generate_storage_alias, migration, pallet_prelude::*, Identity};
 
+pub use super::v4::*;
+
 generate_storage_alias!(
 	Creditcoin,
 	UnverifiedTransfers<T: Config> => DoubleMap<

--- a/pallets/creditcoin/src/migrations/v6.rs
+++ b/pallets/creditcoin/src/migrations/v6.rs
@@ -1,6 +1,8 @@
 use super::v5;
 use crate::Config;
+use frame_support::generate_storage_alias;
 use frame_support::pallet_prelude::*;
+
 pub use v5::AskOrder as OldAskOrder;
 pub use v5::AskTerms as OldAskTerms;
 pub use v5::BidOrder as OldBidOrder;
@@ -12,6 +14,46 @@ pub use v5::OrderId as OldOrderId;
 pub use v5::Transfer as OldTransfer;
 pub use v5::TransferKind as OldTransferKind;
 
+use crate::Transfer;
+use crate::TransferId;
+
+generate_storage_alias!(
+	Creditcoin,
+	Transfers<T: Config> => Map<(Identity, TransferId<T::Hash>), Transfer<T::AccountId, T::BlockNumber, T::Hash, T::Moment>>
+);
+
+#[allow(unreachable_code)]
 pub(crate) fn migrate<T: Config>() -> Weight {
-	todo!()
+	let mut weight: Weight = 0;
+	let weight_each = T::DbWeight::get().reads_writes(1, 1);
+
+	Transfers::<T>::translate::<OldTransfer<T::AccountId, T::BlockNumber, T::Hash, T::Moment>, _>(
+		|_id, transfer| {
+			weight = weight.saturating_add(weight_each);
+			Some(Transfer {
+				amount: transfer.amount,
+				from: transfer.from,
+				to: transfer.to,
+				tx_id: transfer.tx_id,
+				block: transfer.block,
+				is_processed: transfer.is_processed,
+				account_id: transfer.account_id,
+				timestamp: transfer.timestamp,
+				deal_order_id: match transfer.order_id {
+					OldOrderId::Deal(id) => id,
+					OldOrderId::Repayment(id) => {
+						log::warn!(
+							"Found unexpected repayment ID attached to a transfer: {:?}",
+							id
+						);
+						return None;
+					},
+				},
+				blockchain: todo!(),
+				kind: todo!(),
+			})
+		},
+	);
+
+	weight
 }

--- a/pallets/creditcoin/src/migrations/v6.rs
+++ b/pallets/creditcoin/src/migrations/v6.rs
@@ -21,8 +21,10 @@ pub use v5::Blockchain as OldBlockchain;
 pub use v5::DealOrder as OldDealOrder;
 pub use v5::LoanTerms as OldLoanTerms;
 pub use v5::OrderId as OldOrderId;
+pub use v5::Task as OldTask;
 pub use v5::Transfer as OldTransfer;
 pub use v5::TransferKind as OldTransferKind;
+pub use v5::UnverifiedTransfer as OldUnverifiedTransfer;
 
 use crate::Address;
 use crate::AddressId;
@@ -37,8 +39,11 @@ use crate::Currency;
 use crate::CurrencyId;
 use crate::DealOrder;
 use crate::LoanTerms;
+use crate::Task;
+use crate::TaskId;
 use crate::Transfer;
 use crate::TransferId;
+use crate::UnverifiedTransfer;
 
 fn translate_blockchain(old: OldBlockchain) -> Option<Blockchain> {
 	match old {
@@ -110,6 +115,31 @@ fn reconstruct_currency_from_deal<T: Config>(
 	Some(CurrencyId::new::<T>(&currency))
 }
 
+fn translate_transfer<T: Config>(
+	transfer: OldTransfer<T::AccountId, T::BlockNumber, T::Hash, T::Moment>,
+) -> Option<Transfer<T::AccountId, T::BlockNumber, T::Hash, T::Moment>> {
+	#[allow(unreachable_code)]
+	Some(Transfer {
+		amount: transfer.amount,
+		from: transfer.from,
+		to: transfer.to,
+		tx_id: transfer.tx_id,
+		block: transfer.block,
+		is_processed: transfer.is_processed,
+		account_id: transfer.account_id,
+		timestamp: transfer.timestamp,
+		deal_order_id: match transfer.order_id {
+			OldOrderId::Deal(id) => id,
+			OldOrderId::Repayment(id) => {
+				log::warn!("Found unexpected repayment ID attached to a transfer: {:?}", id);
+				return None;
+			},
+		},
+		blockchain: translate_blockchain(transfer.blockchain)?,
+		kind: todo!(),
+	})
+}
+
 generate_storage_alias!(
 	Creditcoin,
 	Transfers<T: Config> => Map<(Identity, TransferId<T::Hash>), Transfer<T::AccountId, T::BlockNumber, T::Hash, T::Moment>>
@@ -148,6 +178,11 @@ generate_storage_alias!(
 generate_storage_alias!(
 	Creditcoin,
 	DealOrders<T: Config> => DoubleMap<(Twox64Concat, T::BlockNumber), (Identity, T::Hash), DealOrder<T::AccountId, T::BlockNumber, T::Hash, T::Moment>>
+);
+
+generate_storage_alias!(
+	Creditcoin,
+	PendingTasks<T: Config> => DoubleMap<(Identity, T::BlockNumber), (Identity, TaskId<T::Hash>), Task<T::AccountId, T::BlockNumber, T::Hash, T::Moment>>
 );
 
 #[allow(unreachable_code)]
@@ -234,27 +269,23 @@ pub(crate) fn migrate<T: Config>() -> Weight {
 	Transfers::<T>::translate::<OldTransfer<T::AccountId, T::BlockNumber, T::Hash, T::Moment>, _>(
 		|_id, transfer| {
 			weight = weight.saturating_add(weight_each);
-			Some(Transfer {
-				amount: transfer.amount,
-				from: transfer.from,
-				to: transfer.to,
-				tx_id: transfer.tx_id,
-				block: transfer.block,
-				is_processed: transfer.is_processed,
-				account_id: transfer.account_id,
-				timestamp: transfer.timestamp,
-				deal_order_id: match transfer.order_id {
-					OldOrderId::Deal(id) => id,
-					OldOrderId::Repayment(id) => {
-						log::warn!(
-							"Found unexpected repayment ID attached to a transfer: {:?}",
-							id
-						);
-						return None;
-					},
+			translate_transfer::<T>(transfer)
+		},
+	);
+
+	PendingTasks::<T>::translate::<OldTask<T::AccountId, T::BlockNumber, T::Hash, T::Moment>, _>(
+		|_exp, _id, task| {
+			weight = weight.saturating_add(weight_each);
+			Some(match task {
+				OldTask::VerifyTransfer(unverified_transfer) => {
+					Task::VerifyTransfer(UnverifiedTransfer {
+						transfer: translate_transfer::<T>(unverified_transfer.transfer)?,
+						from_external: unverified_transfer.from_external,
+						to_external: unverified_transfer.to_external,
+						deadline: unverified_transfer.deadline,
+					})
 				},
-				blockchain: translate_blockchain(transfer.blockchain)?,
-				kind: todo!(),
+				OldTask::CollectCoins(collect_coins) => Task::CollectCoins(collect_coins),
 			})
 		},
 	);

--- a/pallets/creditcoin/src/migrations/v6.rs
+++ b/pallets/creditcoin/src/migrations/v6.rs
@@ -1,7 +1,12 @@
+use core::convert::TryFrom;
+
 use super::v5;
 use crate::Config;
+use crate::ExternalAddress;
 use frame_support::generate_storage_alias;
 use frame_support::pallet_prelude::*;
+
+pub use v5::*;
 
 pub use v5::AskOrder as OldAskOrder;
 pub use v5::AskTerms as OldAskTerms;
@@ -14,12 +19,52 @@ pub use v5::OrderId as OldOrderId;
 pub use v5::Transfer as OldTransfer;
 pub use v5::TransferKind as OldTransferKind;
 
+use crate::Address;
+use crate::AddressId;
+use crate::Blockchain;
 use crate::Transfer;
 use crate::TransferId;
+
+impl TryFrom<OldBlockchain> for Blockchain {
+	type Error = OldBlockchain;
+	fn try_from(old: OldBlockchain) -> Result<Blockchain, OldBlockchain> {
+		match old {
+			OldBlockchain::Ethereum => Ok(Blockchain::ETHEREUM),
+			OldBlockchain::Rinkeby => Ok(Blockchain::RINKEBY),
+			// this assumes that Luniverse == mainnet luniverse, we may want to make the chain ID of the
+			// old "Luniverse" variant on-chain-storage to make testnet work
+			OldBlockchain::Luniverse => Ok(Blockchain::LUNIVERSE),
+			other => Err(other),
+		}
+	}
+}
+
+fn translate_blockchain(old: OldBlockchain) -> Option<Blockchain> {
+	match Blockchain::try_from(old) {
+		Ok(b) => Some(b),
+		Err(old) => {
+			log::warn!("unexpected blockchain found on storage item: {:?}", old);
+			None
+		},
+	}
+}
+
+#[derive(Encode, Decode)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
+pub struct OldAddress<AccountId> {
+	pub blockchain: OldBlockchain,
+	pub value: ExternalAddress,
+	pub owner: AccountId,
+}
 
 generate_storage_alias!(
 	Creditcoin,
 	Transfers<T: Config> => Map<(Identity, TransferId<T::Hash>), Transfer<T::AccountId, T::BlockNumber, T::Hash, T::Moment>>
+);
+
+generate_storage_alias!(
+	Creditcoin,
+	Addresses<T: Config> => Map<(Blake2_128Concat, AddressId<T::Hash>), Address<T::AccountId>>
 );
 
 #[allow(unreachable_code)]
@@ -49,11 +94,20 @@ pub(crate) fn migrate<T: Config>() -> Weight {
 						return None;
 					},
 				},
-				blockchain: todo!(),
+				blockchain: translate_blockchain(transfer.blockchain)?,
 				kind: todo!(),
 			})
 		},
 	);
+
+	Addresses::<T>::translate::<OldAddress<T::AccountId>, _>(|_id, address| {
+		weight = weight.saturating_add(weight_each);
+		Some(Address {
+			blockchain: translate_blockchain(address.blockchain)?,
+			value: address.value,
+			owner: address.owner,
+		})
+	});
 
 	weight
 }

--- a/pallets/creditcoin/src/migrations/v6.rs
+++ b/pallets/creditcoin/src/migrations/v6.rs
@@ -9,6 +9,7 @@ use core::convert::TryFrom;
 use frame_support::generate_storage_alias;
 use frame_support::pallet_prelude::*;
 use sp_std::collections::btree_map::BTreeMap;
+use sp_std::prelude::*;
 
 pub use v5::*;
 

--- a/pallets/creditcoin/src/migrations/v6.rs
+++ b/pallets/creditcoin/src/migrations/v6.rs
@@ -1,0 +1,17 @@
+use super::v5;
+use crate::Config;
+use frame_support::pallet_prelude::*;
+pub use v5::AskOrder as OldAskOrder;
+pub use v5::AskTerms as OldAskTerms;
+pub use v5::BidOrder as OldBidOrder;
+pub use v5::BidTerms as OldBidTerms;
+pub use v5::Blockchain as OldBlockchain;
+pub use v5::DealOrder as OldDealOrder;
+pub use v5::LoanTerms as OldLoanTerms;
+pub use v5::OrderId as OldOrderId;
+pub use v5::Transfer as OldTransfer;
+pub use v5::TransferKind as OldTransferKind;
+
+pub(crate) fn migrate<T: Config>() -> Weight {
+	todo!()
+}

--- a/pallets/creditcoin/src/migrations/v6.rs
+++ b/pallets/creditcoin/src/migrations/v6.rs
@@ -1,9 +1,14 @@
-use core::convert::TryFrom;
-
 use super::v5;
 use crate::Config;
+use crate::EvmCurrencyType;
+use crate::EvmInfo;
+use crate::EvmSupportedTransferKinds;
+use crate::EvmTransferKind;
+use crate::Id;
+use core::convert::TryFrom;
 use frame_support::generate_storage_alias;
 use frame_support::pallet_prelude::*;
+use sp_std::collections::btree_map::BTreeMap;
 
 pub use v5::*;
 
@@ -21,23 +26,19 @@ pub use v5::TransferKind as OldTransferKind;
 
 use crate::Address;
 use crate::AddressId;
+use crate::AskOrder;
+use crate::AskOrderId;
+use crate::AskTerms;
+use crate::BidOrder;
+use crate::BidOrderId;
+use crate::BidTerms;
 use crate::Blockchain;
+use crate::Currency;
+use crate::CurrencyId;
+use crate::DealOrder;
+use crate::LoanTerms;
 use crate::Transfer;
 use crate::TransferId;
-
-impl TryFrom<OldBlockchain> for Blockchain {
-	type Error = OldBlockchain;
-	fn try_from(old: OldBlockchain) -> Result<Blockchain, OldBlockchain> {
-		match old {
-			OldBlockchain::Ethereum => Ok(Blockchain::ETHEREUM),
-			OldBlockchain::Rinkeby => Ok(Blockchain::RINKEBY),
-			// this assumes that Luniverse == mainnet luniverse, we may want to make the chain ID of the
-			// old "Luniverse" variant on-chain-storage to make testnet work
-			OldBlockchain::Luniverse => Ok(Blockchain::LUNIVERSE),
-			other => Err(other),
-		}
-	}
-}
 
 fn translate_blockchain(old: OldBlockchain) -> Option<Blockchain> {
 	match old {
@@ -56,20 +57,179 @@ fn translate_blockchain(old: OldBlockchain) -> Option<Blockchain> {
 	}
 }
 
+fn translate_loan_terms<T: Config>(
+	old: OldLoanTerms,
+	currency: CurrencyId<T::Hash>,
+) -> LoanTerms<T::Hash> {
+	LoanTerms {
+		amount: old.amount,
+		interest_rate: old.interest_rate,
+		term_length: old.term_length,
+		currency,
+	}
+}
+
+fn reconstruct_currency(blockchain: &OldBlockchain, kind: &OldTransferKind) -> Option<Currency> {
+	let info = match blockchain {
+		OldBlockchain::Ethereum => EvmInfo::ETHEREUM,
+		OldBlockchain::Rinkeby => EvmInfo::RINKEBY,
+		OldBlockchain::Luniverse => EvmInfo::LUNIVERSE,
+		other => {
+			log::warn!(
+				"unexpected blockchain found on storage item: {:?}",
+				core::str::from_utf8(other.as_bytes()).ok()
+			);
+			return None;
+		},
+	};
+	let currency_type = match kind {
+		OldTransferKind::Erc20(addr) => EvmCurrencyType::SmartContract(
+			addr.clone(),
+			EvmSupportedTransferKinds::try_from(vec![EvmTransferKind::Erc20])
+				.expect("1 is less than the bound (2); qed"),
+		),
+		OldTransferKind::Ethless(addr) => EvmCurrencyType::SmartContract(
+			addr.clone(),
+			EvmSupportedTransferKinds::try_from(vec![EvmTransferKind::Ethless])
+				.expect("1 is less than the bound (2); qed"),
+		),
+		other => {
+			log::warn!("unexpected transfer kind found in storage: {:?}", other);
+			return None;
+		},
+	};
+	Some(Currency::Evm(currency_type, info))
+}
+
+fn reconstruct_currency_from_deal<T: Config>(
+	deal_order: &OldDealOrder<T::AccountId, T::BlockNumber, T::Hash, T::Moment>,
+) -> Option<CurrencyId<T::Hash>> {
+	let transfer_id = deal_order.funding_transfer_id.as_ref()?;
+	let transfer = OldTransfers::<T>::get(transfer_id)?;
+	let currency = reconstruct_currency(&deal_order.blockchain, &transfer.kind)?;
+	Some(CurrencyId::new::<T>(&currency))
+}
+
 generate_storage_alias!(
 	Creditcoin,
 	Transfers<T: Config> => Map<(Identity, TransferId<T::Hash>), Transfer<T::AccountId, T::BlockNumber, T::Hash, T::Moment>>
 );
+
+struct OldTransfersInstance;
+impl frame_support::traits::StorageInstance for OldTransfersInstance {
+	fn pallet_prefix() -> &'static str {
+		"Creditcoin"
+	}
+	const STORAGE_PREFIX: &'static str = "Transfers";
+}
+#[allow(type_alias_bounds)]
+type OldTransfers<T: Config> = frame_support::storage::types::StorageMap<
+	OldTransfersInstance,
+	Identity,
+	TransferId<T::Hash>,
+	OldTransfer<T::AccountId, T::BlockNumber, T::Hash, T::Moment>,
+>;
 
 generate_storage_alias!(
 	Creditcoin,
 	Addresses<T: Config> => Map<(Blake2_128Concat, AddressId<T::Hash>), Address<T::AccountId>>
 );
 
+generate_storage_alias!(
+	Creditcoin,
+	AskOrders<T: Config> => DoubleMap<(Twox64Concat, T::BlockNumber), (Identity, T::Hash), AskOrder<T::AccountId, T::BlockNumber, T::Hash>>
+);
+
+generate_storage_alias!(
+	Creditcoin,
+	BidOrders<T: Config> => DoubleMap<(Twox64Concat, T::BlockNumber), (Identity, T::Hash), BidOrder<T::AccountId, T::BlockNumber, T::Hash>>
+);
+
+generate_storage_alias!(
+	Creditcoin,
+	DealOrders<T: Config> => DoubleMap<(Twox64Concat, T::BlockNumber), (Identity, T::Hash), DealOrder<T::AccountId, T::BlockNumber, T::Hash, T::Moment>>
+);
+
 #[allow(unreachable_code)]
 pub(crate) fn migrate<T: Config>() -> Weight {
 	let mut weight: Weight = 0;
 	let weight_each = T::DbWeight::get().reads_writes(1, 1);
+
+	let mut reconstructed_currency_ask = BTreeMap::new();
+	let mut reconstructed_currency_bid = BTreeMap::new();
+
+	DealOrders::<T>::translate::<OldDealOrder<T::AccountId, T::BlockNumber, T::Hash, T::Moment>, _>(
+		|_exp, _hash, deal_order| {
+			weight = weight.saturating_add(weight_each);
+
+			let currency = reconstruct_currency_from_deal::<T>(&deal_order)
+				.unwrap_or_else(CurrencyId::placeholder);
+
+			let offer = if let Some(offer) = crate::Offers::<T>::get(
+				deal_order.offer_id.expiration(),
+				deal_order.offer_id.hash(),
+			) {
+				offer
+			} else {
+				log::warn!("deal order has a non-existent offer: {:?}", deal_order.offer_id);
+				return None;
+			};
+
+			reconstructed_currency_ask.insert(offer.ask_id, currency.clone());
+			reconstructed_currency_bid.insert(offer.bid_id, currency.clone());
+
+			Some(DealOrder {
+				offer_id: deal_order.offer_id,
+				lender_address_id: deal_order.lender_address_id,
+				borrower_address_id: deal_order.borrower_address_id,
+				terms: translate_loan_terms::<T>(deal_order.terms, currency),
+				expiration_block: deal_order.expiration_block,
+				timestamp: deal_order.timestamp,
+				block: deal_order.block,
+				funding_transfer_id: deal_order.funding_transfer_id,
+				repayment_transfer_id: deal_order.repayment_transfer_id,
+				lock: deal_order.lock,
+				borrower: deal_order.borrower,
+			})
+		},
+	);
+
+	AskOrders::<T>::translate::<OldAskOrder<T::AccountId, T::BlockNumber, T::Hash>, _>(
+		|exp, hash, ask_order| {
+			weight = weight.saturating_add(weight_each);
+			let ask_id = AskOrderId::with_expiration_hash::<T>(exp, hash);
+			let currency = reconstructed_currency_ask
+				.remove(&ask_id)
+				.unwrap_or_else(CurrencyId::placeholder);
+			Some(AskOrder {
+				lender_address_id: ask_order.lender_address_id,
+				terms: AskTerms::try_from(translate_loan_terms::<T>(
+					ask_order.terms.0,
+					currency,
+				)).expect("terms are checked for validity on creation so they must be valid on an existing ask order; qed"),
+				expiration_block: ask_order.expiration_block,
+				block: ask_order.block,
+				lender: ask_order.lender,
+			})
+		},
+	);
+
+	BidOrders::<T>::translate::<OldBidOrder<T::AccountId, T::BlockNumber, T::Hash>, _>(
+		|exp, hash, bid_order| {
+			weight = weight.saturating_add(weight_each);
+			let bid_id = BidOrderId::with_expiration_hash::<T>(exp, hash);
+			let currency = reconstructed_currency_bid
+				.remove(&bid_id)
+				.unwrap_or_else(CurrencyId::placeholder);
+			Some(BidOrder {
+				borrower_address_id: bid_order.borrower_address_id,
+				terms: BidTerms::try_from(translate_loan_terms::<T>(bid_order.terms.0, currency)).expect("terms are checked on creation so they must be valid on existing bid order; qed"),
+				expiration_block: bid_order.expiration_block,
+				block: bid_order.block,
+				borrower: bid_order.borrower,
+			})
+		},
+	);
 
 	Transfers::<T>::translate::<OldTransfer<T::AccountId, T::BlockNumber, T::Hash, T::Moment>, _>(
 		|_id, transfer| {

--- a/pallets/creditcoin/src/mock.rs
+++ b/pallets/creditcoin/src/mock.rs
@@ -457,6 +457,7 @@ pub(crate) struct MockedRpcRequests {
 	pub(crate) get_transaction_receipt: Option<PendingRequest>,
 	pub(crate) get_block_number: Option<PendingRequest>,
 	pub(crate) get_block_by_number: Option<PendingRequest>,
+	pub(crate) chain_id: Option<PendingRequest>,
 }
 
 impl Default for MockedRpcRequests {
@@ -496,7 +497,20 @@ impl MockedRpcRequests {
 			uri,
 			responses,
 		));
-		Self { get_transaction, get_transaction_receipt, get_block_number, get_block_by_number }
+		let chain_id = Some(pending_rpc_request("eth_chainId", vec![], uri, responses));
+		Self {
+			get_transaction,
+			get_transaction_receipt,
+			get_block_number,
+			get_block_by_number,
+			chain_id,
+		}
+	}
+
+	pub(crate) fn mock_chain_id(&mut self, state: &mut OffchainState) -> &mut Self {
+		let chain_id = self.chain_id.take().unwrap();
+		state.expect_request(chain_id);
+		self
 	}
 
 	/// Mocks only the RPC response for get_transaction

--- a/pallets/creditcoin/src/mock.rs
+++ b/pallets/creditcoin/src/mock.rs
@@ -1,7 +1,7 @@
 use crate::{
 	self as pallet_creditcoin,
 	ocw::rpc::{JsonRpcRequest, JsonRpcResponse},
-	Blockchain, LegacySighash,
+	LegacySighash, OldBlockchain,
 };
 use ethereum_types::U256;
 use frame_support::{
@@ -325,7 +325,7 @@ pub fn roll_by_with_ocw(n: BlockNumber) {
 }
 
 // must be called in an externalities-provided environment
-pub fn set_rpc_uri(blockchain: &Blockchain, value: impl AsRef<[u8]>) {
+pub fn set_rpc_uri(blockchain: &OldBlockchain, value: impl AsRef<[u8]>) {
 	let mut key = Vec::from(blockchain.as_bytes());
 	key.extend(b"-rpc-uri");
 	let rpc_url_storage = StorageValueRef::persistent(&key);

--- a/pallets/creditcoin/src/mock.rs
+++ b/pallets/creditcoin/src/mock.rs
@@ -1,7 +1,7 @@
 use crate::{
 	self as pallet_creditcoin,
 	ocw::rpc::{JsonRpcRequest, JsonRpcResponse},
-	LegacySighash, OldBlockchain,
+	Blockchain, LegacySighash,
 };
 use ethereum_types::U256;
 use frame_support::{
@@ -325,9 +325,8 @@ pub fn roll_by_with_ocw(n: BlockNumber) {
 }
 
 // must be called in an externalities-provided environment
-pub fn set_rpc_uri(blockchain: &OldBlockchain, value: impl AsRef<[u8]>) {
-	let mut key = Vec::from(blockchain.as_bytes());
-	key.extend(b"-rpc-uri");
+pub fn set_rpc_uri(blockchain: &Blockchain, value: impl AsRef<[u8]>) {
+	let key = blockchain.rpc_key();
 	let rpc_url_storage = StorageValueRef::persistent(&key);
 	rpc_url_storage.set(&value.as_ref());
 }

--- a/pallets/creditcoin/src/ocw.rs
+++ b/pallets/creditcoin/src/ocw.rs
@@ -2,7 +2,7 @@ pub mod errors;
 pub mod rpc;
 pub mod tasks;
 
-use crate::{Blockchain, Call, TransferKind};
+use crate::{Blockchain, Call, LegacyTransferKind};
 pub use errors::{OffchainError, VerificationFailureCause, VerificationResult};
 
 use self::errors::RpcUrlError;
@@ -30,13 +30,15 @@ impl Blockchain {
 			Err(RpcUrlError::NoValue)
 		}
 	}
-	pub fn supports(&self, kind: &TransferKind) -> bool {
+	pub fn supports(&self, kind: &LegacyTransferKind) -> bool {
 		match (self, kind) {
 			(
 				Blockchain::Ethereum | Blockchain::Luniverse | Blockchain::Rinkeby,
-				TransferKind::Erc20(_) | TransferKind::Ethless(_) | TransferKind::Native,
+				LegacyTransferKind::Erc20(_)
+				| LegacyTransferKind::Ethless(_)
+				| LegacyTransferKind::Native,
 			) => true,
-			(Blockchain::Bitcoin, TransferKind::Native) => true,
+			(Blockchain::Bitcoin, LegacyTransferKind::Native) => true,
 			(_, _) => false, // TODO: refine this later
 		}
 	}

--- a/pallets/creditcoin/src/ocw.rs
+++ b/pallets/creditcoin/src/ocw.rs
@@ -2,7 +2,7 @@ pub mod errors;
 pub mod rpc;
 pub mod tasks;
 
-use crate::{Blockchain, Call, LegacyTransferKind};
+use crate::{Call, LegacyTransferKind, OldBlockchain};
 pub use errors::{OffchainError, VerificationFailureCause, VerificationResult};
 
 use self::errors::RpcUrlError;
@@ -18,7 +18,7 @@ use sp_std::prelude::*;
 
 pub type OffchainResult<T, E = errors::OffchainError> = Result<T, E>;
 
-impl Blockchain {
+impl OldBlockchain {
 	pub fn rpc_url(&self) -> OffchainResult<String, errors::RpcUrlError> {
 		let chain_prefix = self.as_bytes();
 		let mut buf = Vec::from(chain_prefix);
@@ -33,12 +33,12 @@ impl Blockchain {
 	pub fn supports(&self, kind: &LegacyTransferKind) -> bool {
 		match (self, kind) {
 			(
-				Blockchain::Ethereum | Blockchain::Luniverse | Blockchain::Rinkeby,
+				OldBlockchain::Ethereum | OldBlockchain::Luniverse | OldBlockchain::Rinkeby,
 				LegacyTransferKind::Erc20(_)
 				| LegacyTransferKind::Ethless(_)
 				| LegacyTransferKind::Native,
 			) => true,
-			(Blockchain::Bitcoin, LegacyTransferKind::Native) => true,
+			(OldBlockchain::Bitcoin, LegacyTransferKind::Native) => true,
 			(_, _) => false, // TODO: refine this later
 		}
 	}

--- a/pallets/creditcoin/src/ocw/errors.rs
+++ b/pallets/creditcoin/src/ocw/errors.rs
@@ -11,6 +11,7 @@ pub enum OffchainError {
 	InvalidTask(VerificationFailureCause),
 	NoRpcUrl(RpcUrlError),
 	RpcError(RpcError),
+	IncorrectChainId,
 	InvalidData,
 }
 

--- a/pallets/creditcoin/src/ocw/rpc.rs
+++ b/pallets/creditcoin/src/ocw/rpc.rs
@@ -342,6 +342,11 @@ pub fn eth_get_block_by_number(
 	rpc_req.send(rpc_url)
 }
 
+pub fn eth_chain_id(rpc_url: &str) -> OffchainResult<U64, RpcError> {
+	let rpc_req = JsonRpcRequest::new("eth_chainId", None);
+	rpc_req.send(rpc_url)
+}
+
 #[cfg(test)]
 mod tests {
 	#[test]

--- a/pallets/creditcoin/src/ocw/tasks/collect_coins.rs
+++ b/pallets/creditcoin/src/ocw/tasks/collect_coins.rs
@@ -6,7 +6,7 @@ use crate::ocw::{
 
 use crate::pallet::{Config, Pallet};
 use crate::{
-	types::{Blockchain, UnverifiedCollectedCoins},
+	types::{OldBlockchain, UnverifiedCollectedCoins},
 	ExternalAddress, ExternalAmount,
 };
 use sp_runtime::SaturatedConversion;
@@ -18,7 +18,7 @@ use ethereum_types::{H160, U64};
 use frame_support::ensure;
 use hex_literal::hex;
 
-pub(crate) const CONTRACT_CHAIN: Blockchain = Blockchain::Ethereum;
+pub(crate) const CONTRACT_CHAIN: OldBlockchain = OldBlockchain::Ethereum;
 const CONTRACT_ADDRESS: H160 = sp_core::H160(hex!("a3EE21C306A700E682AbCdfe9BaA6A08F3820419"));
 const BURN_SELECTOR: [u8; 4] = hex!("42966c68");
 

--- a/pallets/creditcoin/src/ocw/tasks/collect_coins.rs
+++ b/pallets/creditcoin/src/ocw/tasks/collect_coins.rs
@@ -1,14 +1,14 @@
-use crate::ocw::{
-	errors::{VerificationFailureCause, VerificationResult},
-	rpc::{self, EthTransaction, EthTransactionReceipt},
-	OffchainResult, ETH_CONFIRMATIONS,
+use crate::{
+	ocw::{
+		errors::{VerificationFailureCause, VerificationResult},
+		rpc::{self, EthTransaction, EthTransactionReceipt},
+		OffchainResult, ETH_CONFIRMATIONS,
+	},
+	Blockchain,
 };
 
 use crate::pallet::{Config, Pallet};
-use crate::{
-	types::{OldBlockchain, UnverifiedCollectedCoins},
-	ExternalAddress, ExternalAmount,
-};
+use crate::{types::UnverifiedCollectedCoins, ExternalAddress, ExternalAmount};
 use sp_runtime::SaturatedConversion;
 #[cfg_attr(feature = "std", allow(unused_imports))]
 use sp_std::prelude::*;
@@ -18,7 +18,7 @@ use ethereum_types::{H160, U64};
 use frame_support::ensure;
 use hex_literal::hex;
 
-pub(crate) const CONTRACT_CHAIN: OldBlockchain = OldBlockchain::Ethereum;
+pub(crate) const CONTRACT_CHAIN: Blockchain = Blockchain::ETHEREUM;
 const CONTRACT_ADDRESS: H160 = sp_core::H160(hex!("a3EE21C306A700E682AbCdfe9BaA6A08F3820419"));
 const BURN_SELECTOR: [u8; 4] = hex!("42966c68");
 

--- a/pallets/creditcoin/src/ocw/tasks/verify_transfer.rs
+++ b/pallets/creditcoin/src/ocw/tasks/verify_transfer.rs
@@ -14,8 +14,8 @@ use crate::{
 		OffchainError, OffchainResult, VerificationFailureCause, VerificationResult,
 		ETH_CONFIRMATIONS,
 	},
-	Blockchain, Config, ExternalAddress, ExternalAmount, ExternalTxId, Id, Transfer, TransferKind,
-	UnverifiedTransfer, DealOrderId,
+	Blockchain, Config, DealOrderId, ExternalAddress, ExternalAmount, ExternalTxId, Id,
+	LegacyTransferKind, Transfer, UnverifiedTransfer,
 };
 
 pub(crate) fn ethless_transfer_function_abi() -> Function {
@@ -115,7 +115,7 @@ impl<T: Config> crate::Pallet<T> {
 		} = transfer;
 		log::debug!("verifying OCW transfer");
 		match kind {
-			TransferKind::Ethless(contract) => Self::verify_ethless_transfer(
+			LegacyTransferKind::Ethless(contract) => Self::verify_ethless_transfer(
 				blockchain,
 				contract,
 				from,
@@ -124,9 +124,9 @@ impl<T: Config> crate::Pallet<T> {
 				amount,
 				tx,
 			),
-			TransferKind::Native | TransferKind::Erc20(_) | TransferKind::Other(_) => {
-				Err(VerificationFailureCause::UnsupportedMethod.into())
-			},
+			LegacyTransferKind::Native
+			| LegacyTransferKind::Erc20(_)
+			| LegacyTransferKind::Other(_) => Err(VerificationFailureCause::UnsupportedMethod.into()),
 		}
 	}
 

--- a/pallets/creditcoin/src/ocw/tasks/verify_transfer.rs
+++ b/pallets/creditcoin/src/ocw/tasks/verify_transfer.rs
@@ -14,8 +14,8 @@ use crate::{
 		OffchainError, OffchainResult, VerificationFailureCause, VerificationResult,
 		ETH_CONFIRMATIONS,
 	},
-	Config, DealOrderId, ExternalAddress, ExternalAmount, ExternalTxId, Id, LegacyTransferKind,
-	OldBlockchain, Transfer, UnverifiedTransfer,
+	Blockchain, Config, DealOrderId, ExternalAddress, ExternalAmount, ExternalTxId, Id,
+	LegacyTransferKind, Transfer, UnverifiedTransfer,
 };
 
 pub(crate) fn ethless_transfer_function_abi() -> Function {
@@ -131,7 +131,7 @@ impl<T: Config> crate::Pallet<T> {
 	}
 
 	pub fn verify_ethless_transfer(
-		blockchain: &OldBlockchain,
+		blockchain: &Blockchain,
 		contract_address: &ExternalAddress,
 		from: &ExternalAddress,
 		to: &ExternalAddress,

--- a/pallets/creditcoin/src/ocw/tasks/verify_transfer.rs
+++ b/pallets/creditcoin/src/ocw/tasks/verify_transfer.rs
@@ -14,8 +14,8 @@ use crate::{
 		OffchainError, OffchainResult, VerificationFailureCause, VerificationResult,
 		ETH_CONFIRMATIONS,
 	},
-	Blockchain, Config, ExternalAddress, ExternalAmount, ExternalTxId, Id, OrderId, Transfer,
-	TransferKind, UnverifiedTransfer,
+	Blockchain, Config, ExternalAddress, ExternalAmount, ExternalTxId, Id, Transfer, TransferKind,
+	UnverifiedTransfer, DealOrderId,
 };
 
 pub(crate) fn ethless_transfer_function_abi() -> Function {
@@ -108,16 +108,22 @@ impl<T: Config> crate::Pallet<T> {
 		transfer: &UnverifiedTransfer<T::AccountId, BlockNumberFor<T>, T::Hash, T::Moment>,
 	) -> VerificationResult<Option<T::Moment>> {
 		let UnverifiedTransfer {
-			transfer: Transfer { blockchain, kind, order_id, amount, tx_id: tx, .. },
+			transfer: Transfer { blockchain, kind, deal_order_id, amount, tx_id: tx, .. },
 			from_external: from,
 			to_external: to,
 			..
 		} = transfer;
 		log::debug!("verifying OCW transfer");
 		match kind {
-			TransferKind::Ethless(contract) => {
-				Self::verify_ethless_transfer(blockchain, contract, from, to, order_id, amount, tx)
-			},
+			TransferKind::Ethless(contract) => Self::verify_ethless_transfer(
+				blockchain,
+				contract,
+				from,
+				to,
+				deal_order_id,
+				amount,
+				tx,
+			),
 			TransferKind::Native | TransferKind::Erc20(_) | TransferKind::Other(_) => {
 				Err(VerificationFailureCause::UnsupportedMethod.into())
 			},
@@ -129,7 +135,7 @@ impl<T: Config> crate::Pallet<T> {
 		contract_address: &ExternalAddress,
 		from: &ExternalAddress,
 		to: &ExternalAddress,
-		order_id: &OrderId<BlockNumberFor<T>, T::Hash>,
+		deal_order_id: &DealOrderId<BlockNumberFor<T>, T::Hash>,
 		amount: &ExternalAmount,
 		tx_id: &ExternalTxId,
 	) -> VerificationResult<Option<T::Moment>> {
@@ -159,7 +165,7 @@ impl<T: Config> crate::Pallet<T> {
 			&tx_receipt,
 			&tx,
 			eth_tip,
-			T::HashIntoNonce::from(order_id.hash()),
+			T::HashIntoNonce::from(deal_order_id.hash()),
 		)?;
 
 		let timestamp = if let Some(num) = tx_block_num {

--- a/pallets/creditcoin/src/ocw/tasks/verify_transfer.rs
+++ b/pallets/creditcoin/src/ocw/tasks/verify_transfer.rs
@@ -14,8 +14,8 @@ use crate::{
 		OffchainError, OffchainResult, VerificationFailureCause, VerificationResult,
 		ETH_CONFIRMATIONS,
 	},
-	Blockchain, Config, DealOrderId, ExternalAddress, ExternalAmount, ExternalTxId, Id,
-	LegacyTransferKind, Transfer, UnverifiedTransfer,
+	Config, DealOrderId, ExternalAddress, ExternalAmount, ExternalTxId, Id, LegacyTransferKind,
+	OldBlockchain, Transfer, UnverifiedTransfer,
 };
 
 pub(crate) fn ethless_transfer_function_abi() -> Function {
@@ -131,7 +131,7 @@ impl<T: Config> crate::Pallet<T> {
 	}
 
 	pub fn verify_ethless_transfer(
-		blockchain: &Blockchain,
+		blockchain: &OldBlockchain,
 		contract_address: &ExternalAddress,
 		from: &ExternalAddress,
 		to: &ExternalAddress,

--- a/pallets/creditcoin/src/ocw/tasks/verify_transfer.rs
+++ b/pallets/creditcoin/src/ocw/tasks/verify_transfer.rs
@@ -14,8 +14,8 @@ use crate::{
 		OffchainError, OffchainResult, VerificationFailureCause, VerificationResult,
 		ETH_CONFIRMATIONS,
 	},
-	Blockchain, Config, DealOrderId, ExternalAddress, ExternalAmount, ExternalTxId, Id,
-	LegacyTransferKind, Transfer, UnverifiedTransfer,
+	Blockchain, Config, Currency, DealOrderId, EvmChainId, EvmInfo, ExternalAddress,
+	ExternalAmount, ExternalTxId, Id, LegacyTransferKind, Transfer, UnverifiedTransfer,
 };
 
 pub(crate) fn ethless_transfer_function_abi() -> Function {
@@ -103,30 +103,59 @@ pub(in crate::ocw) fn validate_ethless_transfer(
 	Ok(())
 }
 
+fn verify_chain_id(rpc_url: &str, expected: EvmChainId) -> VerificationResult<()> {
+	let id = rpc::eth_chain_id(rpc_url)?.as_u64();
+	if id == expected.as_u64() {
+		Ok(())
+	} else {
+		Err(OffchainError::IncorrectChainId)
+	}
+}
+
 impl<T: Config> crate::Pallet<T> {
 	pub fn verify_transfer_ocw(
 		transfer: &UnverifiedTransfer<T::AccountId, BlockNumberFor<T>, T::Hash, T::Moment>,
 	) -> VerificationResult<Option<T::Moment>> {
 		let UnverifiedTransfer {
-			transfer: Transfer { blockchain, kind, deal_order_id, amount, tx_id: tx, .. },
+			transfer: Transfer { blockchain, deal_order_id, amount, tx_id: tx, .. },
 			from_external: from,
 			to_external: to,
+			currency_to_check,
 			..
 		} = transfer;
 		log::debug!("verifying OCW transfer");
-		match kind {
-			LegacyTransferKind::Ethless(contract) => Self::verify_ethless_transfer(
-				blockchain,
-				contract,
-				from,
-				to,
-				deal_order_id,
-				amount,
-				tx,
-			),
-			LegacyTransferKind::Native
-			| LegacyTransferKind::Erc20(_)
-			| LegacyTransferKind::Other(_) => Err(VerificationFailureCause::UnsupportedMethod.into()),
+		match currency_to_check {
+			crate::CurrencyOrLegacyTransferKind::TransferKind(kind) => match kind {
+				LegacyTransferKind::Ethless(contract) => Self::verify_ethless_transfer(
+					blockchain,
+					contract,
+					from,
+					to,
+					deal_order_id,
+					amount,
+					tx,
+					None,
+				),
+				LegacyTransferKind::Native
+				| LegacyTransferKind::Erc20(_)
+				| LegacyTransferKind::Other(_) => Err(VerificationFailureCause::UnsupportedMethod.into()),
+			},
+			crate::CurrencyOrLegacyTransferKind::Currency(currency) => match currency {
+				Currency::Evm(currency_type, EvmInfo { chain_id }) => match currency_type {
+					crate::EvmCurrencyType::SmartContract(contract, _) => {
+						Self::verify_ethless_transfer(
+							blockchain,
+							contract,
+							from,
+							to,
+							deal_order_id,
+							amount,
+							tx,
+							Some(*chain_id),
+						)
+					},
+				},
+			},
 		}
 	}
 
@@ -138,8 +167,14 @@ impl<T: Config> crate::Pallet<T> {
 		deal_order_id: &DealOrderId<BlockNumberFor<T>, T::Hash>,
 		amount: &ExternalAmount,
 		tx_id: &ExternalTxId,
+		chain_id: Option<EvmChainId>,
 	) -> VerificationResult<Option<T::Moment>> {
 		let rpc_url = blockchain.rpc_url()?;
+
+		if let Some(chain_id) = chain_id {
+			verify_chain_id(&rpc_url, chain_id)?;
+		}
+
 		let tx = rpc::eth_get_transaction(tx_id, &rpc_url).map_err(|e| {
 			if let RpcError::NoResult = e {
 				OffchainError::InvalidTask(VerificationFailureCause::TaskNonexistent)

--- a/pallets/creditcoin/src/ocw/tests.rs
+++ b/pallets/creditcoin/src/ocw/tests.rs
@@ -337,13 +337,24 @@ fn blockchain_rpc_url_non_utf8() {
 }
 
 #[test]
+fn blockchain_rpc_url_works() {
+	ExtBuilder::default().build_offchain_and_execute(|| {
+		set_rpc_uri(&Blockchain::ETHEREUM, "rpcurl");
+
+		assert_eq!(Blockchain::ETHEREUM.rpc_url().unwrap(), "rpcurl");
+	})
+}
+
+#[test]
 fn blockchain_rpc_url_invalid_scale() {
 	ExtBuilder::default().build_offchain_and_execute(|| {
-		let rpc_url_storage = StorageValueRef::persistent(b"ethereum-rpc-uri");
+		let eth = Blockchain::ETHEREUM;
+		let key = eth.rpc_key();
+		let rpc_url_storage = StorageValueRef::persistent(&key);
 		rpc_url_storage.set(&[0x80]);
 
 		assert_matches!(
-			dbg!(Blockchain::ETHEREUM.rpc_url()).unwrap_err(),
+			eth.rpc_url().unwrap_err(),
 			RpcUrlError::StorageFailure(StorageRetrievalError::Undecodable)
 		);
 	});

--- a/pallets/creditcoin/src/ocw/tests.rs
+++ b/pallets/creditcoin/src/ocw/tests.rs
@@ -528,6 +528,8 @@ fn offchain_worker_logs_error_when_transfer_validation_errors() {
 			.unwrap(),
 		);
 
+		requests.mock_chain_id(&mut state.write());
+
 		requests.mock_get_transaction(&mut state.write());
 
 		crate::mock::roll_by_with_ocw(1);
@@ -596,13 +598,11 @@ fn set_up_verify_transfer_env(
 	let unverified = make_unverified_transfer(transfer.clone());
 
 	if register_transfer {
-		let contract = get_mock_contract().hex_to_address();
-
 		crate::DealOrders::<TestRuntime>::insert_id(deal_order_id.clone(), deal_order);
 
-		assert_ok!(crate::mock::Creditcoin::register_funding_transfer_legacy(
+		assert_ok!(crate::mock::Creditcoin::register_funding_transfer(
 			crate::mock::Origin::signed(test_info.lender.account_id),
-			LegacyTransferKind::Ethless(contract),
+			EvmTransferKind::Ethless.into(),
 			deal_order_id,
 			transfer.tx_id,
 		));
@@ -983,8 +983,12 @@ fn duplicate_retry_fail_and_succeed() {
 		let blockchain = Blockchain::RINKEBY;
 
 		// mocks for when we expect failure
-		MockedRpcRequests::new(dummy_url, &tx_hash, &tx_block_num, &*ETHLESS_RESPONSES)
-			.mock_get_block_number(&mut state.write());
+		{
+			let mut state = state.write();
+			MockedRpcRequests::new(dummy_url, &tx_hash, &tx_block_num, &*ETHLESS_RESPONSES)
+				.mock_chain_id(&mut state)
+				.mock_get_block_number(&mut state);
+		}
 		// mocks for when we expect success
 		MockedRpcRequests::new(dummy_url, &tx_hash, &tx_block_num, &*ETHLESS_RESPONSES)
 			.mock_all(&mut state.write());
@@ -992,17 +996,20 @@ fn duplicate_retry_fail_and_succeed() {
 		set_rpc_uri(&Blockchain::RINKEBY, &dummy_url);
 
 		let loan_amount = get_mock_amount();
-		let terms = LoanTerms { amount: loan_amount, ..Default::default() };
+		let currency = crate::tests::ethless_currency(contract.clone());
 
-		let test_info =
-			TestInfo { blockchain: blockchain.clone(), loan_terms: terms, ..Default::default() };
+		let test_info = TestInfo::with_currency(currency);
+		let test_info = TestInfo {
+			loan_terms: LoanTerms { amount: loan_amount, ..test_info.loan_terms },
+			..test_info
+		};
 		let (_, deal_order_id) = test_info.create_deal_order();
 		let lender = test_info.lender.account_id.clone();
 
 		// test that we get a "fail_transfer" tx when verification fails
-		assert_ok!(Creditcoin::<TestRuntime>::register_funding_transfer_legacy(
+		assert_ok!(Creditcoin::<TestRuntime>::register_funding_transfer(
 			Origin::signed(lender.clone()),
-			LegacyTransferKind::Ethless(contract.clone()),
+			EvmTransferKind::Ethless.into(),
 			deal_order_id.clone(),
 			tx_hash.hex_to_address(),
 		));

--- a/pallets/creditcoin/src/ocw/tests.rs
+++ b/pallets/creditcoin/src/ocw/tests.rs
@@ -24,7 +24,7 @@ use crate::{
 	ocw::tasks::StorageLock,
 	tests::{RefstrExt, TestInfo},
 	types::{DoubleMapExt, TransferId},
-	Blockchain, ExternalAddress, Id, LoanTerms, OrderId, TransferKind, Transfers,
+	Blockchain, ExternalAddress, Id, LegacyTransferKind, LoanTerms,
 };
 use alloc::sync::Arc;
 use assert_matches::assert_matches;
@@ -351,36 +351,36 @@ fn blockchain_rpc_url_invalid_scale() {
 
 #[test]
 fn blockchain_supports_etherlike() {
-	assert!(Blockchain::Ethereum.supports(&crate::TransferKind::Native));
-	assert!(Blockchain::Rinkeby.supports(&crate::TransferKind::Native));
-	assert!(Blockchain::Luniverse.supports(&crate::TransferKind::Native));
-	assert!(Blockchain::Ethereum.supports(&crate::TransferKind::Erc20(default())));
-	assert!(Blockchain::Rinkeby.supports(&crate::TransferKind::Erc20(default())));
-	assert!(Blockchain::Luniverse.supports(&crate::TransferKind::Erc20(default())));
-	assert!(Blockchain::Ethereum.supports(&crate::TransferKind::Ethless(default())));
-	assert!(Blockchain::Rinkeby.supports(&crate::TransferKind::Ethless(default())));
-	assert!(Blockchain::Luniverse.supports(&crate::TransferKind::Ethless(default())));
+	assert!(Blockchain::Ethereum.supports(&crate::LegacyTransferKind::Native));
+	assert!(Blockchain::Rinkeby.supports(&crate::LegacyTransferKind::Native));
+	assert!(Blockchain::Luniverse.supports(&crate::LegacyTransferKind::Native));
+	assert!(Blockchain::Ethereum.supports(&crate::LegacyTransferKind::Erc20(default())));
+	assert!(Blockchain::Rinkeby.supports(&crate::LegacyTransferKind::Erc20(default())));
+	assert!(Blockchain::Luniverse.supports(&crate::LegacyTransferKind::Erc20(default())));
+	assert!(Blockchain::Ethereum.supports(&crate::LegacyTransferKind::Ethless(default())));
+	assert!(Blockchain::Rinkeby.supports(&crate::LegacyTransferKind::Ethless(default())));
+	assert!(Blockchain::Luniverse.supports(&crate::LegacyTransferKind::Ethless(default())));
 }
 
 #[test]
 fn blockchain_unsupported() {
-	assert!(!Blockchain::Other(default()).supports(&crate::TransferKind::Native));
-	assert!(!Blockchain::Other(default()).supports(&crate::TransferKind::Erc20(default())));
-	assert!(!Blockchain::Other(default()).supports(&crate::TransferKind::Ethless(default())));
-	assert!(!Blockchain::Other(default()).supports(&crate::TransferKind::Other(default())));
+	assert!(!Blockchain::Other(default()).supports(&crate::LegacyTransferKind::Native));
+	assert!(!Blockchain::Other(default()).supports(&crate::LegacyTransferKind::Erc20(default())));
+	assert!(!Blockchain::Other(default()).supports(&crate::LegacyTransferKind::Ethless(default())));
+	assert!(!Blockchain::Other(default()).supports(&crate::LegacyTransferKind::Other(default())));
 
-	assert!(!Blockchain::Ethereum.supports(&crate::TransferKind::Other(default())));
-	assert!(!Blockchain::Rinkeby.supports(&crate::TransferKind::Other(default())));
-	assert!(!Blockchain::Luniverse.supports(&crate::TransferKind::Other(default())));
-	assert!(!Blockchain::Bitcoin.supports(&crate::TransferKind::Other(default())));
+	assert!(!Blockchain::Ethereum.supports(&crate::LegacyTransferKind::Other(default())));
+	assert!(!Blockchain::Rinkeby.supports(&crate::LegacyTransferKind::Other(default())));
+	assert!(!Blockchain::Luniverse.supports(&crate::LegacyTransferKind::Other(default())));
+	assert!(!Blockchain::Bitcoin.supports(&crate::LegacyTransferKind::Other(default())));
 
-	assert!(!Blockchain::Bitcoin.supports(&crate::TransferKind::Erc20(default())));
-	assert!(!Blockchain::Bitcoin.supports(&crate::TransferKind::Ethless(default())));
+	assert!(!Blockchain::Bitcoin.supports(&crate::LegacyTransferKind::Erc20(default())));
+	assert!(!Blockchain::Bitcoin.supports(&crate::LegacyTransferKind::Ethless(default())));
 }
 
 #[test]
 fn blockchain_supports_bitcoin_native_transfer() {
-	assert!(Blockchain::Bitcoin.supports(&crate::TransferKind::Native));
+	assert!(Blockchain::Bitcoin.supports(&crate::LegacyTransferKind::Native));
 }
 
 #[test]
@@ -449,7 +449,7 @@ fn verify_transfer_ocw_fails_on_unsupported_method() {
 			deal_order.terms.amount,
 			&deal_order_id,
 			"0xfafafa",
-			crate::TransferKind::Native,
+			crate::LegacyTransferKind::Native,
 		);
 		let unverified = make_unverified_transfer(transfer.clone());
 		assert_matches!(
@@ -457,14 +457,14 @@ fn verify_transfer_ocw_fails_on_unsupported_method() {
 			Err(OffchainError::InvalidTask(UnsupportedMethod))
 		);
 
-		transfer.kind = crate::TransferKind::Erc20(ExternalAddress::default());
+		transfer.kind = crate::LegacyTransferKind::Erc20(ExternalAddress::default());
 		let unverified = make_unverified_transfer(transfer.clone());
 		assert_matches!(
 			crate::Pallet::<TestRuntime>::verify_transfer_ocw(&unverified),
 			Err(OffchainError::InvalidTask(UnsupportedMethod))
 		);
 
-		transfer.kind = crate::TransferKind::Other(ExternalAddress::default());
+		transfer.kind = crate::LegacyTransferKind::Other(ExternalAddress::default());
 		let unverified = make_unverified_transfer(transfer);
 		assert_matches!(
 			crate::Pallet::<TestRuntime>::verify_transfer_ocw(&unverified),
@@ -485,7 +485,7 @@ fn verify_transfer_ocw_returns_err() {
 			deal_order.terms.amount,
 			&deal_order_id,
 			"0xfafafa",
-			crate::TransferKind::Ethless(ETHLESS_CONTRACT_ADDR.to_external_address()),
+			crate::LegacyTransferKind::Ethless(ETHLESS_CONTRACT_ADDR.to_external_address()),
 		);
 		let unverified = make_unverified_transfer(transfer);
 
@@ -579,7 +579,7 @@ fn set_up_verify_transfer_env(
 		deal_order.terms.amount,
 		&deal_order_id,
 		crate::mock::get_mock_tx_hash(),
-		crate::TransferKind::Ethless(ETHLESS_CONTRACT_ADDR.to_external_address()),
+		crate::LegacyTransferKind::Ethless(ETHLESS_CONTRACT_ADDR.to_external_address()),
 	);
 	let unverified = make_unverified_transfer(transfer.clone());
 
@@ -590,7 +590,7 @@ fn set_up_verify_transfer_env(
 
 		assert_ok!(crate::mock::Creditcoin::register_funding_transfer(
 			crate::mock::Origin::signed(test_info.lender.account_id),
-			TransferKind::Ethless(contract),
+			LegacyTransferKind::Ethless(contract),
 			deal_order_id,
 			transfer.tx_id,
 		));
@@ -749,7 +749,7 @@ fn verify_transfer_get_block_invalid_address() {
 
 		mock_requests(&state);
 
-		unverified.transfer.kind = TransferKind::Ethless(default());
+		unverified.transfer.kind = LegacyTransferKind::Ethless(default());
 
 		assert_matches!(
 			crate::Pallet::<TestRuntime>::verify_transfer_ocw(&unverified),

--- a/pallets/creditcoin/src/ocw/tests.rs
+++ b/pallets/creditcoin/src/ocw/tests.rs
@@ -424,6 +424,9 @@ fn make_unverified_transfer(transfer: MockTransfer) -> MockUnverifiedTransfer {
 		to_external: ExternalAddress::try_from((*ETHLESS_TO_ADDR).0.to_vec()).unwrap(),
 		from_external: ExternalAddress::try_from((*ETHLESS_FROM_ADDR).0.to_vec()).unwrap(),
 		deadline: 10000,
+		currency_to_check: crate::CurrencyOrLegacyTransferKind::TransferKind(
+			LegacyTransferKind::Native,
+		),
 	}
 }
 

--- a/pallets/creditcoin/src/ocw/tests.rs
+++ b/pallets/creditcoin/src/ocw/tests.rs
@@ -1040,7 +1040,7 @@ fn duplicate_retry_fail_and_succeed() {
 
 		assert_ok!(Creditcoin::<TestRuntime>::register_funding_transfer_legacy(
 			Origin::signed(lender.clone()),
-			LegacyTransferKind::Ethless(contract.clone()),
+			LegacyTransferKind::Ethless(contract),
 			fake_deal_order_id.clone(),
 			tx_hash.hex_to_address(),
 		));

--- a/pallets/creditcoin/src/ocw/tests.rs
+++ b/pallets/creditcoin/src/ocw/tests.rs
@@ -24,7 +24,7 @@ use crate::{
 	tests::{RefstrExt, TestInfo},
 	types::{DoubleMapExt, TransferId},
 	Blockchain, CurrencyOrLegacyTransferKind, ExternalAddress, Id, LegacyTransferKind, LoanTerms,
-	TransferKind,
+	TransferKind, Transfers,
 };
 use crate::{
 	ocw::tasks::collect_coins::{tests::TX_HASH, CONTRACT_CHAIN},

--- a/pallets/creditcoin/src/ocw/tests.rs
+++ b/pallets/creditcoin/src/ocw/tests.rs
@@ -600,7 +600,7 @@ fn set_up_verify_transfer_env(
 
 		crate::DealOrders::<TestRuntime>::insert_id(deal_order_id.clone(), deal_order);
 
-		assert_ok!(crate::mock::Creditcoin::register_funding_transfer(
+		assert_ok!(crate::mock::Creditcoin::register_funding_transfer_legacy(
 			crate::mock::Origin::signed(test_info.lender.account_id),
 			LegacyTransferKind::Ethless(contract),
 			deal_order_id,
@@ -920,7 +920,7 @@ fn ocw_retries() {
 		let deal_order_id = adjust_deal_order_to_nonce(&deal_order_id, get_mock_nonce());
 
 		let lender = test_info.lender.account_id;
-		assert_ok!(Creditcoin::<TestRuntime>::register_funding_transfer(
+		assert_ok!(Creditcoin::<TestRuntime>::register_funding_transfer_legacy(
 			Origin::signed(lender),
 			LegacyTransferKind::Ethless(contract),
 			deal_order_id,
@@ -1000,7 +1000,7 @@ fn duplicate_retry_fail_and_succeed() {
 		let lender = test_info.lender.account_id.clone();
 
 		// test that we get a "fail_transfer" tx when verification fails
-		assert_ok!(Creditcoin::<TestRuntime>::register_funding_transfer(
+		assert_ok!(Creditcoin::<TestRuntime>::register_funding_transfer_legacy(
 			Origin::signed(lender.clone()),
 			LegacyTransferKind::Ethless(contract.clone()),
 			deal_order_id.clone(),
@@ -1031,7 +1031,7 @@ fn duplicate_retry_fail_and_succeed() {
 		// verification logic is happy
 		let fake_deal_order_id = adjust_deal_order_to_nonce(&deal_order_id, get_mock_nonce());
 
-		assert_ok!(Creditcoin::<TestRuntime>::register_funding_transfer(
+		assert_ok!(Creditcoin::<TestRuntime>::register_funding_transfer_legacy(
 			Origin::signed(lender.clone()),
 			LegacyTransferKind::Ethless(contract.clone()),
 			fake_deal_order_id.clone(),

--- a/pallets/creditcoin/src/ocw/tests.rs
+++ b/pallets/creditcoin/src/ocw/tests.rs
@@ -24,7 +24,7 @@ use crate::{
 	ocw::tasks::StorageLock,
 	tests::{RefstrExt, TestInfo},
 	types::{DoubleMapExt, TransferId},
-	Blockchain, ExternalAddress, Id, LegacyTransferKind, LoanTerms,
+	ExternalAddress, Id, LegacyTransferKind, LoanTerms, OldBlockchain,
 };
 use alloc::sync::Arc;
 use assert_matches::assert_matches;
@@ -323,16 +323,16 @@ fn ethless_transfer_pending() {
 #[test]
 fn blockchain_rpc_url_missing() {
 	ExtBuilder::default().build_offchain_and_execute(|| {
-		assert_eq!(Blockchain::Ethereum.rpc_url(), Err(RpcUrlError::NoValue));
+		assert_eq!(OldBlockchain::Ethereum.rpc_url(), Err(RpcUrlError::NoValue));
 	})
 }
 
 #[test]
 fn blockchain_rpc_url_non_utf8() {
 	ExtBuilder::default().build_offchain_and_execute(|| {
-		set_rpc_uri(&Blockchain::Ethereum, &[0x80]);
+		set_rpc_uri(&OldBlockchain::Ethereum, &[0x80]);
 
-		assert_matches!(Blockchain::Ethereum.rpc_url().unwrap_err(), RpcUrlError::InvalidUrl(_));
+		assert_matches!(OldBlockchain::Ethereum.rpc_url().unwrap_err(), RpcUrlError::InvalidUrl(_));
 	});
 }
 
@@ -343,7 +343,7 @@ fn blockchain_rpc_url_invalid_scale() {
 		rpc_url_storage.set(&[0x80]);
 
 		assert_matches!(
-			dbg!(Blockchain::Ethereum.rpc_url()).unwrap_err(),
+			dbg!(OldBlockchain::Ethereum.rpc_url()).unwrap_err(),
 			RpcUrlError::StorageFailure(StorageRetrievalError::Undecodable)
 		);
 	});
@@ -351,36 +351,38 @@ fn blockchain_rpc_url_invalid_scale() {
 
 #[test]
 fn blockchain_supports_etherlike() {
-	assert!(Blockchain::Ethereum.supports(&crate::LegacyTransferKind::Native));
-	assert!(Blockchain::Rinkeby.supports(&crate::LegacyTransferKind::Native));
-	assert!(Blockchain::Luniverse.supports(&crate::LegacyTransferKind::Native));
-	assert!(Blockchain::Ethereum.supports(&crate::LegacyTransferKind::Erc20(default())));
-	assert!(Blockchain::Rinkeby.supports(&crate::LegacyTransferKind::Erc20(default())));
-	assert!(Blockchain::Luniverse.supports(&crate::LegacyTransferKind::Erc20(default())));
-	assert!(Blockchain::Ethereum.supports(&crate::LegacyTransferKind::Ethless(default())));
-	assert!(Blockchain::Rinkeby.supports(&crate::LegacyTransferKind::Ethless(default())));
-	assert!(Blockchain::Luniverse.supports(&crate::LegacyTransferKind::Ethless(default())));
+	assert!(OldBlockchain::Ethereum.supports(&crate::LegacyTransferKind::Native));
+	assert!(OldBlockchain::Rinkeby.supports(&crate::LegacyTransferKind::Native));
+	assert!(OldBlockchain::Luniverse.supports(&crate::LegacyTransferKind::Native));
+	assert!(OldBlockchain::Ethereum.supports(&crate::LegacyTransferKind::Erc20(default())));
+	assert!(OldBlockchain::Rinkeby.supports(&crate::LegacyTransferKind::Erc20(default())));
+	assert!(OldBlockchain::Luniverse.supports(&crate::LegacyTransferKind::Erc20(default())));
+	assert!(OldBlockchain::Ethereum.supports(&crate::LegacyTransferKind::Ethless(default())));
+	assert!(OldBlockchain::Rinkeby.supports(&crate::LegacyTransferKind::Ethless(default())));
+	assert!(OldBlockchain::Luniverse.supports(&crate::LegacyTransferKind::Ethless(default())));
 }
 
 #[test]
 fn blockchain_unsupported() {
-	assert!(!Blockchain::Other(default()).supports(&crate::LegacyTransferKind::Native));
-	assert!(!Blockchain::Other(default()).supports(&crate::LegacyTransferKind::Erc20(default())));
-	assert!(!Blockchain::Other(default()).supports(&crate::LegacyTransferKind::Ethless(default())));
-	assert!(!Blockchain::Other(default()).supports(&crate::LegacyTransferKind::Other(default())));
+	assert!(!OldBlockchain::Other(default()).supports(&crate::LegacyTransferKind::Native));
+	assert!(!OldBlockchain::Other(default()).supports(&crate::LegacyTransferKind::Erc20(default())));
+	assert!(
+		!OldBlockchain::Other(default()).supports(&crate::LegacyTransferKind::Ethless(default()))
+	);
+	assert!(!OldBlockchain::Other(default()).supports(&crate::LegacyTransferKind::Other(default())));
 
-	assert!(!Blockchain::Ethereum.supports(&crate::LegacyTransferKind::Other(default())));
-	assert!(!Blockchain::Rinkeby.supports(&crate::LegacyTransferKind::Other(default())));
-	assert!(!Blockchain::Luniverse.supports(&crate::LegacyTransferKind::Other(default())));
-	assert!(!Blockchain::Bitcoin.supports(&crate::LegacyTransferKind::Other(default())));
+	assert!(!OldBlockchain::Ethereum.supports(&crate::LegacyTransferKind::Other(default())));
+	assert!(!OldBlockchain::Rinkeby.supports(&crate::LegacyTransferKind::Other(default())));
+	assert!(!OldBlockchain::Luniverse.supports(&crate::LegacyTransferKind::Other(default())));
+	assert!(!OldBlockchain::Bitcoin.supports(&crate::LegacyTransferKind::Other(default())));
 
-	assert!(!Blockchain::Bitcoin.supports(&crate::LegacyTransferKind::Erc20(default())));
-	assert!(!Blockchain::Bitcoin.supports(&crate::LegacyTransferKind::Ethless(default())));
+	assert!(!OldBlockchain::Bitcoin.supports(&crate::LegacyTransferKind::Erc20(default())));
+	assert!(!OldBlockchain::Bitcoin.supports(&crate::LegacyTransferKind::Ethless(default())));
 }
 
 #[test]
 fn blockchain_supports_bitcoin_native_transfer() {
-	assert!(Blockchain::Bitcoin.supports(&crate::LegacyTransferKind::Native));
+	assert!(OldBlockchain::Bitcoin.supports(&crate::LegacyTransferKind::Native));
 }
 
 #[test]
@@ -388,7 +390,7 @@ fn offchain_signed_tx_works() {
 	let mut ext = ExtBuilder::default();
 	let acct_pubkey = ext.generate_authority();
 	let acct = AccountId::from(acct_pubkey.into_account().0);
-	let transfer_id = crate::TransferId::new::<crate::mock::Test>(&Blockchain::Ethereum, &[0]);
+	let transfer_id = crate::TransferId::new::<crate::mock::Test>(&OldBlockchain::Ethereum, &[0]);
 	ext.build_offchain_and_execute_with_state(|_state, pool| {
 		crate::mock::roll_to(1);
 		let call = crate::Call::<crate::mock::Test>::fail_task {
@@ -560,7 +562,7 @@ fn set_up_verify_transfer_env(
 	register_transfer: bool,
 ) -> (MockUnverifiedTransfer, MockedRpcRequests) {
 	let rpc_uri = "http://localhost:8545";
-	set_rpc_uri(&Blockchain::Rinkeby, rpc_uri);
+	set_rpc_uri(&OldBlockchain::Rinkeby, rpc_uri);
 
 	let test_info = TestInfo {
 		loan_terms: LoanTerms { amount: get_mock_amount(), ..Default::default() },

--- a/pallets/creditcoin/src/tests.rs
+++ b/pallets/creditcoin/src/tests.rs
@@ -478,6 +478,7 @@ fn verify_ethless_transfer() {
 			&deal_order_id,
 			&amount,
 			&tx_id,
+			None,
 		));
 	});
 }

--- a/pallets/creditcoin/src/tests.rs
+++ b/pallets/creditcoin/src/tests.rs
@@ -4,8 +4,8 @@ use crate::{
 	types::DoubleMapExt,
 	AddressId, AskOrder, AskOrderId, Authorities, BidOrder, BidOrderId, Blockchain, Currency,
 	CurrencyId, DealOrder, DealOrderId, DealOrders, Duration, EvmInfo, EvmTransferKind,
-	ExternalAddress, ExternalAmount, Guid, Id, LegacySighash, LoanTerms, Offer, OfferId, Transfer,
-	TransferId, TransferKind, Transfers, WeightInfo,
+	ExternalAddress, ExternalAmount, Guid, Id, LegacySighash, LegacyTransferKind, LoanTerms, Offer,
+	OfferId, Transfer, TransferId, Transfers, WeightInfo,
 };
 
 use assert_matches::assert_matches;
@@ -250,7 +250,7 @@ impl TestInfo {
 		let tx = "0xfafafa";
 		assert_ok!(Creditcoin::register_funding_transfer(
 			Origin::signed(self.lender.account_id.clone()),
-			TransferKind::Native,
+			LegacyTransferKind::Native,
 			deal_order_id.clone(),
 			tx.as_bytes().into_bounded()
 		));
@@ -266,7 +266,7 @@ impl TestInfo {
 		let amount = amount.into();
 		assert_ok!(Creditcoin::register_repayment_transfer(
 			Origin::signed(self.borrower.account_id.clone()),
-			TransferKind::Native,
+			LegacyTransferKind::Native,
 			amount,
 			deal_order_id.clone(),
 			tx.as_bytes().into_bounded()
@@ -282,7 +282,7 @@ impl TestInfo {
 		amount: impl Into<ExternalAmount>,
 		deal_order_id: &TestDealOrderId,
 		blockchain_tx_id: impl AsRef<[u8]>,
-		transfer_kind: impl Into<Option<TransferKind>>,
+		transfer_kind: impl Into<Option<LegacyTransferKind>>,
 	) -> TestTransfer {
 		let blockchain_tx_id = blockchain_tx_id.as_ref();
 		let tx = if blockchain_tx_id.starts_with(b"0x") {
@@ -294,7 +294,7 @@ impl TestInfo {
 		(
 			Transfer {
 				blockchain: self.blockchain.clone(),
-				kind: transfer_kind.into().unwrap_or(TransferKind::Native),
+				kind: transfer_kind.into().unwrap_or(LegacyTransferKind::Native),
 				from: from.address_id.clone(),
 				to: to.address_id.clone(),
 				deal_order_id: deal_order_id.clone(),
@@ -517,7 +517,7 @@ fn register_transfer_ocw_fail_to_send() {
 		with_failing_create_transaction(|| {
 			assert_ok!(Creditcoin::register_funding_transfer(
 				Origin::signed(lender.clone()),
-				TransferKind::Ethless(contract.clone()),
+				LegacyTransferKind::Ethless(contract.clone()),
 				deal_order_id.clone(),
 				tx_hash.hex_to_address(),
 			));
@@ -535,7 +535,7 @@ fn register_transfer_ocw_fail_to_send() {
 		with_failing_create_transaction(|| {
 			assert_ok!(Creditcoin::register_funding_transfer(
 				Origin::signed(lender.clone()),
-				TransferKind::Ethless(contract.clone()),
+				LegacyTransferKind::Ethless(contract.clone()),
 				fake_deal_order_id.clone(),
 				tx_hash.hex_to_address(),
 			));
@@ -1223,7 +1223,7 @@ fn fund_deal_order_should_error_when_transfer_order_id_doesnt_match_deal_order_i
 
 		assert_ok!(Creditcoin::register_funding_transfer(
 			Origin::signed(second_test_info.lender.account_id.clone()),
-			TransferKind::Ethless(contract),
+			LegacyTransferKind::Ethless(contract),
 			bogus_deal_order_id.clone(),
 			tx_hash
 		));
@@ -1255,7 +1255,7 @@ fn fund_deal_order_should_error_when_transfer_amount_doesnt_match() {
 
 		assert_ok!(Creditcoin::register_funding_transfer(
 			Origin::signed(test_info.lender.account_id.clone()),
-			TransferKind::Ethless(contract),
+			LegacyTransferKind::Ethless(contract),
 			deal_order_id.clone(),
 			tx_hash
 		));
@@ -1295,7 +1295,7 @@ fn fund_deal_order_should_error_when_transfer_sighash_doesnt_match_lender() {
 
 		assert_ok!(Creditcoin::register_funding_transfer(
 			Origin::signed(test_info.lender.account_id.clone()),
-			TransferKind::Ethless(contract),
+			LegacyTransferKind::Ethless(contract),
 			deal_order_id.clone(),
 			tx_hash
 		));
@@ -1362,7 +1362,7 @@ fn fund_deal_order_works() {
 
 		assert_ok!(Creditcoin::register_funding_transfer(
 			Origin::signed(test_info.lender.account_id.clone()),
-			TransferKind::Ethless(contract),
+			LegacyTransferKind::Ethless(contract),
 			deal_order_id.clone(),
 			tx_hash
 		));
@@ -2275,7 +2275,7 @@ fn close_deal_order_should_succeed() {
 			test_info.borrower.account_id.clone(),
 			test_info.borrower.address_id.clone(),
 			test_info.lender.address_id.clone(),
-			TransferKind::Ethless(contract),
+			LegacyTransferKind::Ethless(contract),
 			33u64.into(),
 			deal_order_id.clone(),
 			tx_hash
@@ -2483,7 +2483,7 @@ fn verify_transfer_should_work() {
 		let transfer_id = TransferId::new::<Test>(&Blockchain::Rinkeby, &tx);
 		let transfer = Transfer {
 			blockchain: test_info.blockchain.clone(),
-			kind: TransferKind::Native,
+			kind: LegacyTransferKind::Native,
 			from: test_info.lender.address_id.clone(),
 			to: test_info.borrower.address_id.clone(),
 			deal_order_id,
@@ -2682,7 +2682,7 @@ fn on_initialize_removes_expired_deals_without_transfers() {
 				let tx = format!("0xfafafa{:02}", expiration_block.clone());
 				assert_ok!(Creditcoin::register_funding_transfer(
 					Origin::signed(test_info.lender.account_id.clone()),
-					TransferKind::Native,
+					LegacyTransferKind::Native,
 					deal_order_id.clone(),
 					tx.as_bytes().into_bounded()
 				));
@@ -2727,7 +2727,7 @@ fn register_funding_transfer_should_error_when_not_signed() {
 		assert_noop!(
 			Creditcoin::register_funding_transfer(
 				Origin::none(),
-				TransferKind::Native,
+				LegacyTransferKind::Native,
 				deal_order_id,
 				tx.as_bytes().into_bounded()
 			),
@@ -2750,7 +2750,7 @@ fn register_funding_transfer_should_error_when_not_deal_order_not_found() {
 		assert_noop!(
 			Creditcoin::register_funding_transfer(
 				Origin::signed(test_info.lender.account_id),
-				TransferKind::Native,
+				LegacyTransferKind::Native,
 				deal_order_id,
 				tx.as_bytes().into_bounded()
 			),
@@ -2769,7 +2769,7 @@ fn register_repayment_transfer_should_error_when_not_signed() {
 		assert_noop!(
 			Creditcoin::register_repayment_transfer(
 				Origin::none(),
-				TransferKind::Native,
+				LegacyTransferKind::Native,
 				21u64.into(),
 				deal_order_id,
 				tx.as_bytes().into_bounded()
@@ -2793,7 +2793,7 @@ fn register_repayment_transfer_should_error_when_not_deal_order_not_found() {
 		assert_noop!(
 			Creditcoin::register_repayment_transfer(
 				Origin::signed(test_info.borrower.account_id),
-				TransferKind::Native,
+				LegacyTransferKind::Native,
 				21u64.into(),
 				deal_order_id,
 				tx.as_bytes().into_bounded()
@@ -2816,7 +2816,7 @@ fn register_transfer_internal_should_error_with_non_existent_lender_address() {
 			test_info.lender.account_id,
 			bogus_address,
 			deal_order.borrower_address_id,
-			TransferKind::Native,
+			LegacyTransferKind::Native,
 			deal_order.terms.amount,
 			deal_order_id,
 			tx.as_bytes().into_bounded(),
@@ -2840,7 +2840,7 @@ fn register_transfer_internal_should_error_with_non_existent_borrower_address() 
 			test_info.lender.account_id,
 			deal_order.lender_address_id,
 			bogus_address,
-			TransferKind::Native,
+			LegacyTransferKind::Native,
 			deal_order.terms.amount,
 			deal_order_id,
 			tx.as_bytes().into_bounded(),
@@ -2862,7 +2862,7 @@ fn register_transfer_internal_should_error_when_signer_doesnt_own_from_address()
 			test_info.lender.account_id,
 			deal_order.borrower_address_id, // should match 1st argument
 			deal_order.lender_address_id,
-			TransferKind::Native,
+			LegacyTransferKind::Native,
 			deal_order.terms.amount,
 			deal_order_id,
 			tx.as_bytes().into_bounded(),
@@ -2885,7 +2885,7 @@ fn register_transfer_internal_should_error_when_addresses_are_not_on_the_same_bl
 			test_info.lender.account_id,
 			deal_order.lender_address_id,
 			second_borrower.address_id,
-			TransferKind::Native,
+			LegacyTransferKind::Native,
 			deal_order.terms.amount,
 			deal_order_id,
 			tx.as_bytes().into_bounded(),
@@ -2908,7 +2908,7 @@ fn register_transfer_internal_should_error_when_transfer_kind_is_not_supported()
 			deal_order.lender_address_id,
 			deal_order.borrower_address_id,
 			// not supported on Blockchain::Rinkeby
-			TransferKind::Other(BoundedVec::try_from(b"other".to_vec()).unwrap()),
+			LegacyTransferKind::Other(BoundedVec::try_from(b"other".to_vec()).unwrap()),
 			deal_order.terms.amount,
 			deal_order_id,
 			tx.as_bytes().into_bounded(),
@@ -2930,7 +2930,7 @@ fn register_transfer_internal_should_error_when_transfer_is_already_registered()
 			test_info.lender.account_id,
 			deal_order.lender_address_id,
 			deal_order.borrower_address_id,
-			TransferKind::Native,
+			LegacyTransferKind::Native,
 			deal_order.terms.amount,
 			deal_order_id,
 			transfer.tx_id,

--- a/pallets/creditcoin/src/tests.rs
+++ b/pallets/creditcoin/src/tests.rs
@@ -2,10 +2,10 @@ use crate::{
 	helpers::{non_paying_error, EVMAddress, PublicToAddress},
 	mock::*,
 	types::DoubleMapExt,
-	AddressId, AskOrder, AskOrderId, Authorities, BidOrder, BidOrderId, Blockchain, Currency,
-	CurrencyId, DealOrder, DealOrderId, DealOrders, Duration, EvmInfo, EvmTransferKind,
-	ExternalAddress, ExternalAmount, Guid, Id, LegacySighash, LegacyTransferKind, LoanTerms, Offer,
-	OfferId, Transfer, TransferId, Transfers, WeightInfo,
+	AddressId, AskOrder, AskOrderId, Authorities, BidOrder, BidOrderId, Currency, CurrencyId,
+	DealOrder, DealOrderId, DealOrders, Duration, EvmInfo, EvmTransferKind, ExternalAddress,
+	ExternalAmount, Guid, Id, LegacySighash, LegacyTransferKind, LoanTerms, Offer, OfferId,
+	OldBlockchain, Transfer, TransferId, Transfers,
 };
 
 use assert_matches::assert_matches;
@@ -53,7 +53,7 @@ pub struct RegisteredAddress {
 impl RegisteredAddress {
 	pub fn from_pubkey_distinct_owner(
 		owners_account_id: AccountId,
-		blockchain: Blockchain,
+		blockchain: OldBlockchain,
 		address_key: impl Into<MultiSigner>,
 		signature: sp_core::ecdsa::Signature,
 	) -> RegisteredAddress {
@@ -76,7 +76,7 @@ impl RegisteredAddress {
 	}
 	pub fn from_pubkey(
 		public_key: impl Into<MultiSigner>,
-		blockchain: Blockchain,
+		blockchain: OldBlockchain,
 		signature: sp_core::ecdsa::Signature,
 	) -> RegisteredAddress {
 		let signer = public_key.into();
@@ -96,7 +96,7 @@ impl RegisteredAddress {
 		));
 		RegisteredAddress { account_id, address_id }
 	}
-	pub fn new(seed: &str, blockchain: Blockchain) -> RegisteredAddress {
+	pub fn new(seed: &str, blockchain: OldBlockchain) -> RegisteredAddress {
 		let (who, address, ownership_proof, _) = generate_address_with_proof(seed);
 		let address_id = AddressId::new::<Test>(&blockchain, &address);
 		assert_ok!(Creditcoin::register_address(
@@ -137,7 +137,7 @@ type TestTransfer = (Transfer<AccountId, u64, H256, u64>, TestTransferId);
 
 #[derive(Clone, Debug)]
 pub struct TestInfo {
-	pub(crate) blockchain: Blockchain,
+	pub(crate) blockchain: OldBlockchain,
 	pub(crate) loan_terms: LoanTerms,
 	pub(crate) lender: RegisteredAddress,
 	pub(crate) borrower: RegisteredAddress,
@@ -160,9 +160,9 @@ impl Default for Currency {
 
 impl Default for TestInfo {
 	fn default() -> Self {
-		let lender = RegisteredAddress::new("lender", Blockchain::Rinkeby);
-		let borrower = RegisteredAddress::new("borrower", Blockchain::Rinkeby);
-		let blockchain = Blockchain::Rinkeby;
+		let lender = RegisteredAddress::new("lender", OldBlockchain::Rinkeby);
+		let borrower = RegisteredAddress::new("borrower", OldBlockchain::Rinkeby);
+		let blockchain = OldBlockchain::Rinkeby;
 
 		let loan_terms =
 			LoanTerms { amount: ExternalAmount::from(10_000_000_u64), ..Default::default() };
@@ -290,7 +290,7 @@ impl TestInfo {
 		} else {
 			blockchain_tx_id.into_bounded()
 		};
-		let id = TransferId::new::<Test>(&Blockchain::Rinkeby, &tx);
+		let id = TransferId::new::<Test>(&OldBlockchain::Rinkeby, &tx);
 		(
 			Transfer {
 				blockchain: self.blockchain.clone(),
@@ -344,7 +344,7 @@ fn register_address_should_work() {
 		System::set_block_number(1);
 
 		let (who, address, ownership_proof, _) = generate_address_with_proof("owner");
-		let blockchain = Blockchain::Rinkeby;
+		let blockchain = OldBlockchain::Rinkeby;
 		assert_ok!(Creditcoin::register_address(
 			Origin::signed(who.clone()),
 			blockchain.clone(),
@@ -371,7 +371,7 @@ fn register_address_should_work() {
 fn register_address_pre_existing() {
 	ExtBuilder::default().build_and_execute(|| {
 		let (who, address, ownership_proof, _) = generate_address_with_proof("owner");
-		let blockchain = Blockchain::Rinkeby;
+		let blockchain = OldBlockchain::Rinkeby;
 		assert_ok!(Creditcoin::register_address(
 			Origin::signed(who.clone()),
 			blockchain.clone(),
@@ -390,7 +390,7 @@ fn register_address_pre_existing() {
 fn register_address_should_error_when_not_signed() {
 	ExtBuilder::default().build_and_execute(|| {
 		let (_who, address, ownership_proof, _) = generate_address_with_proof("owner");
-		let blockchain = Blockchain::Rinkeby;
+		let blockchain = OldBlockchain::Rinkeby;
 
 		assert_noop!(
 			Creditcoin::register_address(Origin::none(), blockchain, address, ownership_proof),
@@ -405,7 +405,7 @@ fn register_address_should_error_when_using_wrong_ownership_proof() {
 		let (who, address, _ownership_proof, _) = generate_address_with_proof("owner");
 		let (_who2, _address2, ownership_proof2, _) = generate_address_with_proof("bogus");
 
-		let blockchain = Blockchain::Rinkeby;
+		let blockchain = OldBlockchain::Rinkeby;
 		assert_noop!(
 			Creditcoin::register_address(
 				Origin::signed(who),
@@ -423,7 +423,7 @@ fn register_address_should_error_when_address_too_long() {
 	ExtBuilder::default().build_and_execute(|| {
 		let (who, address, ownership_proof, _) = generate_address_with_proof("owner");
 		let address = format!("0xff{}", hex::encode(address)).hex_to_address();
-		let blockchain = Blockchain::Rinkeby;
+		let blockchain = OldBlockchain::Rinkeby;
 		assert_noop!(
 			Creditcoin::register_address(Origin::signed(who), blockchain, address, ownership_proof),
 			crate::Error::<Test>::AddressFormatNotSupported
@@ -440,7 +440,7 @@ fn register_address_should_error_when_signature_is_invalid() {
 		// https://docs.rs/sp-core/2.0.0-rc4/sp_core/ecdsa/struct.Signature.html#method.from_raw
 		let ownership_proof = sp_core::ecdsa::Signature::from_raw([0; 65]);
 
-		let blockchain = Blockchain::Rinkeby;
+		let blockchain = OldBlockchain::Rinkeby;
 		assert_noop!(
 			Creditcoin::register_address(Origin::signed(who), blockchain, address, ownership_proof),
 			crate::Error::<Test>::InvalidSignature
@@ -471,7 +471,7 @@ fn verify_ethless_transfer() {
 		let tx_id = tx_hash.hex_to_address();
 
 		assert_ok!(Creditcoin::verify_ethless_transfer(
-			&Blockchain::Rinkeby,
+			&OldBlockchain::Rinkeby,
 			&contract,
 			&from,
 			&to,
@@ -492,7 +492,7 @@ fn register_transfer_ocw_fail_to_send() {
 		let tx_hash = get_mock_tx_hash();
 		let contract = get_mock_contract().hex_to_address();
 		let tx_block_num = get_mock_tx_block_num();
-		let blockchain = Blockchain::Rinkeby;
+		let blockchain = OldBlockchain::Rinkeby;
 
 		// we're going to verify a transfer twice:
 		// First when we expect failure, which means we won't make all of the requests
@@ -502,7 +502,7 @@ fn register_transfer_ocw_fail_to_send() {
 		MockedRpcRequests::new(dummy_url, &tx_hash, &tx_block_num, &*ETHLESS_RESPONSES)
 			.mock_all(&mut state.write());
 
-		set_rpc_uri(&Blockchain::Rinkeby, &dummy_url);
+		set_rpc_uri(&OldBlockchain::Rinkeby, &dummy_url);
 
 		let loan_amount = get_mock_amount();
 		let terms = LoanTerms { amount: loan_amount, ..Default::default() };
@@ -565,13 +565,12 @@ fn add_ask_order_basic() {
 
 	let (ask_order, ask_guid) = ext.execute_with(|| {
 		let test_info = TestInfo::new_defaults();
-		let TestInfo { lender, loan_terms, blockchain, ask_guid, .. } = test_info.clone();
+		let TestInfo { lender, loan_terms, ask_guid, .. } = test_info.clone();
 		let RegisteredAddress { address_id, account_id } = lender;
 		let (ask_order, _) = test_info.create_ask_order();
 		let AskOrder { block, expiration_block, .. } = ask_order;
 
 		let new_ask_order = crate::AskOrder {
-			blockchain,
 			lender_address_id: address_id,
 			terms: loan_terms.try_into().unwrap(),
 			expiration_block,
@@ -679,14 +678,13 @@ fn add_bid_order_basic() {
 
 	let (bid_order, bid_guid) = ext.execute_with(|| {
 		let test_info = TestInfo::new_defaults();
-		let TestInfo { borrower, loan_terms, blockchain, bid_guid, .. } = test_info.clone();
+		let TestInfo { borrower, loan_terms, bid_guid, .. } = test_info.clone();
 		let RegisteredAddress { address_id, account_id } = borrower;
 
 		let (bid_order, _) = test_info.create_bid_order();
 		let BidOrder { expiration_block, block, .. } = bid_order;
 
 		let new_bid_order = crate::BidOrder {
-			blockchain,
 			borrower_address_id: address_id,
 			terms: loan_terms.try_into().unwrap(),
 			expiration_block,
@@ -790,10 +788,10 @@ fn add_offer_basic() {
 		let test_info = TestInfo::new_defaults();
 
 		let (offer, _) = test_info.create_offer();
-		let Offer { blockchain, expiration_block, block, ask_id, bid_id, lender, .. } =
+		let Offer { expiration_block, block, ask_id, bid_id, lender, .. } =
 			offer.clone();
 
-		let new_offer = Offer { blockchain, expiration_block, block, ask_id, bid_id, lender };
+		let new_offer = Offer { expiration_block, block, ask_id, bid_id, lender };
 
 		assert_eq!(new_offer, offer);
 	});
@@ -823,11 +821,10 @@ fn add_offer_should_error_when_blockchain_differs_between_ask_and_bid_order() {
 		let Offer { expiration_block, ask_id, bid_id, lender, .. } = offer;
 
 		// simulate deal transfer
-		crate::AskOrders::<Test>::mutate(
-			&ask_id.expiration(),
-			&ask_id.hash(),
-			|ask_order_storage| {
-				ask_order_storage.as_mut().unwrap().blockchain = Blockchain::Bitcoin;
+		crate::Addresses::<Test>::mutate(
+			&test_info.lender.address_id,
+			|address_storage| {
+				address_storage.as_mut().unwrap().blockchain = OldBlockchain::Bitcoin;
 			},
 		);
 
@@ -845,7 +842,6 @@ fn add_deal_order_basic() {
 
 		let (deal_order, _) = test_info.create_deal_order();
 		let DealOrder {
-			blockchain,
 			expiration_block,
 			lender_address_id,
 			borrower_address_id,
@@ -857,7 +853,6 @@ fn add_deal_order_basic() {
 		} = deal_order.clone();
 
 		let new_deal_order = DealOrder {
-			blockchain,
 			offer_id,
 			lender_address_id,
 			borrower_address_id,
@@ -903,7 +898,7 @@ fn lock_deal_order_should_emit_deal_order_locked_event() {
 			&deal_order_id.hash(),
 			|deal_order_storage| {
 				deal_order_storage.as_mut().unwrap().funding_transfer_id =
-					Some(TransferId::new::<Test>(&deal_order.blockchain, b"12345678"));
+					Some(TransferId::new::<Test>(&test_info.blockchain, b"12345678"));
 			},
 		);
 
@@ -969,7 +964,7 @@ fn lock_deal_order_should_fail_for_non_borrower() {
 	ExtBuilder::default().build_and_execute(|| {
 		let test_info = TestInfo::new_defaults();
 
-		let (deal_order, deal_order_id) = test_info.create_deal_order();
+		let (_, deal_order_id) = test_info.create_deal_order();
 
 		// simulate deal transfer
 		crate::DealOrders::<Test>::mutate(
@@ -977,7 +972,7 @@ fn lock_deal_order_should_fail_for_non_borrower() {
 			&deal_order_id.hash(),
 			|deal_order_storage| {
 				deal_order_storage.as_mut().unwrap().funding_transfer_id =
-					Some(TransferId::new::<Test>(&deal_order.blockchain, b"12345678"));
+					Some(TransferId::new::<Test>(&test_info.blockchain, b"12345678"));
 			},
 		);
 
@@ -993,7 +988,7 @@ fn lock_deal_order_should_fail_if_already_locked() {
 	ExtBuilder::default().build_and_execute(|| {
 		let test_info = TestInfo::new_defaults();
 
-		let (deal_order, deal_order_id) = test_info.create_deal_order();
+		let (_, deal_order_id) = test_info.create_deal_order();
 
 		// simulate deal transfer
 		crate::DealOrders::<Test>::mutate(
@@ -1001,7 +996,7 @@ fn lock_deal_order_should_fail_if_already_locked() {
 			&deal_order_id.hash(),
 			|deal_order_storage| {
 				deal_order_storage.as_mut().unwrap().funding_transfer_id =
-					Some(TransferId::new::<Test>(&deal_order.blockchain, b"12345678"));
+					Some(TransferId::new::<Test>(&test_info.blockchain, b"12345678"));
 			},
 		);
 
@@ -1033,7 +1028,7 @@ fn lock_deal_order_locks_by_borrower() {
 			&deal_order_id.hash(),
 			|deal_order_storage| {
 				deal_order_storage.as_mut().unwrap().funding_transfer_id =
-					Some(TransferId::new::<Test>(&deal_order.blockchain, b"12345678"));
+					Some(TransferId::new::<Test>(&test_info.blockchain, b"12345678"));
 			},
 		);
 
@@ -1051,8 +1046,8 @@ fn lock_deal_order_locks_by_borrower() {
 fn fund_deal_order_should_error_when_not_signed() {
 	ExtBuilder::default().build_and_execute(|| {
 		let test_info = TestInfo::new_defaults();
-		let (deal_order, deal_order_id) = test_info.create_deal_order();
-		let transfer_id = TransferId::new::<Test>(&deal_order.blockchain, b"12345678");
+		let (_, deal_order_id) = test_info.create_deal_order();
+		let transfer_id = TransferId::new::<Test>(&test_info.blockchain, b"12345678");
 
 		assert_noop!(
 			Creditcoin::fund_deal_order(Origin::none(), deal_order_id, transfer_id),
@@ -1065,15 +1060,15 @@ fn fund_deal_order_should_error_when_not_signed() {
 fn fund_deal_order_should_error_when_address_not_registered() {
 	ExtBuilder::default().build_and_execute(|| {
 		let test_info = TestInfo::new_defaults();
-		let (deal_order, deal_order_id) = test_info.create_deal_order();
-		let transfer_id = TransferId::new::<Test>(&deal_order.blockchain, b"12345678");
+		let (_, deal_order_id) = test_info.create_deal_order();
+		let transfer_id = TransferId::new::<Test>(&test_info.blockchain, b"12345678");
 
 		// simulate deal with an address that isn't registered
 		crate::DealOrders::<Test>::mutate(
 			&deal_order_id.expiration(),
 			&deal_order_id.hash(),
 			|deal_order_storage| {
-				let blockchain = Blockchain::Rinkeby;
+				let blockchain = OldBlockchain::Rinkeby;
 
 				deal_order_storage.as_mut().unwrap().lender_address_id =
 					AddressId::new::<Test>(&blockchain, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 0]);
@@ -1095,8 +1090,8 @@ fn fund_deal_order_should_error_when_address_not_registered() {
 fn fund_deal_order_should_error_for_non_lender() {
 	ExtBuilder::default().build_and_execute(|| {
 		let test_info = TestInfo::new_defaults();
-		let (deal_order, deal_order_id) = test_info.create_deal_order();
-		let transfer_id = TransferId::new::<Test>(&deal_order.blockchain, b"12345678");
+		let (_, deal_order_id) = test_info.create_deal_order();
+		let transfer_id = TransferId::new::<Test>(&test_info.blockchain, b"12345678");
 
 		assert_noop!(
 			Creditcoin::fund_deal_order(
@@ -1113,8 +1108,8 @@ fn fund_deal_order_should_error_for_non_lender() {
 fn fund_deal_order_should_error_when_timestamp_is_in_the_future() {
 	ExtBuilder::default().build_and_execute(|| {
 		let test_info = TestInfo::new_defaults();
-		let (deal_order, deal_order_id) = test_info.create_deal_order();
-		let transfer_id = TransferId::new::<Test>(&deal_order.blockchain, b"12345678");
+		let (_, deal_order_id) = test_info.create_deal_order();
+		let transfer_id = TransferId::new::<Test>(&test_info.blockchain, b"12345678");
 
 		// simulate deal with a timestamp in the future
 		crate::DealOrders::<Test>::mutate(
@@ -1140,8 +1135,8 @@ fn fund_deal_order_should_error_when_timestamp_is_in_the_future() {
 fn fund_deal_order_should_error_when_deal_is_funded() {
 	ExtBuilder::default().build_and_execute(|| {
 		let test_info = TestInfo::new_defaults();
-		let (deal_order, deal_order_id) = test_info.create_deal_order();
-		let transfer_id = TransferId::new::<Test>(&deal_order.blockchain, b"12345678");
+		let (_, deal_order_id) = test_info.create_deal_order();
+		let transfer_id = TransferId::new::<Test>(&test_info.blockchain, b"12345678");
 
 		// simulate a funded deal
 		crate::DealOrders::<Test>::mutate(
@@ -1149,7 +1144,7 @@ fn fund_deal_order_should_error_when_deal_is_funded() {
 			&deal_order_id.hash(),
 			|deal_order_storage| {
 				deal_order_storage.as_mut().unwrap().funding_transfer_id =
-					Some(TransferId::new::<Test>(&deal_order.blockchain, b"12345678"));
+					Some(TransferId::new::<Test>(&test_info.blockchain, b"12345678"));
 			},
 		);
 
@@ -1170,8 +1165,8 @@ fn fund_deal_order_should_error_when_deal_has_expired() {
 		roll_to(4); // advance head so we have something to compare to
 
 		let test_info = TestInfo::new_defaults();
-		let (deal_order, deal_order_id) = test_info.create_deal_order();
-		let transfer_id = TransferId::new::<Test>(&deal_order.blockchain, b"12345678");
+		let (_, deal_order_id) = test_info.create_deal_order();
+		let transfer_id = TransferId::new::<Test>(&test_info.blockchain, b"12345678");
 
 		// simulate an expired deal by setting expiration_block < head
 		crate::DealOrders::<Test>::mutate(
@@ -1202,9 +1197,9 @@ fn fund_deal_order_should_error_when_transfer_order_id_doesnt_match_deal_order_i
 
 		// this is a deal_order from another person
 		let second_test_info = TestInfo {
-			lender: RegisteredAddress::new("lender2", Blockchain::Rinkeby),
-			borrower: RegisteredAddress::new("borrower2", Blockchain::Rinkeby),
-			blockchain: Blockchain::Rinkeby,
+			lender: RegisteredAddress::new("lender2", OldBlockchain::Rinkeby),
+			borrower: RegisteredAddress::new("borrower2", OldBlockchain::Rinkeby),
+			blockchain: OldBlockchain::Rinkeby,
 			loan_terms: LoanTerms {
 				amount: 2_000_000u64.into(),
 				interest_rate: Default::default(),
@@ -1562,13 +1557,13 @@ fn register_deal_order_should_error_when_lender_address_doesnt_match_sender() {
 		let test_info = TestInfo {
 			borrower: RegisteredAddress::from_pubkey(
 				key_pair.public(),
-				Blockchain::Rinkeby,
+				OldBlockchain::Rinkeby,
 				ownership_proof,
 			),
 			..TestInfo::new_defaults()
 		};
 
-		let lender = RegisteredAddress::new("lender2", Blockchain::Rinkeby);
+		let lender = RegisteredAddress::new("lender2", OldBlockchain::Rinkeby);
 		let message = test_info.get_register_deal_msg();
 		let compliance_proof = key_pair.sign(&message);
 
@@ -1596,10 +1591,10 @@ fn register_deal_order_should_error_when_lender_and_borrower_are_on_different_ch
 		let pub_key = key_pair.public();
 
 		let test_info = TestInfo {
-			lender: RegisteredAddress::new("lender2", Blockchain::Ethereum),
+			lender: RegisteredAddress::new("lender2", OldBlockchain::Ethereum),
 			borrower: RegisteredAddress::from_pubkey(
 				pub_key.clone(),
-				Blockchain::Rinkeby,
+				OldBlockchain::Rinkeby,
 				ownership_proof,
 			),
 			..TestInfo::new_defaults()
@@ -1634,7 +1629,7 @@ fn register_deal_order_should_error_when_ask_order_id_exists() {
 		let test_info = TestInfo {
 			borrower: RegisteredAddress::from_pubkey(
 				pub_key.clone(),
-				Blockchain::Rinkeby,
+				OldBlockchain::Rinkeby,
 				ownership_proof,
 			),
 			..TestInfo::new_defaults()
@@ -1669,7 +1664,11 @@ fn register_deal_order_should_error_when_bid_order_id_exists() {
 		let pub_key = key_pair.public();
 
 		let test_info = TestInfo {
-			borrower: RegisteredAddress::from_pubkey(pub_key, Blockchain::Rinkeby, ownership_proof),
+			borrower: RegisteredAddress::from_pubkey(
+				pub_key,
+				OldBlockchain::Rinkeby,
+				ownership_proof,
+			),
 			..TestInfo::new_defaults()
 		};
 
@@ -1705,7 +1704,7 @@ fn register_deal_order_should_error_when_offer_id_exists() {
 		let test_info = TestInfo {
 			borrower: RegisteredAddress::from_pubkey(
 				pub_key.clone(),
-				Blockchain::Rinkeby,
+				OldBlockchain::Rinkeby,
 				ownership_proof,
 			),
 			..TestInfo::new_defaults()
@@ -1722,7 +1721,6 @@ fn register_deal_order_should_error_when_offer_id_exists() {
 			ask_id: ask_order_id,
 			bid_id: bid_order_id,
 			block: current_block,
-			blockchain: test_info.blockchain.clone(),
 			expiration_block: test_info.expiration_block,
 			lender: test_info.lender.account_id.clone(),
 		};
@@ -1759,7 +1757,7 @@ fn register_deal_order_should_error_when_deal_order_id_exists() {
 		let test_info = TestInfo {
 			borrower: RegisteredAddress::from_pubkey(
 				pub_key.clone(),
-				Blockchain::Rinkeby,
+				OldBlockchain::Rinkeby,
 				ownership_proof,
 			),
 			..TestInfo::new_defaults()
@@ -1777,7 +1775,6 @@ fn register_deal_order_should_error_when_deal_order_id_exists() {
 		let deal_order_id = DealOrderId::new::<Test>(test_info.expiration_block, &offer_id);
 
 		let deal_order = DealOrder {
-			blockchain: test_info.blockchain,
 			offer_id,
 			lender_address_id: test_info.lender.address_id.clone(),
 			borrower_address_id: test_info.borrower.address_id.clone(),
@@ -1823,7 +1820,7 @@ fn register_deal_order_should_succeed() {
 		let test_info = TestInfo {
 			borrower: RegisteredAddress::from_pubkey(
 				pub_key.clone(),
-				Blockchain::Rinkeby,
+				OldBlockchain::Rinkeby,
 				ownership_proof,
 			),
 			..TestInfo::new_defaults()
@@ -1878,7 +1875,7 @@ fn register_deal_order_accepts_sr25519() {
 			TestInfo {
 				borrower: RegisteredAddress::from_pubkey_distinct_owner(
 					owners_account,
-					Blockchain::Rinkeby,
+					OldBlockchain::Rinkeby,
 					b_pubkey,
 					ownership_proof,
 				),
@@ -1921,7 +1918,7 @@ fn register_deal_order_accepts_ed25519() {
 			TestInfo {
 				borrower: RegisteredAddress::from_pubkey_distinct_owner(
 					owners_account,
-					Blockchain::Rinkeby,
+					OldBlockchain::Rinkeby,
 					b_pubkey,
 					ownership_proof,
 				),
@@ -1950,8 +1947,8 @@ fn register_deal_order_accepts_ed25519() {
 fn close_deal_order_should_error_when_not_signed() {
 	ExtBuilder::default().build_and_execute(|| {
 		let test_info = TestInfo::new_defaults();
-		let (deal_order, deal_order_id) = test_info.create_deal_order();
-		let transfer_id = TransferId::new::<Test>(&deal_order.blockchain, b"12345678");
+		let (_, deal_order_id) = test_info.create_deal_order();
+		let transfer_id = TransferId::new::<Test>(&test_info.blockchain, b"12345678");
 
 		assert_noop!(
 			Creditcoin::close_deal_order(Origin::none(), deal_order_id, transfer_id,),
@@ -1964,15 +1961,15 @@ fn close_deal_order_should_error_when_not_signed() {
 fn close_deal_order_should_error_when_borrower_address_is_not_registered() {
 	ExtBuilder::default().build_and_execute(|| {
 		let test_info = TestInfo::new_defaults();
-		let (deal_order, deal_order_id) = test_info.create_deal_order();
-		let transfer_id = TransferId::new::<Test>(&deal_order.blockchain, b"12345678");
+		let (_, deal_order_id) = test_info.create_deal_order();
+		let transfer_id = TransferId::new::<Test>(&test_info.blockchain, b"12345678");
 
 		// simulate deal with an address that isn't registered
 		crate::DealOrders::<Test>::mutate(
 			&deal_order_id.expiration(),
 			&deal_order_id.hash(),
 			|deal_order_storage| {
-				let blockchain = Blockchain::Rinkeby;
+				let blockchain = OldBlockchain::Rinkeby;
 
 				deal_order_storage.as_mut().unwrap().borrower_address_id =
 					AddressId::new::<Test>(&blockchain, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 0]);
@@ -1994,8 +1991,8 @@ fn close_deal_order_should_error_when_borrower_address_is_not_registered() {
 fn close_deal_order_should_error_when_not_signed_by_borrower() {
 	ExtBuilder::default().build_and_execute(|| {
 		let test_info = TestInfo::new_defaults();
-		let (deal_order, deal_order_id) = test_info.create_deal_order();
-		let transfer_id = TransferId::new::<Test>(&deal_order.blockchain, b"12345678");
+		let (_, deal_order_id) = test_info.create_deal_order();
+		let transfer_id = TransferId::new::<Test>(&test_info.blockchain, b"12345678");
 
 		assert_noop!(
 			Creditcoin::close_deal_order(
@@ -2013,8 +2010,8 @@ fn close_deal_order_should_error_when_not_signed_by_borrower() {
 fn close_deal_order_should_error_when_deal_timestamp_is_in_the_future() {
 	ExtBuilder::default().build_and_execute(|| {
 		let test_info = TestInfo::new_defaults();
-		let (deal_order, deal_order_id) = test_info.create_deal_order();
-		let transfer_id = TransferId::new::<Test>(&deal_order.blockchain, b"12345678");
+		let (_, deal_order_id) = test_info.create_deal_order();
+		let transfer_id = TransferId::new::<Test>(&test_info.blockchain, b"12345678");
 
 		// simulate deal with a timestamp in the future
 		crate::DealOrders::<Test>::mutate(
@@ -2040,8 +2037,8 @@ fn close_deal_order_should_error_when_deal_timestamp_is_in_the_future() {
 fn close_deal_order_should_error_when_deal_order_has_already_been_repaid() {
 	ExtBuilder::default().build_and_execute(|| {
 		let test_info = TestInfo::new_defaults();
-		let (deal_order, deal_order_id) = test_info.create_deal_order();
-		let transfer_id = TransferId::new::<Test>(&deal_order.blockchain, b"12345678");
+		let (_, deal_order_id) = test_info.create_deal_order();
+		let transfer_id = TransferId::new::<Test>(&test_info.blockchain, b"12345678");
 
 		// simulate DealOrder which has been repaid
 		crate::DealOrders::<Test>::mutate(
@@ -2049,7 +2046,7 @@ fn close_deal_order_should_error_when_deal_order_has_already_been_repaid() {
 			&deal_order_id.hash(),
 			|deal_order_storage| {
 				deal_order_storage.as_mut().unwrap().repayment_transfer_id =
-					Some(TransferId::new::<Test>(&deal_order.blockchain, b"4444"));
+					Some(TransferId::new::<Test>(&test_info.blockchain, b"4444"));
 			},
 		);
 
@@ -2068,8 +2065,8 @@ fn close_deal_order_should_error_when_deal_order_has_already_been_repaid() {
 fn close_deal_order_should_error_when_deal_isnt_locked() {
 	ExtBuilder::default().build_and_execute(|| {
 		let test_info = TestInfo::new_defaults();
-		let (deal_order, deal_order_id) = test_info.create_deal_order();
-		let transfer_id = TransferId::new::<Test>(&deal_order.blockchain, b"12345678");
+		let (_, deal_order_id) = test_info.create_deal_order();
+		let transfer_id = TransferId::new::<Test>(&test_info.blockchain, b"12345678");
 
 		// simulate deal which is not locked
 		crate::DealOrders::<Test>::mutate(
@@ -2108,9 +2105,9 @@ fn close_deal_order_should_error_when_transfer_order_id_doesnt_match_deal_order_
 		);
 		// this is a deal_order from another person
 		let second_test_info = TestInfo {
-			lender: RegisteredAddress::new("lender2", Blockchain::Rinkeby),
-			borrower: RegisteredAddress::new("borrower2", Blockchain::Rinkeby),
-			blockchain: Blockchain::Rinkeby,
+			lender: RegisteredAddress::new("lender2", OldBlockchain::Rinkeby),
+			borrower: RegisteredAddress::new("borrower2", OldBlockchain::Rinkeby),
+			blockchain: OldBlockchain::Rinkeby,
 			loan_terms: LoanTerms {
 				amount: 2_000_000u64.into(),
 				interest_rate: Default::default(),
@@ -2338,7 +2335,7 @@ fn exempt_should_error_when_not_signed() {
 fn exempt_should_error_when_deal_order_has_already_been_repaid() {
 	ExtBuilder::default().build_and_execute(|| {
 		let test_info = TestInfo::new_defaults();
-		let (deal_order, deal_order_id) = test_info.create_deal_order();
+		let (_, deal_order_id) = test_info.create_deal_order();
 
 		// simulate DealOrder which has been repaid
 		crate::DealOrders::<Test>::mutate(
@@ -2346,7 +2343,7 @@ fn exempt_should_error_when_deal_order_has_already_been_repaid() {
 			&deal_order_id.hash(),
 			|deal_order_storage| {
 				deal_order_storage.as_mut().unwrap().repayment_transfer_id =
-					Some(TransferId::new::<Test>(&deal_order.blockchain, b"4444"));
+					Some(TransferId::new::<Test>(&test_info.blockchain, b"4444"));
 			},
 		);
 
@@ -2376,14 +2373,14 @@ fn exempt_should_succeed() {
 		System::set_block_number(1);
 
 		let test_info = TestInfo::new_defaults();
-		let (deal_order, deal_order_id) = test_info.create_deal_order();
+		let (_, deal_order_id) = test_info.create_deal_order();
 
 		assert_ok!(Creditcoin::exempt(
 			Origin::signed(test_info.lender.account_id),
 			deal_order_id.clone()
 		));
 
-		let transfer_id = TransferId::new::<Test>(&deal_order.blockchain, b"0");
+		let transfer_id = TransferId::new::<Test>(&test_info.blockchain, b"0");
 
 		// assert field values were updated in storage
 		let saved_deal_order = DealOrders::<Test>::try_get_id(&deal_order_id).unwrap();
@@ -2480,7 +2477,7 @@ fn verify_transfer_should_work() {
 
 		// create a transfer but don't add it into storage
 		let tx = "0xafafaf".as_bytes().into_bounded();
-		let transfer_id = TransferId::new::<Test>(&Blockchain::Rinkeby, &tx);
+		let transfer_id = TransferId::new::<Test>(&OldBlockchain::Rinkeby, &tx);
 		let transfer = Transfer {
 			blockchain: test_info.blockchain.clone(),
 			kind: LegacyTransferKind::Native,
@@ -2533,7 +2530,7 @@ fn fail_transfer_should_work() {
 		let _ = test_info.create_deal_order();
 
 		let tx = "0xafafaf".hex_to_address();
-		let transfer_id = TransferId::new::<Test>(&Blockchain::Rinkeby, &tx);
+		let transfer_id = TransferId::new::<Test>(&OldBlockchain::Rinkeby, &tx);
 
 		let failure_cause = crate::ocw::errors::VerificationFailureCause::TaskFailed;
 		let deadline = Test::unverified_transfer_deadline();
@@ -2567,7 +2564,7 @@ fn fail_transfer_should_error_when_not_signed() {
 		let _ = test_info.create_deal_order();
 
 		let tx = "0xafafaf".hex_to_address();
-		let transfer_id = TransferId::new::<Test>(&Blockchain::Rinkeby, &tx);
+		let transfer_id = TransferId::new::<Test>(&OldBlockchain::Rinkeby, &tx);
 
 		let failure_cause = crate::ocw::errors::VerificationFailureCause::TaskFailed;
 		let deadline = Test::unverified_transfer_deadline();
@@ -2589,7 +2586,7 @@ fn fail_transfer_should_error_when_not_authority() {
 		let _ = test_info.create_deal_order();
 
 		let tx = "0xafafaf".hex_to_address();
-		let transfer_id = TransferId::new::<Test>(&Blockchain::Rinkeby, &tx);
+		let transfer_id = TransferId::new::<Test>(&OldBlockchain::Rinkeby, &tx);
 
 		let failure_cause = crate::ocw::errors::VerificationFailureCause::TaskFailed;
 		let deadline = Test::unverified_transfer_deadline();
@@ -2650,9 +2647,9 @@ fn on_initialize_removes_expired_deals_without_transfers() {
 			let seed2 = format!("{:02}1", expiration_block.clone());
 
 			let test_info = TestInfo {
-				lender: RegisteredAddress::new(&seed1, Blockchain::Rinkeby),
-				borrower: RegisteredAddress::new(&seed2, Blockchain::Rinkeby),
-				blockchain: Blockchain::Rinkeby,
+				lender: RegisteredAddress::new(&seed1, OldBlockchain::Rinkeby),
+				borrower: RegisteredAddress::new(&seed2, OldBlockchain::Rinkeby),
+				blockchain: OldBlockchain::Rinkeby,
 				loan_terms: LoanTerms {
 					amount: 2_000_000u64.into(),
 					interest_rate: Default::default(),
@@ -2810,7 +2807,7 @@ fn register_transfer_internal_legacy_should_error_with_non_existent_lender_addre
 		let (deal_order, deal_order_id) = test_info.create_deal_order();
 		let tx = "0xabcabcabc";
 		let bogus_address =
-			AddressId::new::<Test>(&Blockchain::Rinkeby, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 0]);
+			AddressId::new::<Test>(&OldBlockchain::Rinkeby, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 0]);
 
 		let result = Creditcoin::register_transfer_internal_legacy(
 			test_info.lender.account_id,
@@ -2834,7 +2831,7 @@ fn register_transfer_internal_legacy_should_error_with_non_existent_borrower_add
 		let (deal_order, deal_order_id) = test_info.create_deal_order();
 		let tx = "0xabcabcabc";
 		let bogus_address =
-			AddressId::new::<Test>(&Blockchain::Rinkeby, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 0]);
+			AddressId::new::<Test>(&OldBlockchain::Rinkeby, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 0]);
 
 		let result = Creditcoin::register_transfer_internal_legacy(
 			test_info.lender.account_id,
@@ -2878,7 +2875,7 @@ fn register_transfer_internal_legacy_should_error_when_addresses_are_not_on_the_
 	ExtBuilder::default().build_and_execute(|| {
 		let test_info = TestInfo::new_defaults();
 		let (deal_order, deal_order_id) = test_info.create_deal_order();
-		let second_borrower = RegisteredAddress::new("borrower2", Blockchain::Luniverse);
+		let second_borrower = RegisteredAddress::new("borrower2", OldBlockchain::Luniverse);
 		let tx = "0xabcabcabc";
 
 		let result = Creditcoin::register_transfer_internal_legacy(
@@ -2907,7 +2904,7 @@ fn register_transfer_internal_legacy_should_error_when_transfer_kind_is_not_supp
 			test_info.lender.account_id,
 			deal_order.lender_address_id,
 			deal_order.borrower_address_id,
-			// not supported on Blockchain::Rinkeby
+			// not supported on OldBlockchain::Rinkeby
 			LegacyTransferKind::Other(BoundedVec::try_from(b"other".to_vec()).unwrap()),
 			deal_order.terms.amount,
 			deal_order_id,

--- a/pallets/creditcoin/src/tests.rs
+++ b/pallets/creditcoin/src/tests.rs
@@ -269,7 +269,7 @@ impl TestInfo {
 		let deal_order =
 			Creditcoin::deal_orders(deal_order_id.expiration(), deal_order_id.hash()).unwrap();
 		let tx = "0xfafafa";
-		assert_ok!(Creditcoin::register_funding_transfer_new(
+		assert_ok!(Creditcoin::register_funding_transfer(
 			Origin::signed(self.lender.account_id.clone()),
 			TransferKind::Evm(EvmTransferKind::Ethless),
 			deal_order_id.clone(),
@@ -285,7 +285,7 @@ impl TestInfo {
 	) -> TestTransfer {
 		let tx = "0xafafaf";
 		let amount = amount.into();
-		assert_ok!(Creditcoin::register_repayment_transfer_new(
+		assert_ok!(Creditcoin::register_repayment_transfer(
 			Origin::signed(self.borrower.account_id.clone()),
 			TransferKind::Evm(EvmTransferKind::Ethless),
 			amount,
@@ -303,7 +303,7 @@ impl TestInfo {
 	) -> TestTransfer {
 		let tx = "0xafafaf";
 		let amount = amount.into();
-		assert_ok!(Creditcoin::register_repayment_transfer(
+		assert_ok!(Creditcoin::register_repayment_transfer_legacy(
 			Origin::signed(self.borrower.account_id.clone()),
 			LegacyTransferKind::Ethless(ExternalAddress::default()),
 			amount,
@@ -580,7 +580,7 @@ fn register_transfer_ocw_fail_to_send() {
 
 		// exercise when we try to send a fail_transfer but tx send fails
 		with_failing_create_transaction(|| {
-			assert_ok!(Creditcoin::register_funding_transfer(
+			assert_ok!(Creditcoin::register_funding_transfer_legacy(
 				Origin::signed(lender.clone()),
 				LegacyTransferKind::Ethless(contract.clone()),
 				deal_order_id.clone(),
@@ -598,7 +598,7 @@ fn register_transfer_ocw_fail_to_send() {
 
 		// exercise when we try to send a verify_transfer but tx send fails
 		with_failing_create_transaction(|| {
-			assert_ok!(Creditcoin::register_funding_transfer(
+			assert_ok!(Creditcoin::register_funding_transfer_legacy(
 				Origin::signed(lender.clone()),
 				LegacyTransferKind::Ethless(contract.clone()),
 				fake_deal_order_id.clone(),
@@ -1283,7 +1283,7 @@ fn fund_deal_order_should_error_when_transfer_order_id_doesnt_match_deal_order_i
 		let currency = ethless_currency(contract.clone());
 		register_currency(&currency);
 
-		assert_ok!(Creditcoin::register_funding_transfer(
+		assert_ok!(Creditcoin::register_funding_transfer_legacy(
 			Origin::signed(second_test_info.lender.account_id.clone()),
 			LegacyTransferKind::Ethless(contract),
 			bogus_deal_order_id.clone(),
@@ -1318,7 +1318,7 @@ fn fund_deal_order_should_error_when_transfer_amount_doesnt_match() {
 		let currency = ethless_currency(contract.clone());
 		register_currency(&currency);
 
-		assert_ok!(Creditcoin::register_funding_transfer(
+		assert_ok!(Creditcoin::register_funding_transfer_legacy(
 			Origin::signed(test_info.lender.account_id.clone()),
 			LegacyTransferKind::Ethless(contract),
 			deal_order_id.clone(),
@@ -1361,7 +1361,7 @@ fn fund_deal_order_should_error_when_transfer_sighash_doesnt_match_lender() {
 		let currency = ethless_currency(contract.clone());
 		register_currency(&currency);
 
-		assert_ok!(Creditcoin::register_funding_transfer(
+		assert_ok!(Creditcoin::register_funding_transfer_legacy(
 			Origin::signed(test_info.lender.account_id.clone()),
 			LegacyTransferKind::Ethless(contract),
 			deal_order_id.clone(),
@@ -1431,7 +1431,7 @@ fn fund_deal_order_works() {
 		let currency = ethless_currency(contract.clone());
 		register_currency(&currency);
 
-		assert_ok!(Creditcoin::register_funding_transfer(
+		assert_ok!(Creditcoin::register_funding_transfer_legacy(
 			Origin::signed(test_info.lender.account_id.clone()),
 			LegacyTransferKind::Ethless(contract),
 			deal_order_id.clone(),
@@ -2754,7 +2754,7 @@ fn on_initialize_removes_expired_deals_without_transfers() {
 			// fund only deal orders which expire at even blocks
 			if expiration_block % 2 == 0 {
 				let tx = format!("0xfafafa{:02}", expiration_block.clone());
-				assert_ok!(Creditcoin::register_funding_transfer(
+				assert_ok!(Creditcoin::register_funding_transfer_legacy(
 					Origin::signed(test_info.lender.account_id.clone()),
 					LegacyTransferKind::Ethless(ExternalAddress::default()),
 					deal_order_id.clone(),
@@ -2799,7 +2799,7 @@ fn register_funding_transfer_should_error_when_not_signed() {
 		let tx = "0xabcabcabc";
 
 		assert_noop!(
-			Creditcoin::register_funding_transfer(
+			Creditcoin::register_funding_transfer_legacy(
 				Origin::none(),
 				LegacyTransferKind::Native,
 				deal_order_id,
@@ -2822,7 +2822,7 @@ fn register_funding_transfer_should_error_when_not_deal_order_not_found() {
 		let tx = "0xabcabcabc";
 
 		assert_noop!(
-			Creditcoin::register_funding_transfer(
+			Creditcoin::register_funding_transfer_legacy(
 				Origin::signed(test_info.lender.account_id),
 				LegacyTransferKind::Native,
 				deal_order_id,
@@ -2841,7 +2841,7 @@ fn register_repayment_transfer_should_error_when_not_signed() {
 		let tx = "0xabcabcabc";
 
 		assert_noop!(
-			Creditcoin::register_repayment_transfer(
+			Creditcoin::register_repayment_transfer_legacy(
 				Origin::none(),
 				LegacyTransferKind::Native,
 				21u64.into(),
@@ -2865,7 +2865,7 @@ fn register_repayment_transfer_should_error_when_not_deal_order_not_found() {
 		let tx = "0xabcabcabc";
 
 		assert_noop!(
-			Creditcoin::register_repayment_transfer(
+			Creditcoin::register_repayment_transfer_legacy(
 				Origin::signed(test_info.borrower.account_id),
 				LegacyTransferKind::Native,
 				21u64.into(),

--- a/pallets/creditcoin/src/tests.rs
+++ b/pallets/creditcoin/src/tests.rs
@@ -1246,7 +1246,7 @@ fn fund_deal_order_should_error_when_transfer_order_id_doesnt_match_deal_order_i
 	ExtBuilder::default().build_and_execute(|| {
 		// this is the primary deal_order
 		let contract = "0x0ad1439a0e0bfdcd49939f9722866651a4aa9b3c".as_bytes().into_bounded();
-		let currency = ethless_currency(contract.clone());
+		let currency = ethless_currency(contract);
 		let test_info = TestInfo::with_currency(currency);
 		let (_, deal_order_id) = test_info.create_deal_order();
 
@@ -1298,7 +1298,7 @@ fn fund_deal_order_should_error_when_transfer_order_id_doesnt_match_deal_order_i
 fn fund_deal_order_should_error_when_transfer_amount_doesnt_match() {
 	ExtBuilder::default().build_and_execute(|| {
 		let contract = "0x0ad1439a0e0bfdcd49939f9722866651a4aa9b3c".as_bytes().into_bounded();
-		let currency = ethless_currency(contract.clone());
+		let currency = ethless_currency(contract);
 
 		let test_info = TestInfo::with_currency(currency);
 		let (_deal_order, deal_order_id) = test_info.create_deal_order();
@@ -1340,7 +1340,7 @@ fn fund_deal_order_should_error_when_transfer_amount_doesnt_match() {
 fn fund_deal_order_should_error_when_transfer_sighash_doesnt_match_lender() {
 	ExtBuilder::default().build_and_execute(|| {
 		let contract = "0x0ad1439a0e0bfdcd49939f9722866651a4aa9b3c".as_bytes().into_bounded();
-		let currency = ethless_currency(contract.clone());
+		let currency = ethless_currency(contract);
 
 		let test_info = TestInfo::with_currency(currency);
 
@@ -1410,7 +1410,7 @@ fn fund_deal_order_works() {
 		System::set_block_number(1);
 
 		let contract = "0x0ad1439a0e0bfdcd49939f9722866651a4aa9b3c".as_bytes().into_bounded();
-		let currency = ethless_currency(contract.clone());
+		let currency = ethless_currency(contract);
 		let test_info = TestInfo::with_currency(currency);
 		let (deal_order, deal_order_id) = test_info.create_deal_order();
 
@@ -2311,7 +2311,7 @@ fn close_deal_order_should_succeed() {
 	ExtBuilder::default().build_and_execute(|| {
 		System::set_block_number(1);
 		let contract = "0x0ad1439a0e0bfdcd49939f9722866651a4aa9b3c".as_bytes().into_bounded();
-		let currency = ethless_currency(contract.clone());
+		let currency = ethless_currency(contract);
 
 		let test_info = TestInfo::with_currency(currency);
 		let (deal_order, deal_order_id) = test_info.create_deal_order();

--- a/pallets/creditcoin/src/tests.rs
+++ b/pallets/creditcoin/src/tests.rs
@@ -5,7 +5,7 @@ use crate::{
 	AddressId, AskOrder, AskOrderId, Authorities, BidOrder, BidOrderId, Blockchain, Currencies,
 	Currency, CurrencyId, DealOrder, DealOrderId, DealOrders, Duration, EvmCurrencyType, EvmInfo,
 	EvmTransferKind, ExternalAddress, ExternalAmount, Guid, Id, LegacySighash, LegacyTransferKind,
-	LoanTerms, Offer, OfferId, Transfer, TransferId, TransferKind, Transfers,
+	LoanTerms, Offer, OfferId, Transfer, TransferId, TransferKind, Transfers, WeightInfo,
 };
 
 use assert_matches::assert_matches;

--- a/pallets/creditcoin/src/tests.rs
+++ b/pallets/creditcoin/src/tests.rs
@@ -4,8 +4,8 @@ use crate::{
 	types::DoubleMapExt,
 	AddressId, AskOrder, AskOrderId, Authorities, BidOrder, BidOrderId, Blockchain, Currency,
 	CurrencyId, DealOrder, DealOrderId, DealOrders, Duration, EvmInfo, EvmTransferKind,
-	ExternalAddress, ExternalAmount, Guid, Id, LegacySighash, LoanTerms, Offer, OfferId, OrderId,
-	Transfer, TransferId, TransferKind, Transfers, WeightInfo,
+	ExternalAddress, ExternalAmount, Guid, Id, LegacySighash, LoanTerms, Offer, OfferId, Transfer,
+	TransferId, TransferKind, Transfers, WeightInfo,
 };
 
 use assert_matches::assert_matches;
@@ -297,7 +297,7 @@ impl TestInfo {
 				kind: transfer_kind.into().unwrap_or(TransferKind::Native),
 				from: from.address_id.clone(),
 				to: to.address_id.clone(),
-				order_id: OrderId::Deal(deal_order_id.clone()),
+				deal_order_id: deal_order_id.clone(),
 				amount: amount.into(),
 				tx_id: tx,
 				block: System::block_number(),
@@ -463,10 +463,10 @@ fn verify_ethless_transfer() {
 
 		let from = get_mock_from_address().hex_to_address();
 		let to = get_mock_to_address().hex_to_address();
-		let order_id = crate::OrderId::Deal(crate::DealOrderId::with_expiration_hash::<Test>(
+		let deal_order_id = crate::DealOrderId::with_expiration_hash::<Test>(
 			10000,
 			H256::from_uint(&get_mock_nonce()),
-		));
+		);
 		let amount = get_mock_amount();
 		let tx_id = tx_hash.hex_to_address();
 
@@ -475,7 +475,7 @@ fn verify_ethless_transfer() {
 			&contract,
 			&from,
 			&to,
-			&order_id,
+			&deal_order_id,
 			&amount,
 			&tx_id,
 		));
@@ -1231,7 +1231,7 @@ fn fund_deal_order_should_error_when_transfer_order_id_doesnt_match_deal_order_i
 			second_test_info.create_funding_transfer(&bogus_deal_order_id);
 
 		// try funding DealOrder from Person1 with the transfer from Person2,
-		// which points to a different order_id
+		// which points to a different deal_order_id
 		assert_noop!(
 			Creditcoin::fund_deal_order(
 				Origin::signed(test_info.lender.account_id),
@@ -2277,7 +2277,7 @@ fn close_deal_order_should_succeed() {
 			test_info.lender.address_id.clone(),
 			TransferKind::Ethless(contract),
 			33u64.into(),
-			OrderId::Deal(deal_order_id.clone()),
+			deal_order_id.clone(),
 			tx_hash
 		));
 
@@ -2486,7 +2486,7 @@ fn verify_transfer_should_work() {
 			kind: TransferKind::Native,
 			from: test_info.lender.address_id.clone(),
 			to: test_info.borrower.address_id.clone(),
-			order_id: OrderId::Deal(deal_order_id),
+			deal_order_id,
 			amount: deal_order.terms.amount,
 			tx_id: tx,
 			block: System::block_number(),
@@ -2818,7 +2818,7 @@ fn register_transfer_internal_should_error_with_non_existent_lender_address() {
 			deal_order.borrower_address_id,
 			TransferKind::Native,
 			deal_order.terms.amount,
-			OrderId::Deal(deal_order_id),
+			deal_order_id,
 			tx.as_bytes().into_bounded(),
 		)
 		.unwrap_err();
@@ -2842,7 +2842,7 @@ fn register_transfer_internal_should_error_with_non_existent_borrower_address() 
 			bogus_address,
 			TransferKind::Native,
 			deal_order.terms.amount,
-			OrderId::Deal(deal_order_id),
+			deal_order_id,
 			tx.as_bytes().into_bounded(),
 		)
 		.unwrap_err();
@@ -2864,7 +2864,7 @@ fn register_transfer_internal_should_error_when_signer_doesnt_own_from_address()
 			deal_order.lender_address_id,
 			TransferKind::Native,
 			deal_order.terms.amount,
-			OrderId::Deal(deal_order_id),
+			deal_order_id,
 			tx.as_bytes().into_bounded(),
 		)
 		.unwrap_err();
@@ -2887,7 +2887,7 @@ fn register_transfer_internal_should_error_when_addresses_are_not_on_the_same_bl
 			second_borrower.address_id,
 			TransferKind::Native,
 			deal_order.terms.amount,
-			OrderId::Deal(deal_order_id),
+			deal_order_id,
 			tx.as_bytes().into_bounded(),
 		)
 		.unwrap_err();
@@ -2910,7 +2910,7 @@ fn register_transfer_internal_should_error_when_transfer_kind_is_not_supported()
 			// not supported on Blockchain::Rinkeby
 			TransferKind::Other(BoundedVec::try_from(b"other".to_vec()).unwrap()),
 			deal_order.terms.amount,
-			OrderId::Deal(deal_order_id),
+			deal_order_id,
 			tx.as_bytes().into_bounded(),
 		)
 		.unwrap_err();
@@ -2932,7 +2932,7 @@ fn register_transfer_internal_should_error_when_transfer_is_already_registered()
 			deal_order.borrower_address_id,
 			TransferKind::Native,
 			deal_order.terms.amount,
-			OrderId::Deal(deal_order_id),
+			deal_order_id,
 			transfer.tx_id,
 		)
 		.unwrap_err();

--- a/pallets/creditcoin/src/tests.rs
+++ b/pallets/creditcoin/src/tests.rs
@@ -138,7 +138,7 @@ type TestTransfer = (Transfer<AccountId, u64, H256, u64>, TestTransferId);
 #[derive(Clone, Debug)]
 pub struct TestInfo {
 	pub(crate) blockchain: Blockchain,
-	pub(crate) loan_terms: LoanTerms,
+	pub(crate) loan_terms: LoanTerms<H256>,
 	pub(crate) lender: RegisteredAddress,
 	pub(crate) borrower: RegisteredAddress,
 	pub(crate) ask_guid: Guid,
@@ -665,6 +665,7 @@ fn add_add_ask_order_rejects_zero_term_length_ms() {
 				amount: 0u64.into(),
 				interest_rate: Default::default(),
 				term_length: Duration::from_millis(0),
+				currency: CurrencyId::placeholder(),
 			},
 			..TestInfo::new_defaults()
 		};
@@ -1200,6 +1201,7 @@ fn fund_deal_order_should_error_when_transfer_order_id_doesnt_match_deal_order_i
 				amount: 2_000_000u64.into(),
 				interest_rate: Default::default(),
 				term_length: Duration::from_millis(1_000_000),
+				currency: CurrencyId::placeholder(),
 			},
 			ask_guid: "second-ask-guid".as_bytes().into_bounded(),
 			bid_guid: "second-bid-guid".as_bytes().into_bounded(),
@@ -2104,6 +2106,7 @@ fn close_deal_order_should_error_when_transfer_order_id_doesnt_match_deal_order_
 				amount: 2_000_000u64.into(),
 				interest_rate: Default::default(),
 				term_length: Duration::from_millis(1_000_000),
+				currency: CurrencyId::placeholder(),
 			},
 			ask_guid: "second-ask-guid".as_bytes().into_bounded(),
 			bid_guid: "second-bid-guid".as_bytes().into_bounded(),
@@ -2646,6 +2649,7 @@ fn on_initialize_removes_expired_deals_without_transfers() {
 					amount: 2_000_000u64.into(),
 					interest_rate: Default::default(),
 					term_length: Duration::from_millis(1_000_000),
+					currency: CurrencyId::placeholder(),
 				},
 				ask_guid: format!("{:?}-ask-guid", expiration_block.clone())
 					.as_bytes()

--- a/pallets/creditcoin/src/tests.rs
+++ b/pallets/creditcoin/src/tests.rs
@@ -154,7 +154,7 @@ impl Default for Currency {
 				"0x0000000000000000000000000000000000000000".hex_to_address(),
 				[EvmTransferKind::Ethless].into_bounded(),
 			),
-			EvmInfo { chain_id: 0.into() },
+			EvmInfo::RINKEBY,
 		)
 	}
 }
@@ -192,10 +192,17 @@ impl TestInfo {
 		TestInfo::default()
 	}
 
-	pub fn new_no_currency() -> TestInfo {
-		let mut new = TestInfo::default();
-		new.loan_terms.currency = CurrencyId::placeholder();
-		new
+	pub fn with_currency(currency: Currency) -> TestInfo {
+		let default = TestInfo::default();
+
+		TestInfo {
+			loan_terms: LoanTerms {
+				currency: CurrencyId::new::<Test>(&currency),
+				..default.loan_terms
+			},
+			currency,
+			..default
+		}
 	}
 
 	pub fn create_ask_order(&self) -> TestAskOrder {
@@ -220,6 +227,8 @@ impl TestInfo {
 	pub fn create_bid_order(&self) -> TestBidOrder {
 		let TestInfo { borrower, loan_terms, expiration_block, bid_guid, .. } = self;
 		let RegisteredAddress { address_id, account_id } = borrower;
+
+		Currencies::<Test>::insert(CurrencyId::new::<Test>(&self.currency), &self.currency);
 
 		assert_ok!(Creditcoin::add_bid_order(
 			Origin::signed(account_id.clone()),
@@ -288,24 +297,6 @@ impl TestInfo {
 		assert_ok!(Creditcoin::register_repayment_transfer(
 			Origin::signed(self.borrower.account_id.clone()),
 			TransferKind::Evm(EvmTransferKind::Ethless),
-			amount,
-			deal_order_id.clone(),
-			tx.as_bytes().into_bounded()
-		));
-
-		self.mock_transfer(&self.borrower, &self.lender, amount, deal_order_id, tx)
-	}
-
-	pub fn create_legacy_repayment_transfer(
-		&self,
-		deal_order_id: &TestDealOrderId,
-		amount: impl Into<ExternalAmount>,
-	) -> TestTransfer {
-		let tx = "0xafafaf";
-		let amount = amount.into();
-		assert_ok!(Creditcoin::register_repayment_transfer_legacy(
-			Origin::signed(self.borrower.account_id.clone()),
-			LegacyTransferKind::Ethless(ExternalAddress::default()),
 			amount,
 			deal_order_id.clone(),
 			tx.as_bytes().into_bounded()
@@ -387,15 +378,6 @@ pub fn ethless_currency(contract: ExternalAddress) -> Currency {
 		EvmCurrencyType::SmartContract(contract, [EvmTransferKind::Ethless].into_bounded()),
 		EvmInfo::RINKEBY,
 	)
-}
-
-pub fn register_ethless_currency(contract: ExternalAddress) {
-	register_currency(&ethless_currency(contract));
-}
-
-pub fn register_currency(currency: &Currency) {
-	let id = CurrencyId::new::<Test>(currency);
-	Currencies::<Test>::insert(id, currency);
 }
 
 pub fn get_register_address_message(who: AccountId) -> [u8; 32] {
@@ -561,8 +543,12 @@ fn register_transfer_ocw_fail_to_send() {
 
 		// we're going to verify a transfer twice:
 		// First when we expect failure, which means we won't make all of the requests
-		MockedRpcRequests::new(dummy_url, &tx_hash, &tx_block_num, &*ETHLESS_RESPONSES)
-			.mock_get_block_number(&mut state.write());
+		{
+			let mut state = state.write();
+			MockedRpcRequests::new(dummy_url, &tx_hash, &tx_block_num, &*ETHLESS_RESPONSES)
+				.mock_chain_id(&mut state)
+				.mock_get_block_number(&mut state);
+		}
 		// Second when we expect success, where we'll do all the requests
 		MockedRpcRequests::new(dummy_url, &tx_hash, &tx_block_num, &*ETHLESS_RESPONSES)
 			.mock_all(&mut state.write());
@@ -570,9 +556,13 @@ fn register_transfer_ocw_fail_to_send() {
 		set_rpc_uri(&Blockchain::RINKEBY, &dummy_url);
 
 		let loan_amount = get_mock_amount();
-		let terms = LoanTerms { amount: loan_amount, ..Default::default() };
-
-		let test_info = TestInfo { blockchain, loan_terms: terms, ..Default::default() };
+		let currency = ethless_currency(contract.clone());
+		let test_info = TestInfo::with_currency(currency);
+		let test_info = TestInfo {
+			blockchain,
+			loan_terms: LoanTerms { amount: loan_amount, ..test_info.loan_terms },
+			..test_info
+		};
 
 		let (_, deal_order_id) = test_info.create_deal_order();
 
@@ -580,9 +570,9 @@ fn register_transfer_ocw_fail_to_send() {
 
 		// exercise when we try to send a fail_transfer but tx send fails
 		with_failing_create_transaction(|| {
-			assert_ok!(Creditcoin::register_funding_transfer_legacy(
+			assert_ok!(Creditcoin::register_funding_transfer(
 				Origin::signed(lender.clone()),
-				LegacyTransferKind::Ethless(contract.clone()),
+				EvmTransferKind::Ethless.into(),
 				deal_order_id.clone(),
 				tx_hash.hex_to_address(),
 			));
@@ -1255,7 +1245,9 @@ fn fund_deal_order_should_error_when_deal_has_expired() {
 fn fund_deal_order_should_error_when_transfer_order_id_doesnt_match_deal_order_id() {
 	ExtBuilder::default().build_and_execute(|| {
 		// this is the primary deal_order
-		let test_info = TestInfo::new_defaults();
+		let contract = "0x0ad1439a0e0bfdcd49939f9722866651a4aa9b3c".as_bytes().into_bounded();
+		let currency = ethless_currency(contract.clone());
+		let test_info = TestInfo::with_currency(currency);
 		let (_, deal_order_id) = test_info.create_deal_order();
 
 		// this is a deal_order from another person
@@ -1267,7 +1259,7 @@ fn fund_deal_order_should_error_when_transfer_order_id_doesnt_match_deal_order_i
 				amount: 2_000_000u64.into(),
 				interest_rate: Default::default(),
 				term_length: Duration::from_millis(1_000_000),
-				currency: CurrencyId::placeholder(),
+				currency: CurrencyId::new::<Test>(&Default::default()),
 			},
 			ask_guid: "second-ask-guid".as_bytes().into_bounded(),
 			bid_guid: "second-bid-guid".as_bytes().into_bounded(),
@@ -1279,13 +1271,10 @@ fn fund_deal_order_should_error_when_transfer_order_id_doesnt_match_deal_order_i
 
 		//  insert as exemption to bypass transfer verification
 		let tx_hash = "0".as_bytes().into_bounded();
-		let contract = "0x0ad1439a0e0bfdcd49939f9722866651a4aa9b3c".as_bytes().into_bounded();
-		let currency = ethless_currency(contract.clone());
-		register_currency(&currency);
 
-		assert_ok!(Creditcoin::register_funding_transfer_legacy(
+		assert_ok!(Creditcoin::register_funding_transfer(
 			Origin::signed(second_test_info.lender.account_id.clone()),
-			LegacyTransferKind::Ethless(contract),
+			TransferKind::Evm(EvmTransferKind::Ethless),
 			bogus_deal_order_id.clone(),
 			tx_hash
 		));
@@ -1308,19 +1297,18 @@ fn fund_deal_order_should_error_when_transfer_order_id_doesnt_match_deal_order_i
 #[test]
 fn fund_deal_order_should_error_when_transfer_amount_doesnt_match() {
 	ExtBuilder::default().build_and_execute(|| {
-		let test_info = TestInfo::new_no_currency();
+		let contract = "0x0ad1439a0e0bfdcd49939f9722866651a4aa9b3c".as_bytes().into_bounded();
+		let currency = ethless_currency(contract.clone());
+
+		let test_info = TestInfo::with_currency(currency);
 		let (_deal_order, deal_order_id) = test_info.create_deal_order();
 
 		//  insert as exemption to bypass transfer verification
 		let tx_hash = "0".as_bytes().into_bounded();
-		let contract = "0x0ad1439a0e0bfdcd49939f9722866651a4aa9b3c".as_bytes().into_bounded();
 
-		let currency = ethless_currency(contract.clone());
-		register_currency(&currency);
-
-		assert_ok!(Creditcoin::register_funding_transfer_legacy(
+		assert_ok!(Creditcoin::register_funding_transfer(
 			Origin::signed(test_info.lender.account_id.clone()),
-			LegacyTransferKind::Ethless(contract),
+			EvmTransferKind::Ethless.into(),
 			deal_order_id.clone(),
 			tx_hash
 		));
@@ -1351,19 +1339,19 @@ fn fund_deal_order_should_error_when_transfer_amount_doesnt_match() {
 #[test]
 fn fund_deal_order_should_error_when_transfer_sighash_doesnt_match_lender() {
 	ExtBuilder::default().build_and_execute(|| {
-		let test_info = TestInfo::new_no_currency();
+		let contract = "0x0ad1439a0e0bfdcd49939f9722866651a4aa9b3c".as_bytes().into_bounded();
+		let currency = ethless_currency(contract.clone());
+
+		let test_info = TestInfo::with_currency(currency);
+
 		let (deal_order, deal_order_id) = test_info.create_deal_order();
 
 		//  insert as exemption to bypass transfer verification
 		let tx_hash = "0".as_bytes().into_bounded();
-		let contract = "0x0ad1439a0e0bfdcd49939f9722866651a4aa9b3c".as_bytes().into_bounded();
 
-		let currency = ethless_currency(contract.clone());
-		register_currency(&currency);
-
-		assert_ok!(Creditcoin::register_funding_transfer_legacy(
+		assert_ok!(Creditcoin::register_funding_transfer(
 			Origin::signed(test_info.lender.account_id.clone()),
-			LegacyTransferKind::Ethless(contract),
+			EvmTransferKind::Ethless.into(),
 			deal_order_id.clone(),
 			tx_hash
 		));
@@ -1421,19 +1409,17 @@ fn fund_deal_order_works() {
 	ExtBuilder::default().build_and_execute(|| {
 		System::set_block_number(1);
 
-		let test_info = TestInfo::new_no_currency();
+		let contract = "0x0ad1439a0e0bfdcd49939f9722866651a4aa9b3c".as_bytes().into_bounded();
+		let currency = ethless_currency(contract.clone());
+		let test_info = TestInfo::with_currency(currency);
 		let (deal_order, deal_order_id) = test_info.create_deal_order();
 
 		//  insert as exemption to bypass transfer verification
 		let tx_hash = "0".as_bytes().into_bounded();
-		let contract = "0x0ad1439a0e0bfdcd49939f9722866651a4aa9b3c".as_bytes().into_bounded();
 
-		let currency = ethless_currency(contract.clone());
-		register_currency(&currency);
-
-		assert_ok!(Creditcoin::register_funding_transfer_legacy(
+		assert_ok!(Creditcoin::register_funding_transfer(
 			Origin::signed(test_info.lender.account_id.clone()),
-			LegacyTransferKind::Ethless(contract),
+			EvmTransferKind::Ethless.into(),
 			deal_order_id.clone(),
 			tx_hash
 		));
@@ -2018,7 +2004,7 @@ fn register_deal_order_accepts_ed25519() {
 #[test]
 fn close_deal_order_should_error_when_not_signed() {
 	ExtBuilder::default().build_and_execute(|| {
-		let test_info = TestInfo::new_no_currency();
+		let test_info = TestInfo::new_defaults();
 		let (_, deal_order_id) = test_info.create_deal_order();
 		let transfer_id = TransferId::new::<Test>(&test_info.blockchain, b"12345678");
 
@@ -2032,7 +2018,7 @@ fn close_deal_order_should_error_when_not_signed() {
 #[test]
 fn close_deal_order_should_error_when_borrower_address_is_not_registered() {
 	ExtBuilder::default().build_and_execute(|| {
-		let test_info = TestInfo::new_no_currency();
+		let test_info = TestInfo::new_defaults();
 		let (_, deal_order_id) = test_info.create_deal_order();
 		let transfer_id = TransferId::new::<Test>(&test_info.blockchain, b"12345678");
 
@@ -2184,7 +2170,7 @@ fn close_deal_order_should_error_when_transfer_order_id_doesnt_match_deal_order_
 				amount: 2_000_000u64.into(),
 				interest_rate: Default::default(),
 				term_length: Duration::from_millis(1_000_000),
-				currency: CurrencyId::placeholder(),
+				currency: CurrencyId::new::<Test>(&Currency::default()),
 			},
 			ask_guid: "second-ask-guid".as_bytes().into_bounded(),
 			bid_guid: "second-bid-guid".as_bytes().into_bounded(),
@@ -2195,7 +2181,7 @@ fn close_deal_order_should_error_when_transfer_order_id_doesnt_match_deal_order_
 		let (_bogus_deal_order, bogus_deal_order_id) = second_test_info.create_deal_order();
 
 		let (_, transfer_id) =
-			second_test_info.create_legacy_repayment_transfer(&bogus_deal_order_id, 33u64);
+			second_test_info.create_repayment_transfer(&bogus_deal_order_id, 33u64);
 
 		// Person1 tries closing the deal by using the transfer made by Person2
 		assert_noop!(
@@ -2212,7 +2198,7 @@ fn close_deal_order_should_error_when_transfer_order_id_doesnt_match_deal_order_
 #[test]
 fn close_deal_order_should_error_when_transfer_block_is_greater_than_current_block() {
 	ExtBuilder::default().build_and_execute(|| {
-		let test_info = TestInfo::new_no_currency();
+		let test_info = TestInfo::new_defaults();
 		let (deal_order, deal_order_id) = test_info.create_deal_order();
 
 		// lock DealOrder
@@ -2226,7 +2212,7 @@ fn close_deal_order_should_error_when_transfer_block_is_greater_than_current_blo
 		);
 
 		let (_transfer, transfer_id) =
-			test_info.create_legacy_repayment_transfer(&deal_order_id, deal_order.terms.amount);
+			test_info.create_repayment_transfer(&deal_order_id, deal_order.terms.amount);
 
 		// modify transfer in order to cause transfer mismatch
 		crate::Transfers::<Test>::mutate(&transfer_id, |transfer_storage| {
@@ -2250,7 +2236,7 @@ fn close_deal_order_should_error_when_transfer_block_is_greater_than_current_blo
 #[test]
 fn close_deal_order_should_error_when_transfer_sighash_doesnt_match_borrower() {
 	ExtBuilder::default().build_and_execute(|| {
-		let test_info = TestInfo::new_no_currency();
+		let test_info = TestInfo::default();
 		let (deal_order, deal_order_id) = test_info.create_deal_order();
 
 		// lock DealOrder
@@ -2264,7 +2250,7 @@ fn close_deal_order_should_error_when_transfer_sighash_doesnt_match_borrower() {
 		);
 
 		let (_, transfer_id) =
-			test_info.create_legacy_repayment_transfer(&deal_order_id, deal_order.terms.amount);
+			test_info.create_repayment_transfer(&deal_order_id, deal_order.terms.amount);
 
 		// modify transfer in order to cause transfer mismatch
 		crate::Transfers::<Test>::mutate(&transfer_id, |transfer_storage| {
@@ -2286,7 +2272,7 @@ fn close_deal_order_should_error_when_transfer_sighash_doesnt_match_borrower() {
 #[test]
 fn close_deal_order_should_error_when_transfer_has_already_been_processed() {
 	ExtBuilder::default().build_and_execute(|| {
-		let test_info = TestInfo::new_no_currency();
+		let test_info = TestInfo::default();
 		let (deal_order, deal_order_id) = test_info.create_deal_order();
 
 		// lock DealOrder
@@ -2300,7 +2286,7 @@ fn close_deal_order_should_error_when_transfer_has_already_been_processed() {
 		);
 
 		let (_, transfer_id) =
-			test_info.create_legacy_repayment_transfer(&deal_order_id, deal_order.terms.amount);
+			test_info.create_repayment_transfer(&deal_order_id, deal_order.terms.amount);
 
 		// modify transfer in order to cause transfer mismatch
 		crate::Transfers::<Test>::mutate(&transfer_id, |transfer_storage| {
@@ -2324,8 +2310,10 @@ fn close_deal_order_should_error_when_transfer_has_already_been_processed() {
 fn close_deal_order_should_succeed() {
 	ExtBuilder::default().build_and_execute(|| {
 		System::set_block_number(1);
+		let contract = "0x0ad1439a0e0bfdcd49939f9722866651a4aa9b3c".as_bytes().into_bounded();
+		let currency = ethless_currency(contract.clone());
 
-		let test_info = TestInfo::new_no_currency();
+		let test_info = TestInfo::with_currency(currency);
 		let (deal_order, deal_order_id) = test_info.create_deal_order();
 
 		// lock DealOrder
@@ -2340,17 +2328,16 @@ fn close_deal_order_should_succeed() {
 
 		//  insert as exemption to bypass transfer verification
 		let tx_hash = "0".as_bytes().into_bounded();
-		let contract = "0x0ad1439a0e0bfdcd49939f9722866651a4aa9b3c".as_bytes().into_bounded();
-		register_ethless_currency(contract.clone());
 
-		assert_ok!(Creditcoin::register_transfer_internal_legacy(
+		assert_ok!(Creditcoin::register_transfer_internal(
 			test_info.borrower.account_id.clone(),
 			test_info.borrower.address_id.clone(),
 			test_info.lender.address_id.clone(),
-			LegacyTransferKind::Ethless(contract),
+			EvmTransferKind::Ethless.into(),
 			33u64.into(),
 			deal_order_id.clone(),
-			tx_hash
+			tx_hash,
+			&test_info.loan_terms.currency
 		));
 
 		let (_, transfer_id) =
@@ -2729,7 +2716,7 @@ fn on_initialize_removes_expired_deals_without_transfers() {
 					amount: 2_000_000u64.into(),
 					interest_rate: Default::default(),
 					term_length: Duration::from_millis(1_000_000),
-					currency: CurrencyId::placeholder(),
+					currency: CurrencyId::new::<Test>(&Currency::default()),
 				},
 				ask_guid: format!("{:?}-ask-guid", expiration_block.clone())
 					.as_bytes()
@@ -2754,9 +2741,9 @@ fn on_initialize_removes_expired_deals_without_transfers() {
 			// fund only deal orders which expire at even blocks
 			if expiration_block % 2 == 0 {
 				let tx = format!("0xfafafa{:02}", expiration_block.clone());
-				assert_ok!(Creditcoin::register_funding_transfer_legacy(
+				assert_ok!(Creditcoin::register_funding_transfer(
 					Origin::signed(test_info.lender.account_id.clone()),
-					LegacyTransferKind::Ethless(ExternalAddress::default()),
+					EvmTransferKind::Ethless.into(),
 					deal_order_id.clone(),
 					tx.as_bytes().into_bounded()
 				));

--- a/pallets/creditcoin/src/tests.rs
+++ b/pallets/creditcoin/src/tests.rs
@@ -2271,7 +2271,7 @@ fn close_deal_order_should_succeed() {
 		let tx_hash = "0".as_bytes().into_bounded();
 		let contract = "0x0ad1439a0e0bfdcd49939f9722866651a4aa9b3c".as_bytes().into_bounded();
 
-		assert_ok!(Creditcoin::register_transfer_internal(
+		assert_ok!(Creditcoin::register_transfer_internal_legacy(
 			test_info.borrower.account_id.clone(),
 			test_info.borrower.address_id.clone(),
 			test_info.lender.address_id.clone(),
@@ -2804,7 +2804,7 @@ fn register_repayment_transfer_should_error_when_not_deal_order_not_found() {
 }
 
 #[test]
-fn register_transfer_internal_should_error_with_non_existent_lender_address() {
+fn register_transfer_internal_legacy_should_error_with_non_existent_lender_address() {
 	ExtBuilder::default().build_and_execute(|| {
 		let test_info = TestInfo::new_defaults();
 		let (deal_order, deal_order_id) = test_info.create_deal_order();
@@ -2812,7 +2812,7 @@ fn register_transfer_internal_should_error_with_non_existent_lender_address() {
 		let bogus_address =
 			AddressId::new::<Test>(&Blockchain::Rinkeby, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 0]);
 
-		let result = Creditcoin::register_transfer_internal(
+		let result = Creditcoin::register_transfer_internal_legacy(
 			test_info.lender.account_id,
 			bogus_address,
 			deal_order.borrower_address_id,
@@ -2828,7 +2828,7 @@ fn register_transfer_internal_should_error_with_non_existent_lender_address() {
 }
 
 #[test]
-fn register_transfer_internal_should_error_with_non_existent_borrower_address() {
+fn register_transfer_internal_legacy_should_error_with_non_existent_borrower_address() {
 	ExtBuilder::default().build_and_execute(|| {
 		let test_info = TestInfo::new_defaults();
 		let (deal_order, deal_order_id) = test_info.create_deal_order();
@@ -2836,7 +2836,7 @@ fn register_transfer_internal_should_error_with_non_existent_borrower_address() 
 		let bogus_address =
 			AddressId::new::<Test>(&Blockchain::Rinkeby, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 0]);
 
-		let result = Creditcoin::register_transfer_internal(
+		let result = Creditcoin::register_transfer_internal_legacy(
 			test_info.lender.account_id,
 			deal_order.lender_address_id,
 			bogus_address,
@@ -2852,13 +2852,13 @@ fn register_transfer_internal_should_error_with_non_existent_borrower_address() 
 }
 
 #[test]
-fn register_transfer_internal_should_error_when_signer_doesnt_own_from_address() {
+fn register_transfer_internal_legacy_should_error_when_signer_doesnt_own_from_address() {
 	ExtBuilder::default().build_and_execute(|| {
 		let test_info = TestInfo::new_defaults();
 		let (deal_order, deal_order_id) = test_info.create_deal_order();
 		let tx = "0xabcabcabc";
 
-		let result = Creditcoin::register_transfer_internal(
+		let result = Creditcoin::register_transfer_internal_legacy(
 			test_info.lender.account_id,
 			deal_order.borrower_address_id, // should match 1st argument
 			deal_order.lender_address_id,
@@ -2874,14 +2874,14 @@ fn register_transfer_internal_should_error_when_signer_doesnt_own_from_address()
 }
 
 #[test]
-fn register_transfer_internal_should_error_when_addresses_are_not_on_the_same_blockchain() {
+fn register_transfer_internal_legacy_should_error_when_addresses_are_not_on_the_same_blockchain() {
 	ExtBuilder::default().build_and_execute(|| {
 		let test_info = TestInfo::new_defaults();
 		let (deal_order, deal_order_id) = test_info.create_deal_order();
 		let second_borrower = RegisteredAddress::new("borrower2", Blockchain::Luniverse);
 		let tx = "0xabcabcabc";
 
-		let result = Creditcoin::register_transfer_internal(
+		let result = Creditcoin::register_transfer_internal_legacy(
 			test_info.lender.account_id,
 			deal_order.lender_address_id,
 			second_borrower.address_id,
@@ -2897,13 +2897,13 @@ fn register_transfer_internal_should_error_when_addresses_are_not_on_the_same_bl
 }
 
 #[test]
-fn register_transfer_internal_should_error_when_transfer_kind_is_not_supported() {
+fn register_transfer_internal_legacy_should_error_when_transfer_kind_is_not_supported() {
 	ExtBuilder::default().build_and_execute(|| {
 		let test_info = TestInfo::new_defaults();
 		let (deal_order, deal_order_id) = test_info.create_deal_order();
 		let tx = "0xabcabcabc";
 
-		let result = Creditcoin::register_transfer_internal(
+		let result = Creditcoin::register_transfer_internal_legacy(
 			test_info.lender.account_id,
 			deal_order.lender_address_id,
 			deal_order.borrower_address_id,
@@ -2920,13 +2920,13 @@ fn register_transfer_internal_should_error_when_transfer_kind_is_not_supported()
 }
 
 #[test]
-fn register_transfer_internal_should_error_when_transfer_is_already_registered() {
+fn register_transfer_internal_legacy_should_error_when_transfer_is_already_registered() {
 	ExtBuilder::default().build_and_execute(|| {
 		let test_info = TestInfo::new_defaults();
 		let (deal_order, deal_order_id) = test_info.create_deal_order();
 		let (transfer, _transfer_id) = test_info.create_funding_transfer(&deal_order_id);
 
-		let result = Creditcoin::register_transfer_internal(
+		let result = Creditcoin::register_transfer_internal_legacy(
 			test_info.lender.account_id,
 			deal_order.lender_address_id,
 			deal_order.borrower_address_id,

--- a/pallets/creditcoin/src/tests.rs
+++ b/pallets/creditcoin/src/tests.rs
@@ -192,6 +192,12 @@ impl TestInfo {
 		TestInfo::default()
 	}
 
+	pub fn new_no_currency() -> TestInfo {
+		let mut new = TestInfo::default();
+		new.loan_terms.currency = CurrencyId::placeholder();
+		new
+	}
+
 	pub fn create_ask_order(&self) -> TestAskOrder {
 		let TestInfo { lender, loan_terms, expiration_block, ask_guid, .. } = self;
 		let RegisteredAddress { address_id, account_id } = lender;
@@ -273,6 +279,24 @@ impl TestInfo {
 	}
 
 	pub fn create_repayment_transfer(
+		&self,
+		deal_order_id: &TestDealOrderId,
+		amount: impl Into<ExternalAmount>,
+	) -> TestTransfer {
+		let tx = "0xafafaf";
+		let amount = amount.into();
+		assert_ok!(Creditcoin::register_repayment_transfer_new(
+			Origin::signed(self.borrower.account_id.clone()),
+			TransferKind::Evm(EvmTransferKind::Ethless),
+			amount,
+			deal_order_id.clone(),
+			tx.as_bytes().into_bounded()
+		));
+
+		self.mock_transfer(&self.borrower, &self.lender, amount, deal_order_id, tx)
+	}
+
+	pub fn create_legacy_repayment_transfer(
 		&self,
 		deal_order_id: &TestDealOrderId,
 		amount: impl Into<ExternalAmount>,
@@ -363,6 +387,10 @@ pub fn ethless_currency(contract: ExternalAddress) -> Currency {
 		EvmCurrencyType::SmartContract(contract, [EvmTransferKind::Ethless].into_bounded()),
 		EvmInfo::RINKEBY,
 	)
+}
+
+pub fn register_ethless_currency(contract: ExternalAddress) {
+	register_currency(&ethless_currency(contract));
 }
 
 pub fn register_currency(currency: &Currency) {
@@ -1280,10 +1308,7 @@ fn fund_deal_order_should_error_when_transfer_order_id_doesnt_match_deal_order_i
 #[test]
 fn fund_deal_order_should_error_when_transfer_amount_doesnt_match() {
 	ExtBuilder::default().build_and_execute(|| {
-		let test_info = TestInfo {
-			loan_terms: LoanTerms { currency: CurrencyId::placeholder(), ..Default::default() },
-			..Default::default()
-		};
+		let test_info = TestInfo::new_no_currency();
 		let (_deal_order, deal_order_id) = test_info.create_deal_order();
 
 		//  insert as exemption to bypass transfer verification
@@ -1326,10 +1351,7 @@ fn fund_deal_order_should_error_when_transfer_amount_doesnt_match() {
 #[test]
 fn fund_deal_order_should_error_when_transfer_sighash_doesnt_match_lender() {
 	ExtBuilder::default().build_and_execute(|| {
-		let test_info = TestInfo {
-			loan_terms: LoanTerms { currency: CurrencyId::placeholder(), ..Default::default() },
-			..Default::default()
-		};
+		let test_info = TestInfo::new_no_currency();
 		let (deal_order, deal_order_id) = test_info.create_deal_order();
 
 		//  insert as exemption to bypass transfer verification
@@ -1399,10 +1421,7 @@ fn fund_deal_order_works() {
 	ExtBuilder::default().build_and_execute(|| {
 		System::set_block_number(1);
 
-		let test_info = TestInfo {
-			loan_terms: LoanTerms { currency: CurrencyId::placeholder(), ..Default::default() },
-			..Default::default()
-		};
+		let test_info = TestInfo::new_no_currency();
 		let (deal_order, deal_order_id) = test_info.create_deal_order();
 
 		//  insert as exemption to bypass transfer verification
@@ -1999,7 +2018,7 @@ fn register_deal_order_accepts_ed25519() {
 #[test]
 fn close_deal_order_should_error_when_not_signed() {
 	ExtBuilder::default().build_and_execute(|| {
-		let test_info = TestInfo::new_defaults();
+		let test_info = TestInfo::new_no_currency();
 		let (_, deal_order_id) = test_info.create_deal_order();
 		let transfer_id = TransferId::new::<Test>(&test_info.blockchain, b"12345678");
 
@@ -2013,7 +2032,7 @@ fn close_deal_order_should_error_when_not_signed() {
 #[test]
 fn close_deal_order_should_error_when_borrower_address_is_not_registered() {
 	ExtBuilder::default().build_and_execute(|| {
-		let test_info = TestInfo::new_defaults();
+		let test_info = TestInfo::new_no_currency();
 		let (_, deal_order_id) = test_info.create_deal_order();
 		let transfer_id = TransferId::new::<Test>(&test_info.blockchain, b"12345678");
 
@@ -2176,7 +2195,7 @@ fn close_deal_order_should_error_when_transfer_order_id_doesnt_match_deal_order_
 		let (_bogus_deal_order, bogus_deal_order_id) = second_test_info.create_deal_order();
 
 		let (_, transfer_id) =
-			second_test_info.create_repayment_transfer(&bogus_deal_order_id, 33u64);
+			second_test_info.create_legacy_repayment_transfer(&bogus_deal_order_id, 33u64);
 
 		// Person1 tries closing the deal by using the transfer made by Person2
 		assert_noop!(
@@ -2193,7 +2212,7 @@ fn close_deal_order_should_error_when_transfer_order_id_doesnt_match_deal_order_
 #[test]
 fn close_deal_order_should_error_when_transfer_block_is_greater_than_current_block() {
 	ExtBuilder::default().build_and_execute(|| {
-		let test_info = TestInfo::new_defaults();
+		let test_info = TestInfo::new_no_currency();
 		let (deal_order, deal_order_id) = test_info.create_deal_order();
 
 		// lock DealOrder
@@ -2207,7 +2226,7 @@ fn close_deal_order_should_error_when_transfer_block_is_greater_than_current_blo
 		);
 
 		let (_transfer, transfer_id) =
-			test_info.create_repayment_transfer(&deal_order_id, deal_order.terms.amount);
+			test_info.create_legacy_repayment_transfer(&deal_order_id, deal_order.terms.amount);
 
 		// modify transfer in order to cause transfer mismatch
 		crate::Transfers::<Test>::mutate(&transfer_id, |transfer_storage| {
@@ -2231,7 +2250,7 @@ fn close_deal_order_should_error_when_transfer_block_is_greater_than_current_blo
 #[test]
 fn close_deal_order_should_error_when_transfer_sighash_doesnt_match_borrower() {
 	ExtBuilder::default().build_and_execute(|| {
-		let test_info = TestInfo::new_defaults();
+		let test_info = TestInfo::new_no_currency();
 		let (deal_order, deal_order_id) = test_info.create_deal_order();
 
 		// lock DealOrder
@@ -2245,7 +2264,7 @@ fn close_deal_order_should_error_when_transfer_sighash_doesnt_match_borrower() {
 		);
 
 		let (_, transfer_id) =
-			test_info.create_repayment_transfer(&deal_order_id, deal_order.terms.amount);
+			test_info.create_legacy_repayment_transfer(&deal_order_id, deal_order.terms.amount);
 
 		// modify transfer in order to cause transfer mismatch
 		crate::Transfers::<Test>::mutate(&transfer_id, |transfer_storage| {
@@ -2267,7 +2286,7 @@ fn close_deal_order_should_error_when_transfer_sighash_doesnt_match_borrower() {
 #[test]
 fn close_deal_order_should_error_when_transfer_has_already_been_processed() {
 	ExtBuilder::default().build_and_execute(|| {
-		let test_info = TestInfo::new_defaults();
+		let test_info = TestInfo::new_no_currency();
 		let (deal_order, deal_order_id) = test_info.create_deal_order();
 
 		// lock DealOrder
@@ -2281,7 +2300,7 @@ fn close_deal_order_should_error_when_transfer_has_already_been_processed() {
 		);
 
 		let (_, transfer_id) =
-			test_info.create_repayment_transfer(&deal_order_id, deal_order.terms.amount);
+			test_info.create_legacy_repayment_transfer(&deal_order_id, deal_order.terms.amount);
 
 		// modify transfer in order to cause transfer mismatch
 		crate::Transfers::<Test>::mutate(&transfer_id, |transfer_storage| {
@@ -2306,7 +2325,7 @@ fn close_deal_order_should_succeed() {
 	ExtBuilder::default().build_and_execute(|| {
 		System::set_block_number(1);
 
-		let test_info = TestInfo::new_defaults();
+		let test_info = TestInfo::new_no_currency();
 		let (deal_order, deal_order_id) = test_info.create_deal_order();
 
 		// lock DealOrder
@@ -2322,6 +2341,7 @@ fn close_deal_order_should_succeed() {
 		//  insert as exemption to bypass transfer verification
 		let tx_hash = "0".as_bytes().into_bounded();
 		let contract = "0x0ad1439a0e0bfdcd49939f9722866651a4aa9b3c".as_bytes().into_bounded();
+		register_ethless_currency(contract.clone());
 
 		assert_ok!(Creditcoin::register_transfer_internal_legacy(
 			test_info.borrower.account_id.clone(),

--- a/pallets/creditcoin/src/tests/collectCoins.json
+++ b/pallets/creditcoin/src/tests/collectCoins.json
@@ -473,5 +473,10 @@
       "transactionsRoot": "0x4270c05aff0c30786ff65957ed7b2d6c964482b5acc9bfc18e12f1aa4736b453",
       "uncles": []
     }
+  },
+  "eth_chainId": {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": "0x4"
   }
 }

--- a/pallets/creditcoin/src/tests/ethlessTransfer.json
+++ b/pallets/creditcoin/src/tests/ethlessTransfer.json
@@ -108,5 +108,10 @@
       "uncles": [],
       "baseFeePerGas": "0x7"
     }
+  },
+  "eth_chainId": {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": "0x4"
   }
 }

--- a/pallets/creditcoin/src/types.rs
+++ b/pallets/creditcoin/src/types.rs
@@ -36,30 +36,6 @@ mod bounded_serde;
 #[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
-pub enum OldBlockchain {
-	Ethereum,
-	Rinkeby,
-	Luniverse,
-	Bitcoin,
-	#[cfg_attr(feature = "std", serde(with = "bounded_serde"))]
-	Other(OtherChain),
-}
-
-impl OldBlockchain {
-	pub fn as_bytes(&self) -> &[u8] {
-		match self {
-			OldBlockchain::Ethereum => b"ethereum",
-			OldBlockchain::Rinkeby => b"rinkeby",
-			OldBlockchain::Luniverse => b"luniverse",
-			OldBlockchain::Bitcoin => b"bitcoin",
-			OldBlockchain::Other(chain) => chain.as_slice(),
-		}
-	}
-}
-
-#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
-#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub enum LegacyTransferKind {
 	#[cfg_attr(feature = "std", serde(with = "bounded_serde"))]
 	Erc20(ExternalAddress),
@@ -74,7 +50,7 @@ pub enum LegacyTransferKind {
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct Address<AccountId> {
-	pub blockchain: OldBlockchain,
+	pub blockchain: Blockchain,
 	#[cfg_attr(feature = "std", serde(with = "bounded_serde"))]
 	pub value: ExternalAddress,
 	pub owner: AccountId,
@@ -100,7 +76,7 @@ pub struct CollectedCoins<Hash, Balance> {
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct Transfer<AccountId, BlockNum, Hash, Moment> {
-	pub blockchain: OldBlockchain,
+	pub blockchain: Blockchain,
 	pub kind: LegacyTransferKind,
 	pub from: AddressId<Hash>,
 	pub to: AddressId<Hash>,
@@ -262,7 +238,7 @@ macro_rules! concatenate {
 pub(crate) use concatenate;
 
 impl<H> AddressId<H> {
-	pub fn new<Config>(blockchain: &OldBlockchain, address: &[u8]) -> AddressId<H>
+	pub fn new<Config>(blockchain: &Blockchain, address: &[u8]) -> AddressId<H>
 	where
 		Config: frame_system::Config,
 		<Config as frame_system::Config>::Hashing: Hash<Output = H>,
@@ -303,7 +279,7 @@ impl<B, H> RepaymentOrderId<B, H> {
 }
 
 impl<H> TransferId<H> {
-	pub fn new<Config>(blockchain: &OldBlockchain, blockchain_tx_id: &[u8]) -> TransferId<H>
+	pub fn new<Config>(blockchain: &Blockchain, blockchain_tx_id: &[u8]) -> TransferId<H>
 	where
 		Config: frame_system::Config,
 		<Config as frame_system::Config>::Hashing: Hash<Output = H>,

--- a/pallets/creditcoin/src/types.rs
+++ b/pallets/creditcoin/src/types.rs
@@ -128,7 +128,7 @@ pub struct Offer<AccountId, BlockNum, Hash> {
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct AskOrder<AccountId, BlockNum, Hash> {
 	pub lender_address_id: AddressId<Hash>,
-	pub terms: AskTerms,
+	pub terms: AskTerms<Hash>,
 	pub expiration_block: BlockNum,
 	pub block: BlockNum,
 	pub lender: AccountId,
@@ -139,7 +139,7 @@ pub struct AskOrder<AccountId, BlockNum, Hash> {
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct BidOrder<AccountId, BlockNum, Hash> {
 	pub borrower_address_id: AddressId<Hash>,
-	pub terms: BidTerms,
+	pub terms: BidTerms<Hash>,
 	pub expiration_block: BlockNum,
 	pub block: BlockNum,
 	pub borrower: AccountId,
@@ -152,7 +152,7 @@ pub struct DealOrder<AccountId, BlockNum, Hash, Moment> {
 	pub offer_id: OfferId<BlockNum, Hash>,
 	pub lender_address_id: AddressId<Hash>,
 	pub borrower_address_id: AddressId<Hash>,
-	pub terms: LoanTerms,
+	pub terms: LoanTerms<Hash>,
 	pub expiration_block: BlockNum,
 	pub timestamp: Moment,
 	pub block: Option<BlockNum>,
@@ -174,12 +174,16 @@ impl<Hash> AddressId<Hash> {
 	}
 }
 
-#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+#[derive(
+	Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen, PartialOrd, Ord,
+)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct AskOrderId<BlockNum, Hash>(BlockNum, Hash);
 
-#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+#[derive(
+	Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen, PartialOrd, Ord,
+)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct BidOrderId<BlockNum, Hash>(BlockNum, Hash);

--- a/pallets/creditcoin/src/types.rs
+++ b/pallets/creditcoin/src/types.rs
@@ -240,6 +240,13 @@ pub struct OfferId<BlockNum, Hash>(BlockNum, Hash);
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct TransferId<Hash>(Hash);
 
+#[cfg(test)]
+impl<Hash> TransferId<Hash> {
+	pub fn make(hash: Hash) -> Self {
+		Self(hash)
+	}
+}
+
 #[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]

--- a/pallets/creditcoin/src/types.rs
+++ b/pallets/creditcoin/src/types.rs
@@ -77,7 +77,7 @@ pub struct CollectedCoins<Hash, Balance> {
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct Transfer<AccountId, BlockNum, Hash, Moment> {
 	pub blockchain: Blockchain,
-	pub kind: LegacyTransferKind,
+	pub kind: TransferKind,
 	pub from: AddressId<Hash>,
 	pub to: AddressId<Hash>,
 	pub deal_order_id: DealOrderId<BlockNum, Hash>,

--- a/pallets/creditcoin/src/types.rs
+++ b/pallets/creditcoin/src/types.rs
@@ -101,15 +101,18 @@ pub struct UnverifiedCollectedCoins {
 }
 
 #[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
-#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct UnverifiedTransfer<AccountId, BlockNum, Hash, Moment> {
 	pub transfer: Transfer<AccountId, BlockNum, Hash, Moment>,
-	#[cfg_attr(feature = "std", serde(with = "bounded_serde"))]
 	pub from_external: ExternalAddress,
-	#[cfg_attr(feature = "std", serde(with = "bounded_serde"))]
 	pub to_external: ExternalAddress,
 	pub deadline: BlockNum,
+	pub currency_to_check: CurrencyOrLegacyTransferKind,
+}
+
+#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+pub enum CurrencyOrLegacyTransferKind {
+	Currency(Currency),
+	TransferKind(LegacyTransferKind),
 }
 
 #[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]

--- a/pallets/creditcoin/src/types.rs
+++ b/pallets/creditcoin/src/types.rs
@@ -60,7 +60,7 @@ impl Blockchain {
 #[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
-pub enum TransferKind {
+pub enum LegacyTransferKind {
 	#[cfg_attr(feature = "std", serde(with = "bounded_serde"))]
 	Erc20(ExternalAddress),
 	#[cfg_attr(feature = "std", serde(with = "bounded_serde"))]
@@ -101,7 +101,7 @@ pub struct CollectedCoins<Hash, Balance> {
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct Transfer<AccountId, BlockNum, Hash, Moment> {
 	pub blockchain: Blockchain,
-	pub kind: TransferKind,
+	pub kind: LegacyTransferKind,
 	pub from: AddressId<Hash>,
 	pub to: AddressId<Hash>,
 	pub deal_order_id: DealOrderId<BlockNum, Hash>,
@@ -194,6 +194,13 @@ pub struct DealOrder<AccountId, BlockNum, Hash, Moment> {
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct AddressId<Hash>(Hash);
+
+#[cfg(test)]
+impl<Hash> AddressId<Hash> {
+	pub fn make(hash: Hash) -> Self {
+		Self(hash)
+	}
+}
 
 #[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]

--- a/pallets/creditcoin/src/types.rs
+++ b/pallets/creditcoin/src/types.rs
@@ -36,7 +36,7 @@ mod bounded_serde;
 #[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
-pub enum Blockchain {
+pub enum OldBlockchain {
 	Ethereum,
 	Rinkeby,
 	Luniverse,
@@ -45,14 +45,14 @@ pub enum Blockchain {
 	Other(OtherChain),
 }
 
-impl Blockchain {
+impl OldBlockchain {
 	pub fn as_bytes(&self) -> &[u8] {
 		match self {
-			Blockchain::Ethereum => b"ethereum",
-			Blockchain::Rinkeby => b"rinkeby",
-			Blockchain::Luniverse => b"luniverse",
-			Blockchain::Bitcoin => b"bitcoin",
-			Blockchain::Other(chain) => chain.as_slice(),
+			OldBlockchain::Ethereum => b"ethereum",
+			OldBlockchain::Rinkeby => b"rinkeby",
+			OldBlockchain::Luniverse => b"luniverse",
+			OldBlockchain::Bitcoin => b"bitcoin",
+			OldBlockchain::Other(chain) => chain.as_slice(),
 		}
 	}
 }
@@ -74,7 +74,7 @@ pub enum LegacyTransferKind {
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct Address<AccountId> {
-	pub blockchain: Blockchain,
+	pub blockchain: OldBlockchain,
 	#[cfg_attr(feature = "std", serde(with = "bounded_serde"))]
 	pub value: ExternalAddress,
 	pub owner: AccountId,
@@ -100,7 +100,7 @@ pub struct CollectedCoins<Hash, Balance> {
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct Transfer<AccountId, BlockNum, Hash, Moment> {
-	pub blockchain: Blockchain,
+	pub blockchain: OldBlockchain,
 	pub kind: LegacyTransferKind,
 	pub from: AddressId<Hash>,
 	pub to: AddressId<Hash>,
@@ -140,7 +140,6 @@ pub struct UnverifiedTransfer<AccountId, BlockNum, Hash, Moment> {
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct Offer<AccountId, BlockNum, Hash> {
-	pub blockchain: Blockchain,
 	pub ask_id: AskOrderId<BlockNum, Hash>,
 	pub bid_id: BidOrderId<BlockNum, Hash>,
 	pub expiration_block: BlockNum,
@@ -152,7 +151,6 @@ pub struct Offer<AccountId, BlockNum, Hash> {
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct AskOrder<AccountId, BlockNum, Hash> {
-	pub blockchain: Blockchain,
 	pub lender_address_id: AddressId<Hash>,
 	pub terms: AskTerms,
 	pub expiration_block: BlockNum,
@@ -164,7 +162,6 @@ pub struct AskOrder<AccountId, BlockNum, Hash> {
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct BidOrder<AccountId, BlockNum, Hash> {
-	pub blockchain: Blockchain,
 	pub borrower_address_id: AddressId<Hash>,
 	pub terms: BidTerms,
 	pub expiration_block: BlockNum,
@@ -176,7 +173,6 @@ pub struct BidOrder<AccountId, BlockNum, Hash> {
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct DealOrder<AccountId, BlockNum, Hash, Moment> {
-	pub blockchain: Blockchain,
 	pub offer_id: OfferId<BlockNum, Hash>,
 	pub lender_address_id: AddressId<Hash>,
 	pub borrower_address_id: AddressId<Hash>,
@@ -266,7 +262,7 @@ macro_rules! concatenate {
 pub(crate) use concatenate;
 
 impl<H> AddressId<H> {
-	pub fn new<Config>(blockchain: &Blockchain, address: &[u8]) -> AddressId<H>
+	pub fn new<Config>(blockchain: &OldBlockchain, address: &[u8]) -> AddressId<H>
 	where
 		Config: frame_system::Config,
 		<Config as frame_system::Config>::Hashing: Hash<Output = H>,
@@ -307,7 +303,7 @@ impl<B, H> RepaymentOrderId<B, H> {
 }
 
 impl<H> TransferId<H> {
-	pub fn new<Config>(blockchain: &Blockchain, blockchain_tx_id: &[u8]) -> TransferId<H>
+	pub fn new<Config>(blockchain: &OldBlockchain, blockchain_tx_id: &[u8]) -> TransferId<H>
 	where
 		Config: frame_system::Config,
 		<Config as frame_system::Config>::Hashing: Hash<Output = H>,

--- a/pallets/creditcoin/src/types.rs
+++ b/pallets/creditcoin/src/types.rs
@@ -104,7 +104,7 @@ pub struct Transfer<AccountId, BlockNum, Hash, Moment> {
 	pub kind: TransferKind,
 	pub from: AddressId<Hash>,
 	pub to: AddressId<Hash>,
-	pub order_id: OrderId<BlockNum, Hash>,
+	pub deal_order_id: DealOrderId<BlockNum, Hash>,
 	pub amount: ExternalAmount,
 	#[cfg_attr(feature = "std", serde(with = "bounded_serde"))]
 	pub tx_id: ExternalTxId,
@@ -225,14 +225,6 @@ pub struct RepaymentOrderId<BlockNum, Hash>(BlockNum, Hash);
 #[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
-pub enum OrderId<BlockNum, Hash> {
-	Deal(DealOrderId<BlockNum, Hash>),
-	Repayment(RepaymentOrderId<BlockNum, Hash>),
-}
-
-#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
-#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct OfferId<BlockNum, Hash>(BlockNum, Hash);
 
 #[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
@@ -252,16 +244,6 @@ impl<Hash> TransferId<Hash> {
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct CollectedCoinsId<Hash>(Hash);
 
-fn bytes_to_hex(bytes: &[u8]) -> Vec<u8> {
-	const HEX_CHARS_LOWER: &[u8; 16] = b"0123456789abcdef";
-	let mut hex = Vec::with_capacity(bytes.len() * 2);
-	for byte in bytes {
-		hex.push(HEX_CHARS_LOWER[(byte >> 4) as usize]);
-		hex.push(HEX_CHARS_LOWER[(byte & 0x0F) as usize]);
-	}
-	hex
-}
-
 macro_rules! concatenate {
 	(@strip_plus + $($rest: tt)*) => {
 		$($rest)*
@@ -275,19 +257,6 @@ macro_rules! concatenate {
 	};
 }
 pub(crate) use concatenate;
-
-impl<B, H> OrderId<B, H>
-where
-	H: AsRef<[u8]>,
-{
-	pub fn to_hex(&self) -> Vec<u8> {
-		let bytes = match self {
-			OrderId::Deal(deal) => deal.1.as_ref(),
-			OrderId::Repayment(repay) => repay.1.as_ref(),
-		};
-		bytes_to_hex(bytes)
-	}
-}
 
 impl<H> AddressId<H> {
 	pub fn new<Config>(blockchain: &Blockchain, address: &[u8]) -> AddressId<H>
@@ -432,39 +401,6 @@ impl_id!(AskOrderId);
 impl_id!(BidOrderId);
 impl_id!(OfferId);
 impl_id!(RepaymentOrderId);
-
-impl<'a, B, H> Id<B, H> for &'a OrderId<B, H>
-where
-	B: Clone,
-	H: Clone,
-{
-	fn expiration(&self) -> B {
-		match self {
-			OrderId::Deal(deal) => deal.expiration(),
-			OrderId::Repayment(repay) => repay.expiration(),
-		}
-	}
-
-	fn hash(&self) -> H {
-		match self {
-			OrderId::Deal(deal) => deal.hash(),
-			OrderId::Repayment(repay) => repay.hash(),
-		}
-	}
-}
-impl<B, H> Id<B, H> for OrderId<B, H>
-where
-	B: Clone,
-	H: Clone,
-{
-	fn expiration(&self) -> B {
-		(&self).expiration()
-	}
-
-	fn hash(&self) -> H {
-		(&self).hash()
-	}
-}
 
 #[ext(name = DoubleMapExt)]
 pub(crate) impl<Prefix, Hasher1, Key1, Hasher2, Key2, Value, QueryKind, OnEmpty, MaxValues, IdTy>

--- a/pallets/creditcoin/src/types/loan_terms.rs
+++ b/pallets/creditcoin/src/types/loan_terms.rs
@@ -1,5 +1,7 @@
 use core::ops::Deref;
 
+use crate::CurrencyId;
+
 use super::ExternalAmount;
 use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::RuntimeDebug;
@@ -56,19 +58,20 @@ pub struct InterestRate {
 #[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
-pub struct LoanTerms {
+pub struct LoanTerms<Hash> {
 	pub amount: ExternalAmount,
 	pub interest_rate: InterestRate,
 	pub term_length: Duration,
+	pub currency: CurrencyId<Hash>,
 }
 
 #[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
-pub struct AskTerms(LoanTerms);
+pub struct AskTerms<Hash>(LoanTerms<Hash>);
 
-impl Deref for AskTerms {
-	type Target = LoanTerms;
+impl<Hash> Deref for AskTerms<Hash> {
+	type Target = LoanTerms<Hash>;
 
 	fn deref(&self) -> &Self::Target {
 		&self.0
@@ -84,9 +87,9 @@ impl<T: crate::Config> From<InvalidTermLengthError> for crate::Error<T> {
 	}
 }
 
-impl TryFrom<LoanTerms> for AskTerms {
+impl<Hash> TryFrom<LoanTerms<Hash>> for AskTerms<Hash> {
 	type Error = InvalidTermLengthError;
-	fn try_from(terms: LoanTerms) -> Result<Self, Self::Error> {
+	fn try_from(terms: LoanTerms<Hash>) -> Result<Self, Self::Error> {
 		if terms.term_length.is_zero() {
 			return Err(InvalidTermLengthError);
 		}
@@ -95,14 +98,14 @@ impl TryFrom<LoanTerms> for AskTerms {
 	}
 }
 
-impl AskTerms {
-	pub fn match_with(&self, bid_terms: &BidTerms) -> bool {
+impl<Hash> AskTerms<Hash> {
+	pub fn match_with(&self, bid_terms: &BidTerms<Hash>) -> bool {
 		self.amount == bid_terms.amount
 			&& self.interest_rate == bid_terms.interest_rate
 			&& self.term_length == bid_terms.term_length
 	}
 
-	pub fn agreed_terms(&self, bid_terms: BidTerms) -> Option<LoanTerms> {
+	pub fn agreed_terms(&self, bid_terms: BidTerms<Hash>) -> Option<LoanTerms<Hash>> {
 		self.match_with(&bid_terms).then(|| bid_terms.0)
 	}
 }
@@ -110,19 +113,19 @@ impl AskTerms {
 #[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
-pub struct BidTerms(LoanTerms);
+pub struct BidTerms<Hash>(LoanTerms<Hash>);
 
-impl Deref for BidTerms {
-	type Target = LoanTerms;
+impl<Hash> Deref for BidTerms<Hash> {
+	type Target = LoanTerms<Hash>;
 
 	fn deref(&self) -> &Self::Target {
 		&self.0
 	}
 }
 
-impl TryFrom<LoanTerms> for BidTerms {
+impl<Hash> TryFrom<LoanTerms<Hash>> for BidTerms<Hash> {
 	type Error = InvalidTermLengthError;
-	fn try_from(terms: LoanTerms) -> Result<Self, Self::Error> {
+	fn try_from(terms: LoanTerms<Hash>) -> Result<Self, Self::Error> {
 		if terms.term_length.is_zero() {
 			return Err(InvalidTermLengthError);
 		}
@@ -131,23 +134,27 @@ impl TryFrom<LoanTerms> for BidTerms {
 	}
 }
 
-impl BidTerms {
-	pub fn match_with(&self, ask_terms: &AskTerms) -> bool {
+impl<Hash> BidTerms<Hash> {
+	pub fn match_with(&self, ask_terms: &AskTerms<Hash>) -> bool {
 		ask_terms.match_with(self)
 	}
 
-	pub fn agreed_terms(self, ask_terms: &AskTerms) -> Option<LoanTerms> {
+	pub fn agreed_terms(self, ask_terms: &AskTerms<Hash>) -> Option<LoanTerms<Hash>> {
 		ask_terms.agreed_terms(self)
 	}
 }
 
 #[cfg(test)]
-impl Default for LoanTerms {
+impl<Hash> Default for LoanTerms<Hash>
+where
+	Hash: Default,
+{
 	fn default() -> Self {
 		Self {
 			amount: Default::default(),
 			interest_rate: InterestRate::default(),
 			term_length: Duration::from_millis(100_000),
+			currency: CurrencyId::placeholder(),
 		}
 	}
 }

--- a/pallets/creditcoin/src/types/loan_terms.rs
+++ b/pallets/creditcoin/src/types/loan_terms.rs
@@ -145,16 +145,13 @@ impl<Hash> BidTerms<Hash> {
 }
 
 #[cfg(test)]
-impl<Hash> Default for LoanTerms<Hash>
-where
-	Hash: Default,
-{
+impl Default for LoanTerms<sp_core::H256> {
 	fn default() -> Self {
 		Self {
 			amount: Default::default(),
 			interest_rate: InterestRate::default(),
 			term_length: Duration::from_millis(100_000),
-			currency: CurrencyId::placeholder(),
+			currency: CurrencyId::new::<crate::mock::Test>(&crate::Currency::default()),
 		}
 	}
 }

--- a/pallets/creditcoin/src/types/platform.rs
+++ b/pallets/creditcoin/src/types/platform.rs
@@ -83,10 +83,10 @@ impl Blockchain {
 	pub const LUNIVERSE: Blockchain = Blockchain::evm(EvmChainId::LUNIVERSE);
 
 	pub fn as_bytes(&self) -> &[u8] {
-		match self {
-			&Blockchain::ETHEREUM => b"ethereum",
-			&Blockchain::RINKEBY => b"rinkeby",
-			&(Blockchain::LUNIVERSE_TESTNET | Blockchain::LUNIVERSE) => b"luniverse",
+		match *self {
+			Blockchain::ETHEREUM => b"ethereum",
+			Blockchain::RINKEBY => b"rinkeby",
+			Blockchain::LUNIVERSE_TESTNET | Blockchain::LUNIVERSE => b"luniverse",
 			_ => todo!(),
 		}
 	}
@@ -160,7 +160,7 @@ impl Currency {
 	}
 
 	pub fn to_id<T: Config>(&self) -> CurrencyId<T::Hash> {
-		CurrencyId::new::<T>(&self)
+		CurrencyId::new::<T>(self)
 	}
 }
 

--- a/pallets/creditcoin/src/types/platform.rs
+++ b/pallets/creditcoin/src/types/platform.rs
@@ -77,7 +77,7 @@ pub enum Currency {
 #[derive(
 	Clone, RuntimeDebug, PartialEq, Eq, PartialOrd, Encode, Decode, TypeInfo, MaxEncodedLen,
 )]
-pub enum NewTransferKind {
+pub enum TransferKind {
 	Evm(EvmTransferKind),
 }
 

--- a/pallets/creditcoin/src/types/platform.rs
+++ b/pallets/creditcoin/src/types/platform.rs
@@ -146,6 +146,11 @@ pub enum Currency {
 }
 
 impl Currency {
+	pub fn blockchain(&self) -> Blockchain {
+		match self {
+			Currency::Evm(_, info) => Blockchain::Evm(info.clone()),
+		}
+	}
 	pub fn supports(&self, kind: &TransferKind) -> bool {
 		match (self, kind) {
 			(Currency::Evm(currency, _), TransferKind::Evm(kind)) => match currency {

--- a/pallets/creditcoin/src/types/platform.rs
+++ b/pallets/creditcoin/src/types/platform.rs
@@ -56,7 +56,7 @@ impl Blockchain {
 
 	pub fn as_bytes(&self) -> &[u8] {
 		match self {
-			&Blockchain::ETHEREUM => b"etheruem",
+			&Blockchain::ETHEREUM => b"ethereum",
 			&Blockchain::RINKEBY => b"rinkeby",
 			&(Blockchain::LUNIVERSE_TESTNET | Blockchain::LUNIVERSE) => b"luniverse",
 			_ => todo!(),
@@ -138,5 +138,19 @@ impl<H> CurrencyId<H> {
 				CurrencyId(T::Hashing::hash(&encoded))
 			},
 		}
+	}
+}
+
+
+#[cfg(test)]
+mod test {
+	use super::*;
+
+	#[test]
+	fn blockchain_as_bytes_back_compat() {
+		assert_eq!(Blockchain::ETHEREUM.as_bytes(), b"ethereum");
+		assert_eq!(Blockchain::RINKEBY.as_bytes(), b"rinkeby");
+		assert_eq!(Blockchain::LUNIVERSE.as_bytes(), b"luniverse");
+		assert_eq!(Blockchain::LUNIVERSE_TESTNET.as_bytes(), b"luniverse");
 	}
 }

--- a/pallets/creditcoin/src/types/platform.rs
+++ b/pallets/creditcoin/src/types/platform.rs
@@ -25,11 +25,14 @@ impl EvmChainId {
 	pub const fn new(value: u64) -> Self {
 		EvmChainId(value)
 	}
+	pub fn as_u64(self) -> u64 {
+		self.0
+	}
 
 	pub const ETHEREUM: EvmChainId = EvmChainId::new(1);
 	pub const RINKEBY: EvmChainId = EvmChainId::new(4);
-	pub const LUNIVERSE_TESTNET: EvmChainId = EvmChainId::new(1635501961136826136);
-	pub const LUNIVERSE: EvmChainId = EvmChainId::new(3158073271666164067);
+	pub const LUNIVERSE_TESTNET: EvmChainId = EvmChainId::new(949790);
+	pub const LUNIVERSE: EvmChainId = EvmChainId::new(59496427);
 }
 
 #[derive(

--- a/pallets/creditcoin/src/types/platform.rs
+++ b/pallets/creditcoin/src/types/platform.rs
@@ -6,11 +6,21 @@ use scale_info::TypeInfo;
 use sp_runtime::traits::Hash as HashT;
 use strum::EnumCount;
 
-use crate::{ExternalAddress, LegacyTransferKind};
+use crate::{Config, ExternalAddress, LegacyTransferKind};
 
 // as of EIP-155 the max chain ID is 9,223,372,036,854,775,771 which fits well within a u64
 #[derive(
-	Copy, Clone, RuntimeDebug, PartialEq, Eq, PartialOrd, Encode, Decode, TypeInfo, MaxEncodedLen,
+	Copy,
+	Clone,
+	RuntimeDebug,
+	PartialEq,
+	Eq,
+	PartialOrd,
+	Ord,
+	Encode,
+	Decode,
+	TypeInfo,
+	MaxEncodedLen,
 )]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
@@ -38,7 +48,7 @@ impl EvmChainId {
 }
 
 #[derive(
-	Clone, RuntimeDebug, PartialEq, Eq, PartialOrd, Encode, Decode, TypeInfo, MaxEncodedLen,
+	Clone, RuntimeDebug, PartialEq, Eq, PartialOrd, Ord, Encode, Decode, TypeInfo, MaxEncodedLen,
 )]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
@@ -104,6 +114,7 @@ impl Blockchain {
 	PartialEq,
 	Eq,
 	PartialOrd,
+	Ord,
 	Encode,
 	Decode,
 	TypeInfo,
@@ -121,14 +132,14 @@ pub type EvmSupportedTransferKinds =
 	BoundedVec<EvmTransferKind, ConstU32<{ EvmTransferKind::COUNT as u32 }>>;
 
 #[derive(
-	Clone, RuntimeDebug, PartialEq, Eq, PartialOrd, Encode, Decode, TypeInfo, MaxEncodedLen,
+	Clone, RuntimeDebug, PartialEq, Eq, PartialOrd, Ord, Encode, Decode, TypeInfo, MaxEncodedLen,
 )]
 pub enum EvmCurrencyType {
 	SmartContract(ExternalAddress, EvmSupportedTransferKinds),
 }
 
 #[derive(
-	Clone, RuntimeDebug, PartialEq, Eq, PartialOrd, Encode, Decode, TypeInfo, MaxEncodedLen,
+	Clone, RuntimeDebug, PartialEq, Eq, PartialOrd, Ord, Encode, Decode, TypeInfo, MaxEncodedLen,
 )]
 pub enum Currency {
 	Evm(EvmCurrencyType, EvmInfo),
@@ -141,6 +152,10 @@ impl Currency {
 				EvmCurrencyType::SmartContract(_, supported) => supported.contains(kind),
 			},
 		}
+	}
+
+	pub fn to_id<T: Config>(&self) -> CurrencyId<T::Hash> {
+		CurrencyId::new::<T>(&self)
 	}
 }
 
@@ -170,7 +185,7 @@ impl TryFrom<super::LegacyTransferKind> for TransferKind {
 }
 
 #[derive(
-	Clone, RuntimeDebug, PartialEq, Eq, PartialOrd, Encode, Decode, TypeInfo, MaxEncodedLen,
+	Clone, RuntimeDebug, PartialEq, Eq, PartialOrd, Encode, Decode, TypeInfo, MaxEncodedLen, Ord,
 )]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]

--- a/pallets/creditcoin/src/types/platform.rs
+++ b/pallets/creditcoin/src/types/platform.rs
@@ -25,6 +25,11 @@ impl EvmChainId {
 	pub const fn new(value: u64) -> Self {
 		EvmChainId(value)
 	}
+
+	pub const ETHEREUM: EvmChainId = EvmChainId::new(1);
+	pub const RINKEBY: EvmChainId = EvmChainId::new(4);
+	pub const LUNIVERSE_TESTNET: EvmChainId = EvmChainId::new(1635501961136826136);
+	pub const LUNIVERSE: EvmChainId = EvmChainId::new(3158073271666164067);
 }
 
 #[derive(
@@ -34,6 +39,13 @@ impl EvmChainId {
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct EvmInfo {
 	pub chain_id: EvmChainId,
+}
+
+impl EvmInfo {
+	pub const ETHEREUM: EvmInfo = EvmInfo { chain_id: EvmChainId::ETHEREUM };
+	pub const RINKEBY: EvmInfo = EvmInfo { chain_id: EvmChainId::RINKEBY };
+	pub const LUNIVERSE_TESTNET: EvmInfo = EvmInfo { chain_id: EvmChainId::LUNIVERSE_TESTNET };
+	pub const LUNIVERSE: EvmInfo = EvmInfo { chain_id: EvmChainId::LUNIVERSE };
 }
 
 #[derive(
@@ -49,10 +61,11 @@ impl Blockchain {
 	pub const fn evm(chain_id: EvmChainId) -> Blockchain {
 		Blockchain::Evm(EvmInfo { chain_id })
 	}
-	pub const ETHEREUM: Blockchain = Blockchain::evm(EvmChainId::new(1));
-	pub const RINKEBY: Blockchain = Blockchain::evm(EvmChainId::new(4));
-	pub const LUNIVERSE_TESTNET: Blockchain = Blockchain::evm(EvmChainId::new(1635501961136826136));
-	pub const LUNIVERSE: Blockchain = Blockchain::evm(EvmChainId::new(3158073271666164067));
+
+	pub const ETHEREUM: Blockchain = Blockchain::evm(EvmChainId::ETHEREUM);
+	pub const RINKEBY: Blockchain = Blockchain::evm(EvmChainId::RINKEBY);
+	pub const LUNIVERSE_TESTNET: Blockchain = Blockchain::evm(EvmChainId::LUNIVERSE_TESTNET);
+	pub const LUNIVERSE: Blockchain = Blockchain::evm(EvmChainId::LUNIVERSE);
 
 	pub fn as_bytes(&self) -> &[u8] {
 		match self {
@@ -124,6 +137,8 @@ pub enum TransferKind {
 #[derive(
 	Clone, RuntimeDebug, PartialEq, Eq, PartialOrd, Encode, Decode, TypeInfo, MaxEncodedLen,
 )]
+#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct CurrencyId<Hash>(Hash);
 
 impl<H> CurrencyId<H> {
@@ -141,6 +156,25 @@ impl<H> CurrencyId<H> {
 	}
 }
 
+impl<H> CurrencyId<H>
+where
+	H: Default,
+{
+	pub fn placeholder() -> Self {
+		Self(H::default())
+	}
+}
+
+impl<H> CurrencyId<H>
+where
+	H: Default + PartialEq,
+{
+	pub fn is_placeholder(&self) -> bool {
+		let default = CurrencyId(H::default());
+
+		self == &default
+	}
+}
 
 #[cfg(test)]
 mod test {


### PR DESCRIPTION
Might be easiest to review commit-by-commit, I tried to separate each step.

Description of proposed changes:
Makes all the changes to move the codebase over to the new types. Introduces a new path for registering transfer for deals with a known currency.

TODO:
- [ ] Tests for the new paths
- [ ] Fix/update creditcoin-js and the integration tests for the new types
- [ ] Add new benchmarks (maybe?) for the new transfer extrinsics
- [ ] Migration v6 tests
- [ ] Migration performance measurement (need to fork off from mainnet then try the migration locally to get a baseline)
- [ ] Spot-check that the migrations don't mangle data
- [ ] Figure out a scheme for the RPC URI key of a blockchain (`evm-{chainid}` might suffice)
- [ ] Reduce the code duplication between the two register_transfer paths

Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
