### PR TITLE
Migrate towards new types for register currency - Part 1

### DIFF
--- a/pallets/creditcoin/src/benchmarking.rs
+++ b/pallets/creditcoin/src/benchmarking.rs
@@ -5,7 +5,7 @@ use crate::benchmarking::alloc::format;
 use crate::helpers::{EVMAddress, PublicToAddress};
 use crate::ocw::errors::VerificationFailureCause as Cause;
 use crate::ocw::tasks::collect_coins::CONTRACT_CHAIN;
-use crate::types::Blockchain;
+use crate::types::OldBlockchain;
 use crate::Duration;
 #[allow(unused)]
 use crate::Pallet as Creditcoin;
@@ -123,7 +123,7 @@ benchmarks! {
 		let message = sp_io::hashing::sha2_256(who.encode().as_slice());
 		let signature = ecdsa_sign(ktypeid, &pkey, &message).expect("ecdsa signature");
 
-	}: _(RawOrigin::Signed(who), Blockchain::Ethereum, address,signature)
+	}: _(RawOrigin::Signed(who), OldBlockchain::Ethereum, address,signature)
 
 	claim_legacy_wallet {
 		let pubkey = {
@@ -373,7 +373,7 @@ fn generate_transfer<T: Config>(
 		)
 	};
 	let tx = raw_tx.as_bytes().into_bounded();
-	let transfer_id = TransferId::new::<T>(&Blockchain::Ethereum, &tx);
+	let transfer_id = TransferId::new::<T>(&OldBlockchain::Ethereum, &tx);
 
 	let contract = "0x0ad1439a0e0bfdcd49939f9722866651a4aa9b3c".as_bytes().into_bounded();
 
@@ -525,13 +525,13 @@ fn register_eth_addr<T: Config>(who: &T::AccountId, seed: &str) -> AddressId<<T>
 	let ktypeid = KeyTypeId(*b"dumy");
 	let pkey = ecdsa_generate(ktypeid, Some(format!("//{}", seed).as_bytes().to_vec()));
 	let address = EVMAddress::from_public(&pkey);
-	let address_id = crate::AddressId::new::<T>(&Blockchain::Ethereum, &address);
+	let address_id = crate::AddressId::new::<T>(&OldBlockchain::Ethereum, &address);
 
 	let message = sp_io::hashing::sha2_256(who.encode().as_slice());
 	let signature = ecdsa_sign(ktypeid, &pkey, &message).expect("ecdsa signature");
 
 	let origin = RawOrigin::Signed(who.clone());
-	Creditcoin::<T>::register_address(origin.into(), Blockchain::Ethereum, address, signature)
+	Creditcoin::<T>::register_address(origin.into(), OldBlockchain::Ethereum, address, signature)
 		.unwrap();
 
 	address_id
@@ -596,7 +596,7 @@ fn generate_bid<T: Config>(
 
 fn fake_address_id<T: Config>(seed: u32) -> AddressId<T::Hash> {
 	let address = format!("somefakeaddress{}", seed);
-	crate::AddressId::new::<T>(&Blockchain::Ethereum, address.as_bytes())
+	crate::AddressId::new::<T>(&OldBlockchain::Ethereum, address.as_bytes())
 }
 
 fn fake_ask_id<T: Config>(
@@ -612,7 +612,6 @@ fn insert_fake_ask<T: Config>(who: &T::AccountId, expiration_block: BlockNumberF
 	let ask_id = fake_ask_id::<T>(seed, expiration_block);
 	let ask = crate::AskOrder {
 		block: System::<T>::block_number(),
-		blockchain: Blockchain::Ethereum,
 		expiration_block,
 		lender: who.clone(),
 		lender_address_id: address_id,
@@ -635,7 +634,6 @@ fn insert_fake_bid<T: Config>(who: &T::AccountId, expiration_block: BlockNumberF
 	let bid_id = fake_bid_id::<T>(seed, expiration_block);
 	let bid = crate::BidOrder {
 		block: System::<T>::block_number(),
-		blockchain: Blockchain::Ethereum,
 		expiration_block,
 		borrower: who.clone(),
 		borrower_address_id: address_id,
@@ -666,7 +664,6 @@ fn insert_fake_offer<T: Config>(
 		ask_id,
 		bid_id,
 		block: System::<T>::block_number(),
-		blockchain: Blockchain::Ethereum,
 		expiration_block,
 		lender: who.clone(),
 	};
@@ -683,7 +680,7 @@ fn fake_deal_id<T: Config>(
 
 fn fake_transfer_id<T: Config>(seed: u32) -> TransferId<T::Hash> {
 	let tx_id = format!("somefaketransfertxid{}", seed);
-	crate::TransferId::new::<T>(&Blockchain::Ethereum, tx_id.as_bytes())
+	crate::TransferId::new::<T>(&OldBlockchain::Ethereum, tx_id.as_bytes())
 }
 
 fn insert_fake_deal<T: Config>(
@@ -699,7 +696,6 @@ fn insert_fake_deal<T: Config>(
 	let deal_id = fake_deal_id::<T>(expiration_block, &offer_id);
 	let deal = crate::DealOrder::<_, _, _, T::Moment> {
 		block: None,
-		blockchain: Blockchain::Ethereum,
 		borrower: who.clone(),
 		borrower_address_id: address_id.clone(),
 		lender_address_id: address_id,
@@ -734,7 +730,7 @@ fn insert_fake_unverified_transfer<T: Config>(
 			account_id: who.clone(),
 			amount: ExternalAmount::from(1),
 			block: System::<T>::block_number(),
-			blockchain: Blockchain::Ethereum,
+			blockchain: OldBlockchain::Ethereum,
 			from: fake_address_id::<T>(seed - 1),
 			to: fake_address_id::<T>(seed),
 			is_processed: false,

--- a/pallets/creditcoin/src/benchmarking.rs
+++ b/pallets/creditcoin/src/benchmarking.rs
@@ -380,7 +380,7 @@ fn generate_transfer<T: Config>(
 	if swap_sender {
 		Creditcoin::<T>::register_repayment_transfer(
 			RawOrigin::Signed(who).into(),
-			TransferKind::Ethless(contract),
+			LegacyTransferKind::Ethless(contract),
 			gain.into(),
 			deal_id,
 			tx,
@@ -389,7 +389,7 @@ fn generate_transfer<T: Config>(
 	} else {
 		Creditcoin::<T>::register_funding_transfer(
 			RawOrigin::Signed(who).into(),
-			TransferKind::Ethless(contract),
+			LegacyTransferKind::Ethless(contract),
 			deal_id,
 			tx,
 		)
@@ -738,15 +738,15 @@ fn insert_fake_unverified_transfer<T: Config>(
 			from: fake_address_id::<T>(seed - 1),
 			to: fake_address_id::<T>(seed),
 			is_processed: false,
-			kind: TransferKind::Native,
-			deal_order_id: OrderId::Deal(fake_deal_id::<T>(
+			kind: LegacyTransferKind::Native,
+			deal_order_id: fake_deal_id::<T>(
 				deadline,
 				&fake_offer_id::<T>(
 					deadline,
 					&fake_ask_id::<T>(seed, deadline),
 					&fake_bid_id::<T>(seed, deadline),
 				),
-			)),
+			),
 			tx_id: format!("{:03x}", seed).as_bytes().into_bounded(),
 			timestamp: None,
 		},

--- a/pallets/creditcoin/src/benchmarking.rs
+++ b/pallets/creditcoin/src/benchmarking.rs
@@ -739,7 +739,7 @@ fn insert_fake_unverified_transfer<T: Config>(
 			to: fake_address_id::<T>(seed),
 			is_processed: false,
 			kind: TransferKind::Native,
-			order_id: OrderId::Deal(fake_deal_id::<T>(
+			deal_order_id: OrderId::Deal(fake_deal_id::<T>(
 				deadline,
 				&fake_offer_id::<T>(
 					deadline,

--- a/pallets/creditcoin/src/helpers.rs
+++ b/pallets/creditcoin/src/helpers.rs
@@ -118,7 +118,7 @@ impl<T: Config> Pallet<T> {
 		Ok(())
 	}
 
-	pub fn register_transfer_internal(
+	pub fn register_transfer_internal_legacy(
 		who: T::AccountId,
 		from_id: AddressId<T::Hash>,
 		to_id: AddressId<T::Hash>,

--- a/pallets/creditcoin/src/helpers.rs
+++ b/pallets/creditcoin/src/helpers.rs
@@ -7,8 +7,8 @@ pub use external_address::{EVMAddress, PublicToAddress};
 use crate::{
 	pallet::*,
 	types::{Address, AddressId},
-	DealOrderId, Error, ExternalAmount, ExternalTxId, Guid, Id, OrderId, Task, TaskId, Transfer,
-	TransferId, TransferKind, UnverifiedTransfer,
+	DealOrderId, Error, ExternalAmount, ExternalTxId, Guid, Id, Task, TaskId, Transfer, TransferId,
+	TransferKind, UnverifiedTransfer,
 };
 
 use frame_support::{ensure, traits::Get};
@@ -124,7 +124,7 @@ impl<T: Config> Pallet<T> {
 		to_id: AddressId<T::Hash>,
 		transfer_kind: TransferKind,
 		amount: ExternalAmount,
-		order_id: OrderId<T::BlockNumber, T::Hash>,
+		deal_order_id: DealOrderId<T::BlockNumber, T::Hash>,
 		blockchain_tx_id: ExternalTxId,
 	) -> Result<
 		(TransferId<T::Hash>, Transfer<T::AccountId, BlockNumberFor<T>, T::Hash, T::Moment>),
@@ -151,7 +151,7 @@ impl<T: Config> Pallet<T> {
 			block,
 			from: from_id,
 			to: to_id,
-			order_id,
+			deal_order_id,
 			is_processed: false,
 			account_id: who,
 			tx_id: blockchain_tx_id,

--- a/pallets/creditcoin/src/helpers.rs
+++ b/pallets/creditcoin/src/helpers.rs
@@ -7,8 +7,8 @@ pub use external_address::{EVMAddress, PublicToAddress};
 use crate::{
 	pallet::*,
 	types::{Address, AddressId},
-	DealOrderId, Error, ExternalAmount, ExternalTxId, Guid, Id, Task, TaskId, Transfer, TransferId,
-	TransferKind, UnverifiedTransfer,
+	DealOrderId, Error, ExternalAmount, ExternalTxId, Guid, Id, LegacyTransferKind, Task, TaskId,
+	Transfer, TransferId, UnverifiedTransfer,
 };
 
 use frame_support::{ensure, traits::Get};
@@ -122,7 +122,7 @@ impl<T: Config> Pallet<T> {
 		who: T::AccountId,
 		from_id: AddressId<T::Hash>,
 		to_id: AddressId<T::Hash>,
-		transfer_kind: TransferKind,
+		transfer_kind: LegacyTransferKind,
 		amount: ExternalAmount,
 		deal_order_id: DealOrderId<T::BlockNumber, T::Hash>,
 		blockchain_tx_id: ExternalTxId,

--- a/pallets/creditcoin/src/helpers/external_address.rs
+++ b/pallets/creditcoin/src/helpers/external_address.rs
@@ -1,4 +1,4 @@
-use crate::{Blockchain, ExternalAddress};
+use crate::{ExternalAddress, OldBlockchain};
 use base58::FromBase58;
 use core::convert::TryFrom;
 use frame_support::BoundedVec;
@@ -7,18 +7,18 @@ use sp_io::hashing::keccak_256;
 use sp_io::hashing::sha2_256;
 
 pub fn generate_external_address(
-	blockchain: &Blockchain,
+	blockchain: &OldBlockchain,
 	reference: &ExternalAddress,
 	public_key: Public,
 ) -> Option<ExternalAddress> {
 	match blockchain {
-		Blockchain::Luniverse | Blockchain::Ethereum | Blockchain::Rinkeby
+		OldBlockchain::Luniverse | OldBlockchain::Ethereum | OldBlockchain::Rinkeby
 			if EVMAddress::try_extract_addresss_type(reference).is_some() =>
 		{
 			Some(EVMAddress::from_public(&public_key))
 		},
-		Blockchain::Bitcoin => None,
-		Blockchain::Other(_) => None,
+		OldBlockchain::Bitcoin => None,
+		OldBlockchain::Other(_) => None,
 		_ => None,
 	}
 }
@@ -51,13 +51,13 @@ impl PublicToAddress for EVMAddress {
 	}
 }
 
-pub fn address_is_well_formed(blockchain: &Blockchain, address: &ExternalAddress) -> bool {
+pub fn address_is_well_formed(blockchain: &OldBlockchain, address: &ExternalAddress) -> bool {
 	match blockchain {
-		Blockchain::Bitcoin => btc_address_is_well_formed(address),
-		Blockchain::Ethereum | Blockchain::Luniverse | Blockchain::Rinkeby => {
+		OldBlockchain::Bitcoin => btc_address_is_well_formed(address),
+		OldBlockchain::Ethereum | OldBlockchain::Luniverse | OldBlockchain::Rinkeby => {
 			eth_address_is_well_formed(address)
 		},
-		Blockchain::Other(_) => false,
+		OldBlockchain::Other(_) => false,
 	}
 }
 
@@ -171,11 +171,11 @@ mod tests {
 
 	#[test]
 	fn address_is_well_formed_works() {
-		let ethereum = Blockchain::Ethereum;
-		let bitcoin = Blockchain::Bitcoin;
-		let rinkeby = Blockchain::Rinkeby;
-		let luniverse = Blockchain::Luniverse;
-		let other = Blockchain::Other(BoundedVec::try_from(b"other".to_vec()).unwrap());
+		let ethereum = OldBlockchain::Ethereum;
+		let bitcoin = OldBlockchain::Bitcoin;
+		let rinkeby = OldBlockchain::Rinkeby;
+		let luniverse = OldBlockchain::Luniverse;
+		let other = OldBlockchain::Other(BoundedVec::try_from(b"other".to_vec()).unwrap());
 
 		let eth_addr = hex::decode("5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed")
 			.unwrap()

--- a/pallets/creditcoin/src/lib.rs
+++ b/pallets/creditcoin/src/lib.rs
@@ -716,7 +716,7 @@ pub mod pallet {
 		#[pallet::weight(<T as Config>::WeightInfo::register_address())]
 		pub fn register_address(
 			origin: OriginFor<T>,
-			blockchain: Blockchain,
+			blockchain: OldBlockchain,
 			address: ExternalAddress,
 			ownership_proof: sp_core::ecdsa::Signature,
 		) -> DispatchResult {
@@ -775,7 +775,6 @@ pub mod pallet {
 			ensure!(address.owner == who, Error::<T>::NotAddressOwner);
 
 			let ask_order = AskOrder {
-				blockchain: address.blockchain,
 				lender_address_id: address_id,
 				terms: terms.try_into().map_err(Error::<T>::from)?,
 				expiration_block,
@@ -810,7 +809,6 @@ pub mod pallet {
 			ensure!(address.owner == who, Error::<T>::NotAddressOwner);
 
 			let bid_order = BidOrder {
-				blockchain: address.blockchain,
 				borrower_address_id: address_id,
 				terms: terms.try_into().map_err(Error::<T>::from)?,
 				expiration_block,
@@ -849,8 +847,11 @@ pub mod pallet {
 
 			ensure!(bid_order.expiration_block >= head, Error::<T>::BidOrderExpired);
 
+			let lender_address = Self::get_address(&ask_order.lender_address_id)?;
+			let borrower_address = Self::get_address(&bid_order.borrower_address_id)?;
+
 			ensure!(
-				ask_order.blockchain == bid_order.blockchain,
+				lender_address.blockchain == borrower_address.blockchain,
 				Error::<T>::AddressPlatformMismatch
 			);
 
@@ -864,7 +865,6 @@ pub mod pallet {
 				ask_id: ask_order_id,
 				bid_id: bid_order_id,
 				block: Self::block_number(),
-				blockchain: ask_order.blockchain,
 				expiration_block,
 				lender: who,
 			};
@@ -904,7 +904,6 @@ pub mod pallet {
 				.ok_or(Error::<T>::AskBidMismatch)?;
 
 			let deal_order = DealOrder {
-				blockchain: offer.blockchain,
 				offer_id,
 				lender_address_id: ask_order.lender_address_id,
 				borrower_address_id: bid_order.borrower_address_id,
@@ -1056,7 +1055,6 @@ pub mod pallet {
 			let current_block = Self::block_number();
 
 			let ask_order = AskOrder {
-				blockchain: lender.blockchain.clone(),
 				lender_address_id: lender_address_id.clone(),
 				terms: terms.clone().try_into().map_err(Error::<T>::from)?,
 				expiration_block,
@@ -1065,7 +1063,6 @@ pub mod pallet {
 			};
 
 			let bid_order = BidOrder {
-				blockchain: lender.blockchain.clone(),
 				borrower_address_id: borrower_address_id.clone(),
 				terms: terms.clone().try_into().map_err(Error::<T>::from)?,
 				expiration_block,
@@ -1077,13 +1074,11 @@ pub mod pallet {
 				ask_id: ask_order_id.clone(),
 				bid_id: bid_order_id.clone(),
 				block: current_block,
-				blockchain: lender.blockchain.clone(),
 				expiration_block,
 				lender: lender_account,
 			};
 
 			let deal_order = DealOrder {
-				blockchain: lender.blockchain,
 				offer_id: offer_id.clone(),
 				lender_address_id,
 				borrower_address_id,

--- a/pallets/creditcoin/src/lib.rs
+++ b/pallets/creditcoin/src/lib.rs
@@ -1215,7 +1215,7 @@ pub mod pallet {
 
 			let order = try_get_id!(DealOrders<T>, &deal_order_id, NonExistentDealOrder)?;
 
-			let (transfer_id, transfer) = Self::register_transfer_internal(
+			let (transfer_id, transfer) = Self::register_transfer_internal_legacy(
 				who,
 				order.lender_address_id,
 				order.borrower_address_id,
@@ -1242,7 +1242,7 @@ pub mod pallet {
 
 			let order = try_get_id!(DealOrders<T>, &deal_order_id, NonExistentDealOrder)?;
 
-			let (transfer_id, transfer) = Self::register_transfer_internal(
+			let (transfer_id, transfer) = Self::register_transfer_internal_legacy(
 				who,
 				order.borrower_address_id,
 				order.lender_address_id,

--- a/pallets/creditcoin/src/lib.rs
+++ b/pallets/creditcoin/src/lib.rs
@@ -1207,7 +1207,7 @@ pub mod pallet {
 		#[pallet::weight(<T as Config>::WeightInfo::register_transfer_ocw())]
 		pub fn register_funding_transfer(
 			origin: OriginFor<T>,
-			transfer_kind: TransferKind,
+			transfer_kind: LegacyTransferKind,
 			deal_order_id: DealOrderId<T::BlockNumber, T::Hash>,
 			blockchain_tx_id: ExternalTxId,
 		) -> DispatchResult {
@@ -1233,7 +1233,7 @@ pub mod pallet {
 		#[pallet::weight(<T as Config>::WeightInfo::register_transfer_ocw())]
 		pub fn register_repayment_transfer(
 			origin: OriginFor<T>,
-			transfer_kind: TransferKind,
+			transfer_kind: LegacyTransferKind,
 			repayment_amount: ExternalAmount,
 			deal_order_id: DealOrderId<T::BlockNumber, T::Hash>,
 			blockchain_tx_id: ExternalTxId,
@@ -1283,7 +1283,7 @@ pub mod pallet {
 						account_id: who,
 						amount: ExternalAmount::zero(),
 						is_processed: true,
-						kind: TransferKind::Native,
+						kind: crate::LegacyTransferKind::Native,
 						tx_id: ExternalTxId::try_from(b"0".to_vec()).expect(
 							"0 is a length of one which will always be < size bound of ExternalTxId",
 						),

--- a/pallets/creditcoin/src/lib.rs
+++ b/pallets/creditcoin/src/lib.rs
@@ -987,7 +987,7 @@ pub mod pallet {
 				},
 				|transfer, deal_order| {
 					ensure!(
-						transfer.order_id == OrderId::Deal(deal_order_id.clone()),
+						transfer.deal_order_id == deal_order_id.clone(),
 						Error::<T>::TransferDealOrderMismatch
 					);
 					ensure!(
@@ -1147,7 +1147,7 @@ pub mod pallet {
 				},
 				|transfer, _deal_order| {
 					ensure!(
-						transfer.order_id == OrderId::Deal(deal_order_id.clone()),
+						transfer.deal_order_id == deal_order_id.clone(),
 						Error::<T>::TransferDealOrderMismatch
 					);
 
@@ -1221,7 +1221,7 @@ pub mod pallet {
 				order.borrower_address_id,
 				transfer_kind,
 				order.terms.amount,
-				OrderId::Deal(deal_order_id),
+				deal_order_id,
 				blockchain_tx_id,
 			)?;
 			Self::deposit_event(Event::<T>::TransferRegistered(transfer_id, transfer));
@@ -1248,7 +1248,7 @@ pub mod pallet {
 				order.lender_address_id,
 				transfer_kind,
 				repayment_amount,
-				OrderId::Deal(deal_order_id),
+				deal_order_id,
 				blockchain_tx_id,
 			)?;
 			Self::deposit_event(Event::<T>::TransferRegistered(transfer_id, transfer));
@@ -1278,7 +1278,7 @@ pub mod pallet {
 					ensure!(who == lender.owner, Error::<T>::NotLender);
 
 					let fake_transfer = Transfer {
-						order_id: OrderId::Deal(deal_order_id.clone()),
+						deal_order_id: deal_order_id.clone(),
 						block: Self::block_number(),
 						account_id: who,
 						amount: ExternalAmount::zero(),

--- a/pallets/creditcoin/src/migrations/mod.rs
+++ b/pallets/creditcoin/src/migrations/mod.rs
@@ -6,6 +6,7 @@ mod v2;
 mod v3;
 mod v4;
 mod v5;
+mod v6;
 
 pub(crate) fn migrate<T: Config>() -> Weight {
 	let version = StorageVersion::get::<Pallet<T>>();
@@ -34,6 +35,11 @@ pub(crate) fn migrate<T: Config>() -> Weight {
 	if version < 5 {
 		weight = weight.saturating_add(v5::migrate::<T>());
 		StorageVersion::new(5).put::<Pallet<T>>();
+	}
+
+	if version < 6 {
+		weight = weight.saturating_add(v6::migrate::<T>());
+		StorageVersion::new(6).put::<Pallet<T>>();
 	}
 
 	weight

--- a/pallets/creditcoin/src/migrations/v1.rs
+++ b/pallets/creditcoin/src/migrations/v1.rs
@@ -3,11 +3,11 @@
 
 use crate::{
 	loan_terms::{Decimals, Duration},
-	AddressId, Blockchain, Config, ExternalAmount, OfferId, RatePerPeriod, TransferId,
+	AddressId, Config, ExternalAmount, OfferId, RatePerPeriod, TransferId,
 };
 use codec::{Decode, Encode};
-use frame_support::weights::Weight;
-use frame_support::{generate_storage_alias, traits::Get};
+use frame_support::generate_storage_alias;
+use frame_support::pallet_prelude::*;
 use frame_support::{Identity, Twox64Concat};
 use sp_runtime::traits::{Saturating, UniqueSaturatedInto};
 
@@ -123,6 +123,32 @@ pub struct BidOrder<AccountId, BlockNum, Hash> {
 	pub expiration_block: BlockNum,
 	pub block: BlockNum,
 	pub borrower: AccountId,
+}
+
+type OtherChainLen = ConstU32<256>;
+pub type OtherChain = BoundedVec<u8, OtherChainLen>;
+
+#[derive(Encode, Decode)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
+pub enum Blockchain {
+	Ethereum,
+	Rinkeby,
+	Luniverse,
+	Bitcoin,
+	Other(OtherChain),
+}
+
+impl Blockchain {
+	#[allow(dead_code)]
+	pub fn as_bytes(&self) -> &[u8] {
+		match self {
+			Blockchain::Ethereum => b"ethereum",
+			Blockchain::Rinkeby => b"rinkeby",
+			Blockchain::Luniverse => b"luniverse",
+			Blockchain::Bitcoin => b"bitcoin",
+			Blockchain::Other(chain) => chain.as_slice(),
+		}
+	}
 }
 
 generate_storage_alias!(

--- a/pallets/creditcoin/src/migrations/v1.rs
+++ b/pallets/creditcoin/src/migrations/v1.rs
@@ -129,7 +129,7 @@ type OtherChainLen = ConstU32<256>;
 pub type OtherChain = BoundedVec<u8, OtherChainLen>;
 
 #[derive(Encode, Decode)]
-#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq, Clone))]
 pub enum Blockchain {
 	Ethereum,
 	Rinkeby,

--- a/pallets/creditcoin/src/migrations/v2.rs
+++ b/pallets/creditcoin/src/migrations/v2.rs
@@ -150,7 +150,7 @@ mod test {
 	use sp_runtime::traits::Hash;
 
 	impl<H> TransferId<H> {
-		pub fn new_old<Config>(blockchain: &Blockchain, blockchain_tx_id: &[u8]) -> TransferId<H>
+		pub fn from_old_blockchain<Config>(blockchain: &Blockchain, blockchain_tx_id: &[u8]) -> TransferId<H>
 		where
 			Config: frame_system::Config,
 			<Config as frame_system::Config>::Hashing: Hash<Output = H>,
@@ -235,7 +235,7 @@ mod test {
 		ExtBuilder::default().build_and_execute(|| {
 			let test_info = TestInfo::new_defaults();
 			let blockchain = Blockchain::Ethereum;
-			let transfer_id = TransferId::new_old::<Test>(&blockchain, &[0]);
+			let transfer_id = TransferId::from_old_blockchain::<Test>(&blockchain, &[0]);
 			let old_transfer = OldTransfer {
 				blockchain: Blockchain::Ethereum,
 				kind: TransferKind::Native,

--- a/pallets/creditcoin/src/migrations/v3.rs
+++ b/pallets/creditcoin/src/migrations/v3.rs
@@ -1,27 +1,77 @@
 // `interest_type` added to `LoanTerms`
 
-use super::{v1, v2};
-use core::convert::TryFrom;
+use super::v2;
+use codec::{Decode, Encode};
 use frame_support::dispatch::Weight;
 use frame_support::{generate_storage_alias, traits::Get, Identity, Twox64Concat};
 
-use crate::Config;
+use crate::{AddressId, Config, Duration, ExternalAmount, OfferId, TransferId};
 
-use v1::AskOrder as OldAskOrder;
-use v1::AskTerms as OldAskTerms;
-use v1::BidOrder as OldBidOrder;
-use v1::BidTerms as OldBidTerms;
-use v1::InterestRate as OldInterestRate;
-use v1::LoanTerms as OldLoanTerms;
-use v2::DealOrder as OldDealOrder;
+pub use v2::AskOrder as OldAskOrder;
+pub use v2::AskTerms as OldAskTerms;
+pub use v2::BidOrder as OldBidOrder;
+pub use v2::BidTerms as OldBidTerms;
+pub use v2::Blockchain;
+pub use v2::DealOrder as OldDealOrder;
+pub use v2::InterestRate as OldInterestRate;
+pub use v2::LoanTerms as OldLoanTerms;
+pub use v2::*;
 
-use crate::AskOrder;
-use crate::AskTerms;
-use crate::BidOrder;
-use crate::BidTerms;
-use crate::DealOrder;
 use crate::InterestRate;
-use crate::LoanTerms;
+
+#[derive(Encode, Decode)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
+pub struct LoanTerms {
+	pub amount: ExternalAmount,
+	pub interest_rate: InterestRate,
+	pub term_length: Duration,
+}
+
+#[derive(Encode, Decode)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
+pub struct AskTerms(LoanTerms);
+#[derive(Encode, Decode)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
+pub struct BidTerms(LoanTerms);
+
+#[derive(Encode, Decode)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
+pub struct AskOrder<AccountId, BlockNum, Hash> {
+	pub blockchain: Blockchain,
+	pub lender_address_id: AddressId<Hash>,
+	pub terms: AskTerms,
+	pub expiration_block: BlockNum,
+	pub block: BlockNum,
+	pub lender: AccountId,
+}
+
+#[derive(Encode, Decode)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
+pub struct BidOrder<AccountId, BlockNum, Hash> {
+	pub blockchain: Blockchain,
+	pub borrower_address_id: AddressId<Hash>,
+	pub terms: BidTerms,
+	pub expiration_block: BlockNum,
+	pub block: BlockNum,
+	pub borrower: AccountId,
+}
+
+#[derive(Encode, Decode)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
+pub struct DealOrder<AccountId, BlockNum, Hash, Moment> {
+	pub blockchain: Blockchain,
+	pub offer_id: OfferId<BlockNum, Hash>,
+	pub lender_address_id: AddressId<Hash>,
+	pub borrower_address_id: AddressId<Hash>,
+	pub terms: LoanTerms,
+	pub expiration_block: BlockNum,
+	pub timestamp: Moment,
+	pub block: Option<BlockNum>,
+	pub funding_transfer_id: Option<TransferId<Hash>>,
+	pub repayment_transfer_id: Option<TransferId<Hash>>,
+	pub lock: Option<AccountId>,
+	pub borrower: AccountId,
+}
 
 impl From<OldInterestRate> for InterestRate {
 	fn from(old: OldInterestRate) -> Self {
@@ -44,15 +94,27 @@ impl From<OldLoanTerms> for LoanTerms {
 	}
 }
 
+impl From<LoanTerms> for AskTerms {
+	fn from(terms: LoanTerms) -> Self {
+		Self(terms)
+	}
+}
+
+impl From<LoanTerms> for BidTerms {
+	fn from(terms: LoanTerms) -> Self {
+		Self(terms)
+	}
+}
+
 impl From<OldAskTerms> for AskTerms {
 	fn from(old: OldAskTerms) -> Self {
-		Self::try_from(LoanTerms::from(old.0)).expect("existing ask terms must be valid")
+		AskTerms(LoanTerms::from(old.0))
 	}
 }
 
 impl From<OldBidTerms> for BidTerms {
 	fn from(old: OldBidTerms) -> Self {
-		Self::try_from(LoanTerms::from(old.0)).expect("existing bid terms must be valid")
+		BidTerms(LoanTerms::from(old.0))
 	}
 }
 
@@ -133,12 +195,12 @@ mod tests {
 	use crate::{
 		mock::{ExtBuilder, Test},
 		tests::TestInfo,
-		AskOrderId, BidOrderId, Blockchain, DealOrderId, DoubleMapExt, Duration, OfferId,
+		AskOrderId, BidOrderId, DealOrderId, DoubleMapExt, Duration, InterestRate, OfferId,
 	};
 
 	use super::{
-		generate_storage_alias, AskOrder, AskTerms, BidOrder, BidTerms, Config, DealOrder,
-		Identity, InterestRate, LoanTerms, OldAskOrder, OldAskTerms, OldBidOrder, OldBidTerms,
+		generate_storage_alias, AskOrder, AskTerms, BidOrder, BidTerms, Blockchain, Config,
+		DealOrder, Identity, LoanTerms, OldAskOrder, OldAskTerms, OldBidOrder, OldBidTerms,
 		OldDealOrder, OldInterestRate, OldLoanTerms, Twox64Concat,
 	};
 
@@ -170,7 +232,7 @@ mod tests {
 			let test_info = TestInfo::new_defaults();
 
 			let old_ask_order = OldAskOrder {
-				blockchain: crate::Blockchain::Ethereum,
+				blockchain: Blockchain::Ethereum,
 				lender_address_id: test_info.lender.address_id,
 				terms: OldAskTerms(OldLoanTerms {
 					amount: 100u64.into(),
@@ -223,7 +285,7 @@ mod tests {
 			let test_info = TestInfo::new_defaults();
 
 			let old_bid_order = OldBidOrder {
-				blockchain: crate::Blockchain::Ethereum,
+				blockchain: Blockchain::Ethereum,
 				borrower_address_id: test_info.borrower.address_id,
 				terms: OldBidTerms(OldLoanTerms {
 					amount: 100u64.into(),

--- a/pallets/creditcoin/src/migrations/v4.rs
+++ b/pallets/creditcoin/src/migrations/v4.rs
@@ -32,9 +32,9 @@ mod tests {
 			let mut ids = Vec::new();
 			for i in 0u8..10u8 {
 				let id =
-					AddressId::<H256>::new::<Test>(&crate::Blockchain::Ethereum, &i.to_be_bytes());
+					AddressId::<H256>::new::<Test>(&crate::OldBlockchain::Ethereum, &i.to_be_bytes());
 				let address = Address {
-					blockchain: crate::Blockchain::Ethereum,
+					blockchain: crate::OldBlockchain::Ethereum,
 					value: i.to_be_bytes().to_vec().try_into().unwrap(),
 					owner: AccountId::new([i; 32]),
 				};

--- a/pallets/creditcoin/src/migrations/v4.rs
+++ b/pallets/creditcoin/src/migrations/v4.rs
@@ -4,6 +4,8 @@ use frame_support::dispatch::Weight;
 use frame_support::traits::Get;
 use sp_runtime::SaturatedConversion;
 
+pub use super::v3::*;
+
 use crate::Config;
 
 pub(crate) fn migrate<T: Config>() -> Weight {

--- a/pallets/creditcoin/src/migrations/v5.rs
+++ b/pallets/creditcoin/src/migrations/v5.rs
@@ -78,7 +78,7 @@ mod tests {
 					kind: crate::TransferKind::Native,
 					from: crate::AddressId::new::<Test>(&eth, b"fromaddr"),
 					to: crate::AddressId::new::<Test>(&eth, b"toaddr"),
-					order_id: crate::OrderId::Deal(crate::DealOrderId::dummy()),
+					deal_order_id: crate::DealOrderId::dummy(),
 					amount: 1.into(),
 					tx_id: tx_id.clone(),
 					block: 1,

--- a/pallets/creditcoin/src/migrations/v5.rs
+++ b/pallets/creditcoin/src/migrations/v5.rs
@@ -2,6 +2,8 @@
 use crate::{CollectedCoinsId, Config, TransferId, UnverifiedTransfer};
 use frame_support::{generate_storage_alias, migration, pallet_prelude::*, Identity};
 
+pub use super::v4::*;
+
 generate_storage_alias!(
 	Creditcoin,
 	UnverifiedTransfers<T: Config> => DoubleMap<

--- a/pallets/creditcoin/src/migrations/v5.rs
+++ b/pallets/creditcoin/src/migrations/v5.rs
@@ -162,7 +162,7 @@ mod tests {
 				to_external: b"abab".to_vec().try_into().unwrap(),
 				deadline: 11,
 			};
-			let transfer_id = TransferId::new_old::<Test>(&eth, &tx_id);
+			let transfer_id = TransferId::from_old_blockchain::<Test>(&eth, &tx_id);
 
 			UnverifiedTransfers::<Test>::insert(deadline, &transfer_id, &transfer);
 			assert!(UnverifiedTransfers::<Test>::contains_key(deadline, &transfer_id));

--- a/pallets/creditcoin/src/migrations/v6.rs
+++ b/pallets/creditcoin/src/migrations/v6.rs
@@ -1,6 +1,8 @@
 use super::v5;
 use crate::Config;
+use frame_support::generate_storage_alias;
 use frame_support::pallet_prelude::*;
+
 pub use v5::AskOrder as OldAskOrder;
 pub use v5::AskTerms as OldAskTerms;
 pub use v5::BidOrder as OldBidOrder;
@@ -12,6 +14,46 @@ pub use v5::OrderId as OldOrderId;
 pub use v5::Transfer as OldTransfer;
 pub use v5::TransferKind as OldTransferKind;
 
+use crate::Transfer;
+use crate::TransferId;
+
+generate_storage_alias!(
+	Creditcoin,
+	Transfers<T: Config> => Map<(Identity, TransferId<T::Hash>), Transfer<T::AccountId, T::BlockNumber, T::Hash, T::Moment>>
+);
+
+#[allow(unreachable_code)]
 pub(crate) fn migrate<T: Config>() -> Weight {
-	todo!()
+	let mut weight: Weight = 0;
+	let weight_each = T::DbWeight::get().reads_writes(1, 1);
+
+	Transfers::<T>::translate::<OldTransfer<T::AccountId, T::BlockNumber, T::Hash, T::Moment>, _>(
+		|_id, transfer| {
+			weight = weight.saturating_add(weight_each);
+			Some(Transfer {
+				amount: transfer.amount,
+				from: transfer.from,
+				to: transfer.to,
+				tx_id: transfer.tx_id,
+				block: transfer.block,
+				is_processed: transfer.is_processed,
+				account_id: transfer.account_id,
+				timestamp: transfer.timestamp,
+				deal_order_id: match transfer.order_id {
+					OldOrderId::Deal(id) => id,
+					OldOrderId::Repayment(id) => {
+						log::warn!(
+							"Found unexpected repayment ID attached to a transfer: {:?}",
+							id
+						);
+						return None;
+					},
+				},
+				blockchain: todo!(),
+				kind: todo!(),
+			})
+		},
+	);
+
+	weight
 }

--- a/pallets/creditcoin/src/migrations/v6.rs
+++ b/pallets/creditcoin/src/migrations/v6.rs
@@ -1,0 +1,17 @@
+use super::v5;
+use crate::Config;
+use frame_support::pallet_prelude::*;
+pub use v5::AskOrder as OldAskOrder;
+pub use v5::AskTerms as OldAskTerms;
+pub use v5::BidOrder as OldBidOrder;
+pub use v5::BidTerms as OldBidTerms;
+pub use v5::Blockchain as OldBlockchain;
+pub use v5::DealOrder as OldDealOrder;
+pub use v5::LoanTerms as OldLoanTerms;
+pub use v5::OrderId as OldOrderId;
+pub use v5::Transfer as OldTransfer;
+pub use v5::TransferKind as OldTransferKind;
+
+pub(crate) fn migrate<T: Config>() -> Weight {
+	todo!()
+}

--- a/pallets/creditcoin/src/mock.rs
+++ b/pallets/creditcoin/src/mock.rs
@@ -1,7 +1,7 @@
 use crate::{
 	self as pallet_creditcoin,
 	ocw::rpc::{JsonRpcRequest, JsonRpcResponse},
-	Blockchain, LegacySighash,
+	LegacySighash, OldBlockchain,
 };
 use ethereum_types::U256;
 use frame_support::{
@@ -325,7 +325,7 @@ pub fn roll_by_with_ocw(n: BlockNumber) {
 }
 
 // must be called in an externalities-provided environment
-pub fn set_rpc_uri(blockchain: &Blockchain, value: impl AsRef<[u8]>) {
+pub fn set_rpc_uri(blockchain: &OldBlockchain, value: impl AsRef<[u8]>) {
 	let mut key = Vec::from(blockchain.as_bytes());
 	key.extend(b"-rpc-uri");
 	let rpc_url_storage = StorageValueRef::persistent(&key);

--- a/pallets/creditcoin/src/ocw.rs
+++ b/pallets/creditcoin/src/ocw.rs
@@ -2,7 +2,7 @@ pub mod errors;
 pub mod rpc;
 pub mod tasks;
 
-use crate::{Blockchain, Call, TransferKind};
+use crate::{Blockchain, Call, LegacyTransferKind};
 pub use errors::{OffchainError, VerificationFailureCause, VerificationResult};
 
 use self::errors::RpcUrlError;
@@ -30,13 +30,15 @@ impl Blockchain {
 			Err(RpcUrlError::NoValue)
 		}
 	}
-	pub fn supports(&self, kind: &TransferKind) -> bool {
+	pub fn supports(&self, kind: &LegacyTransferKind) -> bool {
 		match (self, kind) {
 			(
 				Blockchain::Ethereum | Blockchain::Luniverse | Blockchain::Rinkeby,
-				TransferKind::Erc20(_) | TransferKind::Ethless(_) | TransferKind::Native,
+				LegacyTransferKind::Erc20(_)
+				| LegacyTransferKind::Ethless(_)
+				| LegacyTransferKind::Native,
 			) => true,
-			(Blockchain::Bitcoin, TransferKind::Native) => true,
+			(Blockchain::Bitcoin, LegacyTransferKind::Native) => true,
 			(_, _) => false, // TODO: refine this later
 		}
 	}

--- a/pallets/creditcoin/src/ocw.rs
+++ b/pallets/creditcoin/src/ocw.rs
@@ -2,7 +2,7 @@ pub mod errors;
 pub mod rpc;
 pub mod tasks;
 
-use crate::{Blockchain, Call, LegacyTransferKind};
+use crate::{Call, LegacyTransferKind, OldBlockchain};
 pub use errors::{OffchainError, VerificationFailureCause, VerificationResult};
 
 use self::errors::RpcUrlError;
@@ -18,7 +18,7 @@ use sp_std::prelude::*;
 
 pub type OffchainResult<T, E = errors::OffchainError> = Result<T, E>;
 
-impl Blockchain {
+impl OldBlockchain {
 	pub fn rpc_url(&self) -> OffchainResult<String, errors::RpcUrlError> {
 		let chain_prefix = self.as_bytes();
 		let mut buf = Vec::from(chain_prefix);
@@ -33,12 +33,12 @@ impl Blockchain {
 	pub fn supports(&self, kind: &LegacyTransferKind) -> bool {
 		match (self, kind) {
 			(
-				Blockchain::Ethereum | Blockchain::Luniverse | Blockchain::Rinkeby,
+				OldBlockchain::Ethereum | OldBlockchain::Luniverse | OldBlockchain::Rinkeby,
 				LegacyTransferKind::Erc20(_)
 				| LegacyTransferKind::Ethless(_)
 				| LegacyTransferKind::Native,
 			) => true,
-			(Blockchain::Bitcoin, LegacyTransferKind::Native) => true,
+			(OldBlockchain::Bitcoin, LegacyTransferKind::Native) => true,
 			(_, _) => false, // TODO: refine this later
 		}
 	}

--- a/pallets/creditcoin/src/ocw/tasks/collect_coins.rs
+++ b/pallets/creditcoin/src/ocw/tasks/collect_coins.rs
@@ -6,7 +6,7 @@ use crate::ocw::{
 
 use crate::pallet::{Config, Pallet};
 use crate::{
-	types::{Blockchain, UnverifiedCollectedCoins},
+	types::{OldBlockchain, UnverifiedCollectedCoins},
 	ExternalAddress, ExternalAmount,
 };
 use sp_runtime::SaturatedConversion;
@@ -18,7 +18,7 @@ use ethereum_types::{H160, U64};
 use frame_support::ensure;
 use hex_literal::hex;
 
-pub(crate) const CONTRACT_CHAIN: Blockchain = Blockchain::Ethereum;
+pub(crate) const CONTRACT_CHAIN: OldBlockchain = OldBlockchain::Ethereum;
 const CONTRACT_ADDRESS: H160 = sp_core::H160(hex!("a3EE21C306A700E682AbCdfe9BaA6A08F3820419"));
 const BURN_SELECTOR: [u8; 4] = hex!("42966c68");
 

--- a/pallets/creditcoin/src/ocw/tasks/verify_transfer.rs
+++ b/pallets/creditcoin/src/ocw/tasks/verify_transfer.rs
@@ -14,8 +14,8 @@ use crate::{
 		OffchainError, OffchainResult, VerificationFailureCause, VerificationResult,
 		ETH_CONFIRMATIONS,
 	},
-	Blockchain, Config, ExternalAddress, ExternalAmount, ExternalTxId, Id, Transfer, TransferKind,
-	UnverifiedTransfer, DealOrderId,
+	Blockchain, Config, DealOrderId, ExternalAddress, ExternalAmount, ExternalTxId, Id,
+	LegacyTransferKind, Transfer, UnverifiedTransfer,
 };
 
 pub(crate) fn ethless_transfer_function_abi() -> Function {
@@ -115,7 +115,7 @@ impl<T: Config> crate::Pallet<T> {
 		} = transfer;
 		log::debug!("verifying OCW transfer");
 		match kind {
-			TransferKind::Ethless(contract) => Self::verify_ethless_transfer(
+			LegacyTransferKind::Ethless(contract) => Self::verify_ethless_transfer(
 				blockchain,
 				contract,
 				from,
@@ -124,9 +124,9 @@ impl<T: Config> crate::Pallet<T> {
 				amount,
 				tx,
 			),
-			TransferKind::Native | TransferKind::Erc20(_) | TransferKind::Other(_) => {
-				Err(VerificationFailureCause::UnsupportedMethod.into())
-			},
+			LegacyTransferKind::Native
+			| LegacyTransferKind::Erc20(_)
+			| LegacyTransferKind::Other(_) => Err(VerificationFailureCause::UnsupportedMethod.into()),
 		}
 	}
 

--- a/pallets/creditcoin/src/ocw/tasks/verify_transfer.rs
+++ b/pallets/creditcoin/src/ocw/tasks/verify_transfer.rs
@@ -14,8 +14,8 @@ use crate::{
 		OffchainError, OffchainResult, VerificationFailureCause, VerificationResult,
 		ETH_CONFIRMATIONS,
 	},
-	Blockchain, Config, ExternalAddress, ExternalAmount, ExternalTxId, Id, OrderId, Transfer,
-	TransferKind, UnverifiedTransfer,
+	Blockchain, Config, ExternalAddress, ExternalAmount, ExternalTxId, Id, Transfer, TransferKind,
+	UnverifiedTransfer, DealOrderId,
 };
 
 pub(crate) fn ethless_transfer_function_abi() -> Function {
@@ -108,16 +108,22 @@ impl<T: Config> crate::Pallet<T> {
 		transfer: &UnverifiedTransfer<T::AccountId, BlockNumberFor<T>, T::Hash, T::Moment>,
 	) -> VerificationResult<Option<T::Moment>> {
 		let UnverifiedTransfer {
-			transfer: Transfer { blockchain, kind, order_id, amount, tx_id: tx, .. },
+			transfer: Transfer { blockchain, kind, deal_order_id, amount, tx_id: tx, .. },
 			from_external: from,
 			to_external: to,
 			..
 		} = transfer;
 		log::debug!("verifying OCW transfer");
 		match kind {
-			TransferKind::Ethless(contract) => {
-				Self::verify_ethless_transfer(blockchain, contract, from, to, order_id, amount, tx)
-			},
+			TransferKind::Ethless(contract) => Self::verify_ethless_transfer(
+				blockchain,
+				contract,
+				from,
+				to,
+				deal_order_id,
+				amount,
+				tx,
+			),
 			TransferKind::Native | TransferKind::Erc20(_) | TransferKind::Other(_) => {
 				Err(VerificationFailureCause::UnsupportedMethod.into())
 			},
@@ -129,7 +135,7 @@ impl<T: Config> crate::Pallet<T> {
 		contract_address: &ExternalAddress,
 		from: &ExternalAddress,
 		to: &ExternalAddress,
-		order_id: &OrderId<BlockNumberFor<T>, T::Hash>,
+		deal_order_id: &DealOrderId<BlockNumberFor<T>, T::Hash>,
 		amount: &ExternalAmount,
 		tx_id: &ExternalTxId,
 	) -> VerificationResult<Option<T::Moment>> {
@@ -159,7 +165,7 @@ impl<T: Config> crate::Pallet<T> {
 			&tx_receipt,
 			&tx,
 			eth_tip,
-			T::HashIntoNonce::from(order_id.hash()),
+			T::HashIntoNonce::from(deal_order_id.hash()),
 		)?;
 
 		let timestamp = if let Some(num) = tx_block_num {

--- a/pallets/creditcoin/src/ocw/tasks/verify_transfer.rs
+++ b/pallets/creditcoin/src/ocw/tasks/verify_transfer.rs
@@ -14,8 +14,8 @@ use crate::{
 		OffchainError, OffchainResult, VerificationFailureCause, VerificationResult,
 		ETH_CONFIRMATIONS,
 	},
-	Blockchain, Config, DealOrderId, ExternalAddress, ExternalAmount, ExternalTxId, Id,
-	LegacyTransferKind, Transfer, UnverifiedTransfer,
+	Config, DealOrderId, ExternalAddress, ExternalAmount, ExternalTxId, Id, LegacyTransferKind,
+	OldBlockchain, Transfer, UnverifiedTransfer,
 };
 
 pub(crate) fn ethless_transfer_function_abi() -> Function {
@@ -131,7 +131,7 @@ impl<T: Config> crate::Pallet<T> {
 	}
 
 	pub fn verify_ethless_transfer(
-		blockchain: &Blockchain,
+		blockchain: &OldBlockchain,
 		contract_address: &ExternalAddress,
 		from: &ExternalAddress,
 		to: &ExternalAddress,

--- a/pallets/creditcoin/src/ocw/tests.rs
+++ b/pallets/creditcoin/src/ocw/tests.rs
@@ -24,7 +24,7 @@ use crate::{
 	ocw::tasks::StorageLock,
 	tests::{RefstrExt, TestInfo},
 	types::{DoubleMapExt, TransferId},
-	Blockchain, ExternalAddress, Id, LoanTerms, OrderId, TransferKind, Transfers,
+	Blockchain, ExternalAddress, Id, LegacyTransferKind, LoanTerms,
 };
 use alloc::sync::Arc;
 use assert_matches::assert_matches;
@@ -351,36 +351,36 @@ fn blockchain_rpc_url_invalid_scale() {
 
 #[test]
 fn blockchain_supports_etherlike() {
-	assert!(Blockchain::Ethereum.supports(&crate::TransferKind::Native));
-	assert!(Blockchain::Rinkeby.supports(&crate::TransferKind::Native));
-	assert!(Blockchain::Luniverse.supports(&crate::TransferKind::Native));
-	assert!(Blockchain::Ethereum.supports(&crate::TransferKind::Erc20(default())));
-	assert!(Blockchain::Rinkeby.supports(&crate::TransferKind::Erc20(default())));
-	assert!(Blockchain::Luniverse.supports(&crate::TransferKind::Erc20(default())));
-	assert!(Blockchain::Ethereum.supports(&crate::TransferKind::Ethless(default())));
-	assert!(Blockchain::Rinkeby.supports(&crate::TransferKind::Ethless(default())));
-	assert!(Blockchain::Luniverse.supports(&crate::TransferKind::Ethless(default())));
+	assert!(Blockchain::Ethereum.supports(&crate::LegacyTransferKind::Native));
+	assert!(Blockchain::Rinkeby.supports(&crate::LegacyTransferKind::Native));
+	assert!(Blockchain::Luniverse.supports(&crate::LegacyTransferKind::Native));
+	assert!(Blockchain::Ethereum.supports(&crate::LegacyTransferKind::Erc20(default())));
+	assert!(Blockchain::Rinkeby.supports(&crate::LegacyTransferKind::Erc20(default())));
+	assert!(Blockchain::Luniverse.supports(&crate::LegacyTransferKind::Erc20(default())));
+	assert!(Blockchain::Ethereum.supports(&crate::LegacyTransferKind::Ethless(default())));
+	assert!(Blockchain::Rinkeby.supports(&crate::LegacyTransferKind::Ethless(default())));
+	assert!(Blockchain::Luniverse.supports(&crate::LegacyTransferKind::Ethless(default())));
 }
 
 #[test]
 fn blockchain_unsupported() {
-	assert!(!Blockchain::Other(default()).supports(&crate::TransferKind::Native));
-	assert!(!Blockchain::Other(default()).supports(&crate::TransferKind::Erc20(default())));
-	assert!(!Blockchain::Other(default()).supports(&crate::TransferKind::Ethless(default())));
-	assert!(!Blockchain::Other(default()).supports(&crate::TransferKind::Other(default())));
+	assert!(!Blockchain::Other(default()).supports(&crate::LegacyTransferKind::Native));
+	assert!(!Blockchain::Other(default()).supports(&crate::LegacyTransferKind::Erc20(default())));
+	assert!(!Blockchain::Other(default()).supports(&crate::LegacyTransferKind::Ethless(default())));
+	assert!(!Blockchain::Other(default()).supports(&crate::LegacyTransferKind::Other(default())));
 
-	assert!(!Blockchain::Ethereum.supports(&crate::TransferKind::Other(default())));
-	assert!(!Blockchain::Rinkeby.supports(&crate::TransferKind::Other(default())));
-	assert!(!Blockchain::Luniverse.supports(&crate::TransferKind::Other(default())));
-	assert!(!Blockchain::Bitcoin.supports(&crate::TransferKind::Other(default())));
+	assert!(!Blockchain::Ethereum.supports(&crate::LegacyTransferKind::Other(default())));
+	assert!(!Blockchain::Rinkeby.supports(&crate::LegacyTransferKind::Other(default())));
+	assert!(!Blockchain::Luniverse.supports(&crate::LegacyTransferKind::Other(default())));
+	assert!(!Blockchain::Bitcoin.supports(&crate::LegacyTransferKind::Other(default())));
 
-	assert!(!Blockchain::Bitcoin.supports(&crate::TransferKind::Erc20(default())));
-	assert!(!Blockchain::Bitcoin.supports(&crate::TransferKind::Ethless(default())));
+	assert!(!Blockchain::Bitcoin.supports(&crate::LegacyTransferKind::Erc20(default())));
+	assert!(!Blockchain::Bitcoin.supports(&crate::LegacyTransferKind::Ethless(default())));
 }
 
 #[test]
 fn blockchain_supports_bitcoin_native_transfer() {
-	assert!(Blockchain::Bitcoin.supports(&crate::TransferKind::Native));
+	assert!(Blockchain::Bitcoin.supports(&crate::LegacyTransferKind::Native));
 }
 
 #[test]
@@ -449,7 +449,7 @@ fn verify_transfer_ocw_fails_on_unsupported_method() {
 			deal_order.terms.amount,
 			&deal_order_id,
 			"0xfafafa",
-			crate::TransferKind::Native,
+			crate::LegacyTransferKind::Native,
 		);
 		let unverified = make_unverified_transfer(transfer.clone());
 		assert_matches!(
@@ -457,14 +457,14 @@ fn verify_transfer_ocw_fails_on_unsupported_method() {
 			Err(OffchainError::InvalidTask(UnsupportedMethod))
 		);
 
-		transfer.kind = crate::TransferKind::Erc20(ExternalAddress::default());
+		transfer.kind = crate::LegacyTransferKind::Erc20(ExternalAddress::default());
 		let unverified = make_unverified_transfer(transfer.clone());
 		assert_matches!(
 			crate::Pallet::<TestRuntime>::verify_transfer_ocw(&unverified),
 			Err(OffchainError::InvalidTask(UnsupportedMethod))
 		);
 
-		transfer.kind = crate::TransferKind::Other(ExternalAddress::default());
+		transfer.kind = crate::LegacyTransferKind::Other(ExternalAddress::default());
 		let unverified = make_unverified_transfer(transfer);
 		assert_matches!(
 			crate::Pallet::<TestRuntime>::verify_transfer_ocw(&unverified),
@@ -485,7 +485,7 @@ fn verify_transfer_ocw_returns_err() {
 			deal_order.terms.amount,
 			&deal_order_id,
 			"0xfafafa",
-			crate::TransferKind::Ethless(ETHLESS_CONTRACT_ADDR.to_external_address()),
+			crate::LegacyTransferKind::Ethless(ETHLESS_CONTRACT_ADDR.to_external_address()),
 		);
 		let unverified = make_unverified_transfer(transfer);
 
@@ -579,7 +579,7 @@ fn set_up_verify_transfer_env(
 		deal_order.terms.amount,
 		&deal_order_id,
 		crate::mock::get_mock_tx_hash(),
-		crate::TransferKind::Ethless(ETHLESS_CONTRACT_ADDR.to_external_address()),
+		crate::LegacyTransferKind::Ethless(ETHLESS_CONTRACT_ADDR.to_external_address()),
 	);
 	let unverified = make_unverified_transfer(transfer.clone());
 
@@ -590,7 +590,7 @@ fn set_up_verify_transfer_env(
 
 		assert_ok!(crate::mock::Creditcoin::register_funding_transfer(
 			crate::mock::Origin::signed(test_info.lender.account_id),
-			TransferKind::Ethless(contract),
+			LegacyTransferKind::Ethless(contract),
 			deal_order_id,
 			transfer.tx_id,
 		));
@@ -749,7 +749,7 @@ fn verify_transfer_get_block_invalid_address() {
 
 		mock_requests(&state);
 
-		unverified.transfer.kind = TransferKind::Ethless(default());
+		unverified.transfer.kind = LegacyTransferKind::Ethless(default());
 
 		assert_matches!(
 			crate::Pallet::<TestRuntime>::verify_transfer_ocw(&unverified),

--- a/pallets/creditcoin/src/ocw/tests.rs
+++ b/pallets/creditcoin/src/ocw/tests.rs
@@ -24,7 +24,7 @@ use crate::{
 	ocw::tasks::StorageLock,
 	tests::{RefstrExt, TestInfo},
 	types::{DoubleMapExt, TransferId},
-	Blockchain, ExternalAddress, Id, LegacyTransferKind, LoanTerms,
+	ExternalAddress, Id, LegacyTransferKind, LoanTerms, OldBlockchain,
 };
 use alloc::sync::Arc;
 use assert_matches::assert_matches;
@@ -323,16 +323,16 @@ fn ethless_transfer_pending() {
 #[test]
 fn blockchain_rpc_url_missing() {
 	ExtBuilder::default().build_offchain_and_execute(|| {
-		assert_eq!(Blockchain::Ethereum.rpc_url(), Err(RpcUrlError::NoValue));
+		assert_eq!(OldBlockchain::Ethereum.rpc_url(), Err(RpcUrlError::NoValue));
 	})
 }
 
 #[test]
 fn blockchain_rpc_url_non_utf8() {
 	ExtBuilder::default().build_offchain_and_execute(|| {
-		set_rpc_uri(&Blockchain::Ethereum, &[0x80]);
+		set_rpc_uri(&OldBlockchain::Ethereum, &[0x80]);
 
-		assert_matches!(Blockchain::Ethereum.rpc_url().unwrap_err(), RpcUrlError::InvalidUrl(_));
+		assert_matches!(OldBlockchain::Ethereum.rpc_url().unwrap_err(), RpcUrlError::InvalidUrl(_));
 	});
 }
 
@@ -343,7 +343,7 @@ fn blockchain_rpc_url_invalid_scale() {
 		rpc_url_storage.set(&[0x80]);
 
 		assert_matches!(
-			dbg!(Blockchain::Ethereum.rpc_url()).unwrap_err(),
+			dbg!(OldBlockchain::Ethereum.rpc_url()).unwrap_err(),
 			RpcUrlError::StorageFailure(StorageRetrievalError::Undecodable)
 		);
 	});
@@ -351,36 +351,38 @@ fn blockchain_rpc_url_invalid_scale() {
 
 #[test]
 fn blockchain_supports_etherlike() {
-	assert!(Blockchain::Ethereum.supports(&crate::LegacyTransferKind::Native));
-	assert!(Blockchain::Rinkeby.supports(&crate::LegacyTransferKind::Native));
-	assert!(Blockchain::Luniverse.supports(&crate::LegacyTransferKind::Native));
-	assert!(Blockchain::Ethereum.supports(&crate::LegacyTransferKind::Erc20(default())));
-	assert!(Blockchain::Rinkeby.supports(&crate::LegacyTransferKind::Erc20(default())));
-	assert!(Blockchain::Luniverse.supports(&crate::LegacyTransferKind::Erc20(default())));
-	assert!(Blockchain::Ethereum.supports(&crate::LegacyTransferKind::Ethless(default())));
-	assert!(Blockchain::Rinkeby.supports(&crate::LegacyTransferKind::Ethless(default())));
-	assert!(Blockchain::Luniverse.supports(&crate::LegacyTransferKind::Ethless(default())));
+	assert!(OldBlockchain::Ethereum.supports(&crate::LegacyTransferKind::Native));
+	assert!(OldBlockchain::Rinkeby.supports(&crate::LegacyTransferKind::Native));
+	assert!(OldBlockchain::Luniverse.supports(&crate::LegacyTransferKind::Native));
+	assert!(OldBlockchain::Ethereum.supports(&crate::LegacyTransferKind::Erc20(default())));
+	assert!(OldBlockchain::Rinkeby.supports(&crate::LegacyTransferKind::Erc20(default())));
+	assert!(OldBlockchain::Luniverse.supports(&crate::LegacyTransferKind::Erc20(default())));
+	assert!(OldBlockchain::Ethereum.supports(&crate::LegacyTransferKind::Ethless(default())));
+	assert!(OldBlockchain::Rinkeby.supports(&crate::LegacyTransferKind::Ethless(default())));
+	assert!(OldBlockchain::Luniverse.supports(&crate::LegacyTransferKind::Ethless(default())));
 }
 
 #[test]
 fn blockchain_unsupported() {
-	assert!(!Blockchain::Other(default()).supports(&crate::LegacyTransferKind::Native));
-	assert!(!Blockchain::Other(default()).supports(&crate::LegacyTransferKind::Erc20(default())));
-	assert!(!Blockchain::Other(default()).supports(&crate::LegacyTransferKind::Ethless(default())));
-	assert!(!Blockchain::Other(default()).supports(&crate::LegacyTransferKind::Other(default())));
+	assert!(!OldBlockchain::Other(default()).supports(&crate::LegacyTransferKind::Native));
+	assert!(!OldBlockchain::Other(default()).supports(&crate::LegacyTransferKind::Erc20(default())));
+	assert!(
+		!OldBlockchain::Other(default()).supports(&crate::LegacyTransferKind::Ethless(default()))
+	);
+	assert!(!OldBlockchain::Other(default()).supports(&crate::LegacyTransferKind::Other(default())));
 
-	assert!(!Blockchain::Ethereum.supports(&crate::LegacyTransferKind::Other(default())));
-	assert!(!Blockchain::Rinkeby.supports(&crate::LegacyTransferKind::Other(default())));
-	assert!(!Blockchain::Luniverse.supports(&crate::LegacyTransferKind::Other(default())));
-	assert!(!Blockchain::Bitcoin.supports(&crate::LegacyTransferKind::Other(default())));
+	assert!(!OldBlockchain::Ethereum.supports(&crate::LegacyTransferKind::Other(default())));
+	assert!(!OldBlockchain::Rinkeby.supports(&crate::LegacyTransferKind::Other(default())));
+	assert!(!OldBlockchain::Luniverse.supports(&crate::LegacyTransferKind::Other(default())));
+	assert!(!OldBlockchain::Bitcoin.supports(&crate::LegacyTransferKind::Other(default())));
 
-	assert!(!Blockchain::Bitcoin.supports(&crate::LegacyTransferKind::Erc20(default())));
-	assert!(!Blockchain::Bitcoin.supports(&crate::LegacyTransferKind::Ethless(default())));
+	assert!(!OldBlockchain::Bitcoin.supports(&crate::LegacyTransferKind::Erc20(default())));
+	assert!(!OldBlockchain::Bitcoin.supports(&crate::LegacyTransferKind::Ethless(default())));
 }
 
 #[test]
 fn blockchain_supports_bitcoin_native_transfer() {
-	assert!(Blockchain::Bitcoin.supports(&crate::LegacyTransferKind::Native));
+	assert!(OldBlockchain::Bitcoin.supports(&crate::LegacyTransferKind::Native));
 }
 
 #[test]
@@ -388,7 +390,7 @@ fn offchain_signed_tx_works() {
 	let mut ext = ExtBuilder::default();
 	let acct_pubkey = ext.generate_authority();
 	let acct = AccountId::from(acct_pubkey.into_account().0);
-	let transfer_id = crate::TransferId::new::<crate::mock::Test>(&Blockchain::Ethereum, &[0]);
+	let transfer_id = crate::TransferId::new::<crate::mock::Test>(&OldBlockchain::Ethereum, &[0]);
 	ext.build_offchain_and_execute_with_state(|_state, pool| {
 		crate::mock::roll_to(1);
 		let call = crate::Call::<crate::mock::Test>::fail_task {
@@ -560,7 +562,7 @@ fn set_up_verify_transfer_env(
 	register_transfer: bool,
 ) -> (MockUnverifiedTransfer, MockedRpcRequests) {
 	let rpc_uri = "http://localhost:8545";
-	set_rpc_uri(&Blockchain::Rinkeby, rpc_uri);
+	set_rpc_uri(&OldBlockchain::Rinkeby, rpc_uri);
 
 	let test_info = TestInfo {
 		loan_terms: LoanTerms { amount: get_mock_amount(), ..Default::default() },

--- a/pallets/creditcoin/src/tests.rs
+++ b/pallets/creditcoin/src/tests.rs
@@ -4,8 +4,8 @@ use crate::{
 	types::DoubleMapExt,
 	AddressId, AskOrder, AskOrderId, Authorities, BidOrder, BidOrderId, Blockchain, Currency,
 	CurrencyId, DealOrder, DealOrderId, DealOrders, Duration, EvmInfo, EvmTransferKind,
-	ExternalAddress, ExternalAmount, Guid, Id, LegacySighash, LoanTerms, Offer, OfferId, Transfer,
-	TransferId, TransferKind, Transfers, WeightInfo,
+	ExternalAddress, ExternalAmount, Guid, Id, LegacySighash, LegacyTransferKind, LoanTerms, Offer,
+	OfferId, Transfer, TransferId, Transfers, WeightInfo,
 };
 
 use assert_matches::assert_matches;
@@ -250,7 +250,7 @@ impl TestInfo {
 		let tx = "0xfafafa";
 		assert_ok!(Creditcoin::register_funding_transfer(
 			Origin::signed(self.lender.account_id.clone()),
-			TransferKind::Native,
+			LegacyTransferKind::Native,
 			deal_order_id.clone(),
 			tx.as_bytes().into_bounded()
 		));
@@ -266,7 +266,7 @@ impl TestInfo {
 		let amount = amount.into();
 		assert_ok!(Creditcoin::register_repayment_transfer(
 			Origin::signed(self.borrower.account_id.clone()),
-			TransferKind::Native,
+			LegacyTransferKind::Native,
 			amount,
 			deal_order_id.clone(),
 			tx.as_bytes().into_bounded()
@@ -282,7 +282,7 @@ impl TestInfo {
 		amount: impl Into<ExternalAmount>,
 		deal_order_id: &TestDealOrderId,
 		blockchain_tx_id: impl AsRef<[u8]>,
-		transfer_kind: impl Into<Option<TransferKind>>,
+		transfer_kind: impl Into<Option<LegacyTransferKind>>,
 	) -> TestTransfer {
 		let blockchain_tx_id = blockchain_tx_id.as_ref();
 		let tx = if blockchain_tx_id.starts_with(b"0x") {
@@ -294,7 +294,7 @@ impl TestInfo {
 		(
 			Transfer {
 				blockchain: self.blockchain.clone(),
-				kind: transfer_kind.into().unwrap_or(TransferKind::Native),
+				kind: transfer_kind.into().unwrap_or(LegacyTransferKind::Native),
 				from: from.address_id.clone(),
 				to: to.address_id.clone(),
 				deal_order_id: deal_order_id.clone(),
@@ -517,7 +517,7 @@ fn register_transfer_ocw_fail_to_send() {
 		with_failing_create_transaction(|| {
 			assert_ok!(Creditcoin::register_funding_transfer(
 				Origin::signed(lender.clone()),
-				TransferKind::Ethless(contract.clone()),
+				LegacyTransferKind::Ethless(contract.clone()),
 				deal_order_id.clone(),
 				tx_hash.hex_to_address(),
 			));
@@ -535,7 +535,7 @@ fn register_transfer_ocw_fail_to_send() {
 		with_failing_create_transaction(|| {
 			assert_ok!(Creditcoin::register_funding_transfer(
 				Origin::signed(lender.clone()),
-				TransferKind::Ethless(contract.clone()),
+				LegacyTransferKind::Ethless(contract.clone()),
 				fake_deal_order_id.clone(),
 				tx_hash.hex_to_address(),
 			));
@@ -1223,7 +1223,7 @@ fn fund_deal_order_should_error_when_transfer_order_id_doesnt_match_deal_order_i
 
 		assert_ok!(Creditcoin::register_funding_transfer(
 			Origin::signed(second_test_info.lender.account_id.clone()),
-			TransferKind::Ethless(contract),
+			LegacyTransferKind::Ethless(contract),
 			bogus_deal_order_id.clone(),
 			tx_hash
 		));
@@ -1255,7 +1255,7 @@ fn fund_deal_order_should_error_when_transfer_amount_doesnt_match() {
 
 		assert_ok!(Creditcoin::register_funding_transfer(
 			Origin::signed(test_info.lender.account_id.clone()),
-			TransferKind::Ethless(contract),
+			LegacyTransferKind::Ethless(contract),
 			deal_order_id.clone(),
 			tx_hash
 		));
@@ -1295,7 +1295,7 @@ fn fund_deal_order_should_error_when_transfer_sighash_doesnt_match_lender() {
 
 		assert_ok!(Creditcoin::register_funding_transfer(
 			Origin::signed(test_info.lender.account_id.clone()),
-			TransferKind::Ethless(contract),
+			LegacyTransferKind::Ethless(contract),
 			deal_order_id.clone(),
 			tx_hash
 		));
@@ -1362,7 +1362,7 @@ fn fund_deal_order_works() {
 
 		assert_ok!(Creditcoin::register_funding_transfer(
 			Origin::signed(test_info.lender.account_id.clone()),
-			TransferKind::Ethless(contract),
+			LegacyTransferKind::Ethless(contract),
 			deal_order_id.clone(),
 			tx_hash
 		));
@@ -2275,7 +2275,7 @@ fn close_deal_order_should_succeed() {
 			test_info.borrower.account_id.clone(),
 			test_info.borrower.address_id.clone(),
 			test_info.lender.address_id.clone(),
-			TransferKind::Ethless(contract),
+			LegacyTransferKind::Ethless(contract),
 			33u64.into(),
 			deal_order_id.clone(),
 			tx_hash
@@ -2483,7 +2483,7 @@ fn verify_transfer_should_work() {
 		let transfer_id = TransferId::new::<Test>(&Blockchain::Rinkeby, &tx);
 		let transfer = Transfer {
 			blockchain: test_info.blockchain.clone(),
-			kind: TransferKind::Native,
+			kind: LegacyTransferKind::Native,
 			from: test_info.lender.address_id.clone(),
 			to: test_info.borrower.address_id.clone(),
 			deal_order_id,
@@ -2682,7 +2682,7 @@ fn on_initialize_removes_expired_deals_without_transfers() {
 				let tx = format!("0xfafafa{:02}", expiration_block.clone());
 				assert_ok!(Creditcoin::register_funding_transfer(
 					Origin::signed(test_info.lender.account_id.clone()),
-					TransferKind::Native,
+					LegacyTransferKind::Native,
 					deal_order_id.clone(),
 					tx.as_bytes().into_bounded()
 				));
@@ -2727,7 +2727,7 @@ fn register_funding_transfer_should_error_when_not_signed() {
 		assert_noop!(
 			Creditcoin::register_funding_transfer(
 				Origin::none(),
-				TransferKind::Native,
+				LegacyTransferKind::Native,
 				deal_order_id,
 				tx.as_bytes().into_bounded()
 			),
@@ -2750,7 +2750,7 @@ fn register_funding_transfer_should_error_when_not_deal_order_not_found() {
 		assert_noop!(
 			Creditcoin::register_funding_transfer(
 				Origin::signed(test_info.lender.account_id),
-				TransferKind::Native,
+				LegacyTransferKind::Native,
 				deal_order_id,
 				tx.as_bytes().into_bounded()
 			),
@@ -2769,7 +2769,7 @@ fn register_repayment_transfer_should_error_when_not_signed() {
 		assert_noop!(
 			Creditcoin::register_repayment_transfer(
 				Origin::none(),
-				TransferKind::Native,
+				LegacyTransferKind::Native,
 				21u64.into(),
 				deal_order_id,
 				tx.as_bytes().into_bounded()
@@ -2793,7 +2793,7 @@ fn register_repayment_transfer_should_error_when_not_deal_order_not_found() {
 		assert_noop!(
 			Creditcoin::register_repayment_transfer(
 				Origin::signed(test_info.borrower.account_id),
-				TransferKind::Native,
+				LegacyTransferKind::Native,
 				21u64.into(),
 				deal_order_id,
 				tx.as_bytes().into_bounded()
@@ -2816,7 +2816,7 @@ fn register_transfer_internal_should_error_with_non_existent_lender_address() {
 			test_info.lender.account_id,
 			bogus_address,
 			deal_order.borrower_address_id,
-			TransferKind::Native,
+			LegacyTransferKind::Native,
 			deal_order.terms.amount,
 			deal_order_id,
 			tx.as_bytes().into_bounded(),
@@ -2840,7 +2840,7 @@ fn register_transfer_internal_should_error_with_non_existent_borrower_address() 
 			test_info.lender.account_id,
 			deal_order.lender_address_id,
 			bogus_address,
-			TransferKind::Native,
+			LegacyTransferKind::Native,
 			deal_order.terms.amount,
 			deal_order_id,
 			tx.as_bytes().into_bounded(),
@@ -2862,7 +2862,7 @@ fn register_transfer_internal_should_error_when_signer_doesnt_own_from_address()
 			test_info.lender.account_id,
 			deal_order.borrower_address_id, // should match 1st argument
 			deal_order.lender_address_id,
-			TransferKind::Native,
+			LegacyTransferKind::Native,
 			deal_order.terms.amount,
 			deal_order_id,
 			tx.as_bytes().into_bounded(),
@@ -2885,7 +2885,7 @@ fn register_transfer_internal_should_error_when_addresses_are_not_on_the_same_bl
 			test_info.lender.account_id,
 			deal_order.lender_address_id,
 			second_borrower.address_id,
-			TransferKind::Native,
+			LegacyTransferKind::Native,
 			deal_order.terms.amount,
 			deal_order_id,
 			tx.as_bytes().into_bounded(),
@@ -2908,7 +2908,7 @@ fn register_transfer_internal_should_error_when_transfer_kind_is_not_supported()
 			deal_order.lender_address_id,
 			deal_order.borrower_address_id,
 			// not supported on Blockchain::Rinkeby
-			TransferKind::Other(BoundedVec::try_from(b"other".to_vec()).unwrap()),
+			LegacyTransferKind::Other(BoundedVec::try_from(b"other".to_vec()).unwrap()),
 			deal_order.terms.amount,
 			deal_order_id,
 			tx.as_bytes().into_bounded(),
@@ -2930,7 +2930,7 @@ fn register_transfer_internal_should_error_when_transfer_is_already_registered()
 			test_info.lender.account_id,
 			deal_order.lender_address_id,
 			deal_order.borrower_address_id,
-			TransferKind::Native,
+			LegacyTransferKind::Native,
 			deal_order.terms.amount,
 			deal_order_id,
 			transfer.tx_id,

--- a/pallets/creditcoin/src/tests.rs
+++ b/pallets/creditcoin/src/tests.rs
@@ -2,10 +2,10 @@ use crate::{
 	helpers::{non_paying_error, EVMAddress, PublicToAddress},
 	mock::*,
 	types::DoubleMapExt,
-	AddressId, AskOrder, AskOrderId, Authorities, BidOrder, BidOrderId, Blockchain, Currency,
-	CurrencyId, DealOrder, DealOrderId, DealOrders, Duration, EvmInfo, EvmTransferKind,
-	ExternalAddress, ExternalAmount, Guid, Id, LegacySighash, LegacyTransferKind, LoanTerms, Offer,
-	OfferId, Transfer, TransferId, Transfers, WeightInfo,
+	AddressId, AskOrder, AskOrderId, Authorities, BidOrder, BidOrderId, Currency, CurrencyId,
+	DealOrder, DealOrderId, DealOrders, Duration, EvmInfo, EvmTransferKind, ExternalAddress,
+	ExternalAmount, Guid, Id, LegacySighash, LegacyTransferKind, LoanTerms, Offer, OfferId,
+	OldBlockchain, Transfer, TransferId, Transfers,
 };
 
 use assert_matches::assert_matches;
@@ -53,7 +53,7 @@ pub struct RegisteredAddress {
 impl RegisteredAddress {
 	pub fn from_pubkey_distinct_owner(
 		owners_account_id: AccountId,
-		blockchain: Blockchain,
+		blockchain: OldBlockchain,
 		address_key: impl Into<MultiSigner>,
 		signature: sp_core::ecdsa::Signature,
 	) -> RegisteredAddress {
@@ -76,7 +76,7 @@ impl RegisteredAddress {
 	}
 	pub fn from_pubkey(
 		public_key: impl Into<MultiSigner>,
-		blockchain: Blockchain,
+		blockchain: OldBlockchain,
 		signature: sp_core::ecdsa::Signature,
 	) -> RegisteredAddress {
 		let signer = public_key.into();
@@ -96,7 +96,7 @@ impl RegisteredAddress {
 		));
 		RegisteredAddress { account_id, address_id }
 	}
-	pub fn new(seed: &str, blockchain: Blockchain) -> RegisteredAddress {
+	pub fn new(seed: &str, blockchain: OldBlockchain) -> RegisteredAddress {
 		let (who, address, ownership_proof, _) = generate_address_with_proof(seed);
 		let address_id = AddressId::new::<Test>(&blockchain, &address);
 		assert_ok!(Creditcoin::register_address(
@@ -137,7 +137,7 @@ type TestTransfer = (Transfer<AccountId, u64, H256, u64>, TestTransferId);
 
 #[derive(Clone, Debug)]
 pub struct TestInfo {
-	pub(crate) blockchain: Blockchain,
+	pub(crate) blockchain: OldBlockchain,
 	pub(crate) loan_terms: LoanTerms,
 	pub(crate) lender: RegisteredAddress,
 	pub(crate) borrower: RegisteredAddress,
@@ -160,9 +160,9 @@ impl Default for Currency {
 
 impl Default for TestInfo {
 	fn default() -> Self {
-		let lender = RegisteredAddress::new("lender", Blockchain::Rinkeby);
-		let borrower = RegisteredAddress::new("borrower", Blockchain::Rinkeby);
-		let blockchain = Blockchain::Rinkeby;
+		let lender = RegisteredAddress::new("lender", OldBlockchain::Rinkeby);
+		let borrower = RegisteredAddress::new("borrower", OldBlockchain::Rinkeby);
+		let blockchain = OldBlockchain::Rinkeby;
 
 		let loan_terms =
 			LoanTerms { amount: ExternalAmount::from(10_000_000_u64), ..Default::default() };
@@ -290,7 +290,7 @@ impl TestInfo {
 		} else {
 			blockchain_tx_id.into_bounded()
 		};
-		let id = TransferId::new::<Test>(&Blockchain::Rinkeby, &tx);
+		let id = TransferId::new::<Test>(&OldBlockchain::Rinkeby, &tx);
 		(
 			Transfer {
 				blockchain: self.blockchain.clone(),
@@ -344,7 +344,7 @@ fn register_address_should_work() {
 		System::set_block_number(1);
 
 		let (who, address, ownership_proof, _) = generate_address_with_proof("owner");
-		let blockchain = Blockchain::Rinkeby;
+		let blockchain = OldBlockchain::Rinkeby;
 		assert_ok!(Creditcoin::register_address(
 			Origin::signed(who.clone()),
 			blockchain.clone(),
@@ -371,7 +371,7 @@ fn register_address_should_work() {
 fn register_address_pre_existing() {
 	ExtBuilder::default().build_and_execute(|| {
 		let (who, address, ownership_proof, _) = generate_address_with_proof("owner");
-		let blockchain = Blockchain::Rinkeby;
+		let blockchain = OldBlockchain::Rinkeby;
 		assert_ok!(Creditcoin::register_address(
 			Origin::signed(who.clone()),
 			blockchain.clone(),
@@ -390,7 +390,7 @@ fn register_address_pre_existing() {
 fn register_address_should_error_when_not_signed() {
 	ExtBuilder::default().build_and_execute(|| {
 		let (_who, address, ownership_proof, _) = generate_address_with_proof("owner");
-		let blockchain = Blockchain::Rinkeby;
+		let blockchain = OldBlockchain::Rinkeby;
 
 		assert_noop!(
 			Creditcoin::register_address(Origin::none(), blockchain, address, ownership_proof),
@@ -405,7 +405,7 @@ fn register_address_should_error_when_using_wrong_ownership_proof() {
 		let (who, address, _ownership_proof, _) = generate_address_with_proof("owner");
 		let (_who2, _address2, ownership_proof2, _) = generate_address_with_proof("bogus");
 
-		let blockchain = Blockchain::Rinkeby;
+		let blockchain = OldBlockchain::Rinkeby;
 		assert_noop!(
 			Creditcoin::register_address(
 				Origin::signed(who),
@@ -423,7 +423,7 @@ fn register_address_should_error_when_address_too_long() {
 	ExtBuilder::default().build_and_execute(|| {
 		let (who, address, ownership_proof, _) = generate_address_with_proof("owner");
 		let address = format!("0xff{}", hex::encode(address)).hex_to_address();
-		let blockchain = Blockchain::Rinkeby;
+		let blockchain = OldBlockchain::Rinkeby;
 		assert_noop!(
 			Creditcoin::register_address(Origin::signed(who), blockchain, address, ownership_proof),
 			crate::Error::<Test>::AddressFormatNotSupported
@@ -440,7 +440,7 @@ fn register_address_should_error_when_signature_is_invalid() {
 		// https://docs.rs/sp-core/2.0.0-rc4/sp_core/ecdsa/struct.Signature.html#method.from_raw
 		let ownership_proof = sp_core::ecdsa::Signature::from_raw([0; 65]);
 
-		let blockchain = Blockchain::Rinkeby;
+		let blockchain = OldBlockchain::Rinkeby;
 		assert_noop!(
 			Creditcoin::register_address(Origin::signed(who), blockchain, address, ownership_proof),
 			crate::Error::<Test>::InvalidSignature
@@ -471,7 +471,7 @@ fn verify_ethless_transfer() {
 		let tx_id = tx_hash.hex_to_address();
 
 		assert_ok!(Creditcoin::verify_ethless_transfer(
-			&Blockchain::Rinkeby,
+			&OldBlockchain::Rinkeby,
 			&contract,
 			&from,
 			&to,
@@ -492,7 +492,7 @@ fn register_transfer_ocw_fail_to_send() {
 		let tx_hash = get_mock_tx_hash();
 		let contract = get_mock_contract().hex_to_address();
 		let tx_block_num = get_mock_tx_block_num();
-		let blockchain = Blockchain::Rinkeby;
+		let blockchain = OldBlockchain::Rinkeby;
 
 		// we're going to verify a transfer twice:
 		// First when we expect failure, which means we won't make all of the requests
@@ -502,7 +502,7 @@ fn register_transfer_ocw_fail_to_send() {
 		MockedRpcRequests::new(dummy_url, &tx_hash, &tx_block_num, &*ETHLESS_RESPONSES)
 			.mock_all(&mut state.write());
 
-		set_rpc_uri(&Blockchain::Rinkeby, &dummy_url);
+		set_rpc_uri(&OldBlockchain::Rinkeby, &dummy_url);
 
 		let loan_amount = get_mock_amount();
 		let terms = LoanTerms { amount: loan_amount, ..Default::default() };
@@ -565,13 +565,12 @@ fn add_ask_order_basic() {
 
 	let (ask_order, ask_guid) = ext.execute_with(|| {
 		let test_info = TestInfo::new_defaults();
-		let TestInfo { lender, loan_terms, blockchain, ask_guid, .. } = test_info.clone();
+		let TestInfo { lender, loan_terms, ask_guid, .. } = test_info.clone();
 		let RegisteredAddress { address_id, account_id } = lender;
 		let (ask_order, _) = test_info.create_ask_order();
 		let AskOrder { block, expiration_block, .. } = ask_order;
 
 		let new_ask_order = crate::AskOrder {
-			blockchain,
 			lender_address_id: address_id,
 			terms: loan_terms.try_into().unwrap(),
 			expiration_block,
@@ -679,14 +678,13 @@ fn add_bid_order_basic() {
 
 	let (bid_order, bid_guid) = ext.execute_with(|| {
 		let test_info = TestInfo::new_defaults();
-		let TestInfo { borrower, loan_terms, blockchain, bid_guid, .. } = test_info.clone();
+		let TestInfo { borrower, loan_terms, bid_guid, .. } = test_info.clone();
 		let RegisteredAddress { address_id, account_id } = borrower;
 
 		let (bid_order, _) = test_info.create_bid_order();
 		let BidOrder { expiration_block, block, .. } = bid_order;
 
 		let new_bid_order = crate::BidOrder {
-			blockchain,
 			borrower_address_id: address_id,
 			terms: loan_terms.try_into().unwrap(),
 			expiration_block,
@@ -790,10 +788,10 @@ fn add_offer_basic() {
 		let test_info = TestInfo::new_defaults();
 
 		let (offer, _) = test_info.create_offer();
-		let Offer { blockchain, expiration_block, block, ask_id, bid_id, lender, .. } =
+		let Offer { expiration_block, block, ask_id, bid_id, lender, .. } =
 			offer.clone();
 
-		let new_offer = Offer { blockchain, expiration_block, block, ask_id, bid_id, lender };
+		let new_offer = Offer { expiration_block, block, ask_id, bid_id, lender };
 
 		assert_eq!(new_offer, offer);
 	});
@@ -823,11 +821,10 @@ fn add_offer_should_error_when_blockchain_differs_between_ask_and_bid_order() {
 		let Offer { expiration_block, ask_id, bid_id, lender, .. } = offer;
 
 		// simulate deal transfer
-		crate::AskOrders::<Test>::mutate(
-			&ask_id.expiration(),
-			&ask_id.hash(),
-			|ask_order_storage| {
-				ask_order_storage.as_mut().unwrap().blockchain = Blockchain::Bitcoin;
+		crate::Addresses::<Test>::mutate(
+			&test_info.lender.address_id,
+			|address_storage| {
+				address_storage.as_mut().unwrap().blockchain = OldBlockchain::Bitcoin;
 			},
 		);
 
@@ -845,7 +842,6 @@ fn add_deal_order_basic() {
 
 		let (deal_order, _) = test_info.create_deal_order();
 		let DealOrder {
-			blockchain,
 			expiration_block,
 			lender_address_id,
 			borrower_address_id,
@@ -857,7 +853,6 @@ fn add_deal_order_basic() {
 		} = deal_order.clone();
 
 		let new_deal_order = DealOrder {
-			blockchain,
 			offer_id,
 			lender_address_id,
 			borrower_address_id,
@@ -903,7 +898,7 @@ fn lock_deal_order_should_emit_deal_order_locked_event() {
 			&deal_order_id.hash(),
 			|deal_order_storage| {
 				deal_order_storage.as_mut().unwrap().funding_transfer_id =
-					Some(TransferId::new::<Test>(&deal_order.blockchain, b"12345678"));
+					Some(TransferId::new::<Test>(&test_info.blockchain, b"12345678"));
 			},
 		);
 
@@ -969,7 +964,7 @@ fn lock_deal_order_should_fail_for_non_borrower() {
 	ExtBuilder::default().build_and_execute(|| {
 		let test_info = TestInfo::new_defaults();
 
-		let (deal_order, deal_order_id) = test_info.create_deal_order();
+		let (_, deal_order_id) = test_info.create_deal_order();
 
 		// simulate deal transfer
 		crate::DealOrders::<Test>::mutate(
@@ -977,7 +972,7 @@ fn lock_deal_order_should_fail_for_non_borrower() {
 			&deal_order_id.hash(),
 			|deal_order_storage| {
 				deal_order_storage.as_mut().unwrap().funding_transfer_id =
-					Some(TransferId::new::<Test>(&deal_order.blockchain, b"12345678"));
+					Some(TransferId::new::<Test>(&test_info.blockchain, b"12345678"));
 			},
 		);
 
@@ -993,7 +988,7 @@ fn lock_deal_order_should_fail_if_already_locked() {
 	ExtBuilder::default().build_and_execute(|| {
 		let test_info = TestInfo::new_defaults();
 
-		let (deal_order, deal_order_id) = test_info.create_deal_order();
+		let (_, deal_order_id) = test_info.create_deal_order();
 
 		// simulate deal transfer
 		crate::DealOrders::<Test>::mutate(
@@ -1001,7 +996,7 @@ fn lock_deal_order_should_fail_if_already_locked() {
 			&deal_order_id.hash(),
 			|deal_order_storage| {
 				deal_order_storage.as_mut().unwrap().funding_transfer_id =
-					Some(TransferId::new::<Test>(&deal_order.blockchain, b"12345678"));
+					Some(TransferId::new::<Test>(&test_info.blockchain, b"12345678"));
 			},
 		);
 
@@ -1033,7 +1028,7 @@ fn lock_deal_order_locks_by_borrower() {
 			&deal_order_id.hash(),
 			|deal_order_storage| {
 				deal_order_storage.as_mut().unwrap().funding_transfer_id =
-					Some(TransferId::new::<Test>(&deal_order.blockchain, b"12345678"));
+					Some(TransferId::new::<Test>(&test_info.blockchain, b"12345678"));
 			},
 		);
 
@@ -1051,8 +1046,8 @@ fn lock_deal_order_locks_by_borrower() {
 fn fund_deal_order_should_error_when_not_signed() {
 	ExtBuilder::default().build_and_execute(|| {
 		let test_info = TestInfo::new_defaults();
-		let (deal_order, deal_order_id) = test_info.create_deal_order();
-		let transfer_id = TransferId::new::<Test>(&deal_order.blockchain, b"12345678");
+		let (_, deal_order_id) = test_info.create_deal_order();
+		let transfer_id = TransferId::new::<Test>(&test_info.blockchain, b"12345678");
 
 		assert_noop!(
 			Creditcoin::fund_deal_order(Origin::none(), deal_order_id, transfer_id),
@@ -1065,15 +1060,15 @@ fn fund_deal_order_should_error_when_not_signed() {
 fn fund_deal_order_should_error_when_address_not_registered() {
 	ExtBuilder::default().build_and_execute(|| {
 		let test_info = TestInfo::new_defaults();
-		let (deal_order, deal_order_id) = test_info.create_deal_order();
-		let transfer_id = TransferId::new::<Test>(&deal_order.blockchain, b"12345678");
+		let (_, deal_order_id) = test_info.create_deal_order();
+		let transfer_id = TransferId::new::<Test>(&test_info.blockchain, b"12345678");
 
 		// simulate deal with an address that isn't registered
 		crate::DealOrders::<Test>::mutate(
 			&deal_order_id.expiration(),
 			&deal_order_id.hash(),
 			|deal_order_storage| {
-				let blockchain = Blockchain::Rinkeby;
+				let blockchain = OldBlockchain::Rinkeby;
 
 				deal_order_storage.as_mut().unwrap().lender_address_id =
 					AddressId::new::<Test>(&blockchain, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 0]);
@@ -1095,8 +1090,8 @@ fn fund_deal_order_should_error_when_address_not_registered() {
 fn fund_deal_order_should_error_for_non_lender() {
 	ExtBuilder::default().build_and_execute(|| {
 		let test_info = TestInfo::new_defaults();
-		let (deal_order, deal_order_id) = test_info.create_deal_order();
-		let transfer_id = TransferId::new::<Test>(&deal_order.blockchain, b"12345678");
+		let (_, deal_order_id) = test_info.create_deal_order();
+		let transfer_id = TransferId::new::<Test>(&test_info.blockchain, b"12345678");
 
 		assert_noop!(
 			Creditcoin::fund_deal_order(
@@ -1113,8 +1108,8 @@ fn fund_deal_order_should_error_for_non_lender() {
 fn fund_deal_order_should_error_when_timestamp_is_in_the_future() {
 	ExtBuilder::default().build_and_execute(|| {
 		let test_info = TestInfo::new_defaults();
-		let (deal_order, deal_order_id) = test_info.create_deal_order();
-		let transfer_id = TransferId::new::<Test>(&deal_order.blockchain, b"12345678");
+		let (_, deal_order_id) = test_info.create_deal_order();
+		let transfer_id = TransferId::new::<Test>(&test_info.blockchain, b"12345678");
 
 		// simulate deal with a timestamp in the future
 		crate::DealOrders::<Test>::mutate(
@@ -1140,8 +1135,8 @@ fn fund_deal_order_should_error_when_timestamp_is_in_the_future() {
 fn fund_deal_order_should_error_when_deal_is_funded() {
 	ExtBuilder::default().build_and_execute(|| {
 		let test_info = TestInfo::new_defaults();
-		let (deal_order, deal_order_id) = test_info.create_deal_order();
-		let transfer_id = TransferId::new::<Test>(&deal_order.blockchain, b"12345678");
+		let (_, deal_order_id) = test_info.create_deal_order();
+		let transfer_id = TransferId::new::<Test>(&test_info.blockchain, b"12345678");
 
 		// simulate a funded deal
 		crate::DealOrders::<Test>::mutate(
@@ -1149,7 +1144,7 @@ fn fund_deal_order_should_error_when_deal_is_funded() {
 			&deal_order_id.hash(),
 			|deal_order_storage| {
 				deal_order_storage.as_mut().unwrap().funding_transfer_id =
-					Some(TransferId::new::<Test>(&deal_order.blockchain, b"12345678"));
+					Some(TransferId::new::<Test>(&test_info.blockchain, b"12345678"));
 			},
 		);
 
@@ -1170,8 +1165,8 @@ fn fund_deal_order_should_error_when_deal_has_expired() {
 		roll_to(4); // advance head so we have something to compare to
 
 		let test_info = TestInfo::new_defaults();
-		let (deal_order, deal_order_id) = test_info.create_deal_order();
-		let transfer_id = TransferId::new::<Test>(&deal_order.blockchain, b"12345678");
+		let (_, deal_order_id) = test_info.create_deal_order();
+		let transfer_id = TransferId::new::<Test>(&test_info.blockchain, b"12345678");
 
 		// simulate an expired deal by setting expiration_block < head
 		crate::DealOrders::<Test>::mutate(
@@ -1202,9 +1197,9 @@ fn fund_deal_order_should_error_when_transfer_order_id_doesnt_match_deal_order_i
 
 		// this is a deal_order from another person
 		let second_test_info = TestInfo {
-			lender: RegisteredAddress::new("lender2", Blockchain::Rinkeby),
-			borrower: RegisteredAddress::new("borrower2", Blockchain::Rinkeby),
-			blockchain: Blockchain::Rinkeby,
+			lender: RegisteredAddress::new("lender2", OldBlockchain::Rinkeby),
+			borrower: RegisteredAddress::new("borrower2", OldBlockchain::Rinkeby),
+			blockchain: OldBlockchain::Rinkeby,
 			loan_terms: LoanTerms {
 				amount: 2_000_000u64.into(),
 				interest_rate: Default::default(),
@@ -1562,13 +1557,13 @@ fn register_deal_order_should_error_when_lender_address_doesnt_match_sender() {
 		let test_info = TestInfo {
 			borrower: RegisteredAddress::from_pubkey(
 				key_pair.public(),
-				Blockchain::Rinkeby,
+				OldBlockchain::Rinkeby,
 				ownership_proof,
 			),
 			..TestInfo::new_defaults()
 		};
 
-		let lender = RegisteredAddress::new("lender2", Blockchain::Rinkeby);
+		let lender = RegisteredAddress::new("lender2", OldBlockchain::Rinkeby);
 		let message = test_info.get_register_deal_msg();
 		let compliance_proof = key_pair.sign(&message);
 
@@ -1596,10 +1591,10 @@ fn register_deal_order_should_error_when_lender_and_borrower_are_on_different_ch
 		let pub_key = key_pair.public();
 
 		let test_info = TestInfo {
-			lender: RegisteredAddress::new("lender2", Blockchain::Ethereum),
+			lender: RegisteredAddress::new("lender2", OldBlockchain::Ethereum),
 			borrower: RegisteredAddress::from_pubkey(
 				pub_key.clone(),
-				Blockchain::Rinkeby,
+				OldBlockchain::Rinkeby,
 				ownership_proof,
 			),
 			..TestInfo::new_defaults()
@@ -1634,7 +1629,7 @@ fn register_deal_order_should_error_when_ask_order_id_exists() {
 		let test_info = TestInfo {
 			borrower: RegisteredAddress::from_pubkey(
 				pub_key.clone(),
-				Blockchain::Rinkeby,
+				OldBlockchain::Rinkeby,
 				ownership_proof,
 			),
 			..TestInfo::new_defaults()
@@ -1669,7 +1664,11 @@ fn register_deal_order_should_error_when_bid_order_id_exists() {
 		let pub_key = key_pair.public();
 
 		let test_info = TestInfo {
-			borrower: RegisteredAddress::from_pubkey(pub_key, Blockchain::Rinkeby, ownership_proof),
+			borrower: RegisteredAddress::from_pubkey(
+				pub_key,
+				OldBlockchain::Rinkeby,
+				ownership_proof,
+			),
 			..TestInfo::new_defaults()
 		};
 
@@ -1705,7 +1704,7 @@ fn register_deal_order_should_error_when_offer_id_exists() {
 		let test_info = TestInfo {
 			borrower: RegisteredAddress::from_pubkey(
 				pub_key.clone(),
-				Blockchain::Rinkeby,
+				OldBlockchain::Rinkeby,
 				ownership_proof,
 			),
 			..TestInfo::new_defaults()
@@ -1722,7 +1721,6 @@ fn register_deal_order_should_error_when_offer_id_exists() {
 			ask_id: ask_order_id,
 			bid_id: bid_order_id,
 			block: current_block,
-			blockchain: test_info.blockchain.clone(),
 			expiration_block: test_info.expiration_block,
 			lender: test_info.lender.account_id.clone(),
 		};
@@ -1759,7 +1757,7 @@ fn register_deal_order_should_error_when_deal_order_id_exists() {
 		let test_info = TestInfo {
 			borrower: RegisteredAddress::from_pubkey(
 				pub_key.clone(),
-				Blockchain::Rinkeby,
+				OldBlockchain::Rinkeby,
 				ownership_proof,
 			),
 			..TestInfo::new_defaults()
@@ -1777,7 +1775,6 @@ fn register_deal_order_should_error_when_deal_order_id_exists() {
 		let deal_order_id = DealOrderId::new::<Test>(test_info.expiration_block, &offer_id);
 
 		let deal_order = DealOrder {
-			blockchain: test_info.blockchain,
 			offer_id,
 			lender_address_id: test_info.lender.address_id.clone(),
 			borrower_address_id: test_info.borrower.address_id.clone(),
@@ -1823,7 +1820,7 @@ fn register_deal_order_should_succeed() {
 		let test_info = TestInfo {
 			borrower: RegisteredAddress::from_pubkey(
 				pub_key.clone(),
-				Blockchain::Rinkeby,
+				OldBlockchain::Rinkeby,
 				ownership_proof,
 			),
 			..TestInfo::new_defaults()
@@ -1878,7 +1875,7 @@ fn register_deal_order_accepts_sr25519() {
 			TestInfo {
 				borrower: RegisteredAddress::from_pubkey_distinct_owner(
 					owners_account,
-					Blockchain::Rinkeby,
+					OldBlockchain::Rinkeby,
 					b_pubkey,
 					ownership_proof,
 				),
@@ -1921,7 +1918,7 @@ fn register_deal_order_accepts_ed25519() {
 			TestInfo {
 				borrower: RegisteredAddress::from_pubkey_distinct_owner(
 					owners_account,
-					Blockchain::Rinkeby,
+					OldBlockchain::Rinkeby,
 					b_pubkey,
 					ownership_proof,
 				),
@@ -1950,8 +1947,8 @@ fn register_deal_order_accepts_ed25519() {
 fn close_deal_order_should_error_when_not_signed() {
 	ExtBuilder::default().build_and_execute(|| {
 		let test_info = TestInfo::new_defaults();
-		let (deal_order, deal_order_id) = test_info.create_deal_order();
-		let transfer_id = TransferId::new::<Test>(&deal_order.blockchain, b"12345678");
+		let (_, deal_order_id) = test_info.create_deal_order();
+		let transfer_id = TransferId::new::<Test>(&test_info.blockchain, b"12345678");
 
 		assert_noop!(
 			Creditcoin::close_deal_order(Origin::none(), deal_order_id, transfer_id,),
@@ -1964,15 +1961,15 @@ fn close_deal_order_should_error_when_not_signed() {
 fn close_deal_order_should_error_when_borrower_address_is_not_registered() {
 	ExtBuilder::default().build_and_execute(|| {
 		let test_info = TestInfo::new_defaults();
-		let (deal_order, deal_order_id) = test_info.create_deal_order();
-		let transfer_id = TransferId::new::<Test>(&deal_order.blockchain, b"12345678");
+		let (_, deal_order_id) = test_info.create_deal_order();
+		let transfer_id = TransferId::new::<Test>(&test_info.blockchain, b"12345678");
 
 		// simulate deal with an address that isn't registered
 		crate::DealOrders::<Test>::mutate(
 			&deal_order_id.expiration(),
 			&deal_order_id.hash(),
 			|deal_order_storage| {
-				let blockchain = Blockchain::Rinkeby;
+				let blockchain = OldBlockchain::Rinkeby;
 
 				deal_order_storage.as_mut().unwrap().borrower_address_id =
 					AddressId::new::<Test>(&blockchain, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 0]);
@@ -1994,8 +1991,8 @@ fn close_deal_order_should_error_when_borrower_address_is_not_registered() {
 fn close_deal_order_should_error_when_not_signed_by_borrower() {
 	ExtBuilder::default().build_and_execute(|| {
 		let test_info = TestInfo::new_defaults();
-		let (deal_order, deal_order_id) = test_info.create_deal_order();
-		let transfer_id = TransferId::new::<Test>(&deal_order.blockchain, b"12345678");
+		let (_, deal_order_id) = test_info.create_deal_order();
+		let transfer_id = TransferId::new::<Test>(&test_info.blockchain, b"12345678");
 
 		assert_noop!(
 			Creditcoin::close_deal_order(
@@ -2013,8 +2010,8 @@ fn close_deal_order_should_error_when_not_signed_by_borrower() {
 fn close_deal_order_should_error_when_deal_timestamp_is_in_the_future() {
 	ExtBuilder::default().build_and_execute(|| {
 		let test_info = TestInfo::new_defaults();
-		let (deal_order, deal_order_id) = test_info.create_deal_order();
-		let transfer_id = TransferId::new::<Test>(&deal_order.blockchain, b"12345678");
+		let (_, deal_order_id) = test_info.create_deal_order();
+		let transfer_id = TransferId::new::<Test>(&test_info.blockchain, b"12345678");
 
 		// simulate deal with a timestamp in the future
 		crate::DealOrders::<Test>::mutate(
@@ -2040,8 +2037,8 @@ fn close_deal_order_should_error_when_deal_timestamp_is_in_the_future() {
 fn close_deal_order_should_error_when_deal_order_has_already_been_repaid() {
 	ExtBuilder::default().build_and_execute(|| {
 		let test_info = TestInfo::new_defaults();
-		let (deal_order, deal_order_id) = test_info.create_deal_order();
-		let transfer_id = TransferId::new::<Test>(&deal_order.blockchain, b"12345678");
+		let (_, deal_order_id) = test_info.create_deal_order();
+		let transfer_id = TransferId::new::<Test>(&test_info.blockchain, b"12345678");
 
 		// simulate DealOrder which has been repaid
 		crate::DealOrders::<Test>::mutate(
@@ -2049,7 +2046,7 @@ fn close_deal_order_should_error_when_deal_order_has_already_been_repaid() {
 			&deal_order_id.hash(),
 			|deal_order_storage| {
 				deal_order_storage.as_mut().unwrap().repayment_transfer_id =
-					Some(TransferId::new::<Test>(&deal_order.blockchain, b"4444"));
+					Some(TransferId::new::<Test>(&test_info.blockchain, b"4444"));
 			},
 		);
 
@@ -2068,8 +2065,8 @@ fn close_deal_order_should_error_when_deal_order_has_already_been_repaid() {
 fn close_deal_order_should_error_when_deal_isnt_locked() {
 	ExtBuilder::default().build_and_execute(|| {
 		let test_info = TestInfo::new_defaults();
-		let (deal_order, deal_order_id) = test_info.create_deal_order();
-		let transfer_id = TransferId::new::<Test>(&deal_order.blockchain, b"12345678");
+		let (_, deal_order_id) = test_info.create_deal_order();
+		let transfer_id = TransferId::new::<Test>(&test_info.blockchain, b"12345678");
 
 		// simulate deal which is not locked
 		crate::DealOrders::<Test>::mutate(
@@ -2108,9 +2105,9 @@ fn close_deal_order_should_error_when_transfer_order_id_doesnt_match_deal_order_
 		);
 		// this is a deal_order from another person
 		let second_test_info = TestInfo {
-			lender: RegisteredAddress::new("lender2", Blockchain::Rinkeby),
-			borrower: RegisteredAddress::new("borrower2", Blockchain::Rinkeby),
-			blockchain: Blockchain::Rinkeby,
+			lender: RegisteredAddress::new("lender2", OldBlockchain::Rinkeby),
+			borrower: RegisteredAddress::new("borrower2", OldBlockchain::Rinkeby),
+			blockchain: OldBlockchain::Rinkeby,
 			loan_terms: LoanTerms {
 				amount: 2_000_000u64.into(),
 				interest_rate: Default::default(),
@@ -2338,7 +2335,7 @@ fn exempt_should_error_when_not_signed() {
 fn exempt_should_error_when_deal_order_has_already_been_repaid() {
 	ExtBuilder::default().build_and_execute(|| {
 		let test_info = TestInfo::new_defaults();
-		let (deal_order, deal_order_id) = test_info.create_deal_order();
+		let (_, deal_order_id) = test_info.create_deal_order();
 
 		// simulate DealOrder which has been repaid
 		crate::DealOrders::<Test>::mutate(
@@ -2346,7 +2343,7 @@ fn exempt_should_error_when_deal_order_has_already_been_repaid() {
 			&deal_order_id.hash(),
 			|deal_order_storage| {
 				deal_order_storage.as_mut().unwrap().repayment_transfer_id =
-					Some(TransferId::new::<Test>(&deal_order.blockchain, b"4444"));
+					Some(TransferId::new::<Test>(&test_info.blockchain, b"4444"));
 			},
 		);
 
@@ -2376,14 +2373,14 @@ fn exempt_should_succeed() {
 		System::set_block_number(1);
 
 		let test_info = TestInfo::new_defaults();
-		let (deal_order, deal_order_id) = test_info.create_deal_order();
+		let (_, deal_order_id) = test_info.create_deal_order();
 
 		assert_ok!(Creditcoin::exempt(
 			Origin::signed(test_info.lender.account_id),
 			deal_order_id.clone()
 		));
 
-		let transfer_id = TransferId::new::<Test>(&deal_order.blockchain, b"0");
+		let transfer_id = TransferId::new::<Test>(&test_info.blockchain, b"0");
 
 		// assert field values were updated in storage
 		let saved_deal_order = DealOrders::<Test>::try_get_id(&deal_order_id).unwrap();
@@ -2480,7 +2477,7 @@ fn verify_transfer_should_work() {
 
 		// create a transfer but don't add it into storage
 		let tx = "0xafafaf".as_bytes().into_bounded();
-		let transfer_id = TransferId::new::<Test>(&Blockchain::Rinkeby, &tx);
+		let transfer_id = TransferId::new::<Test>(&OldBlockchain::Rinkeby, &tx);
 		let transfer = Transfer {
 			blockchain: test_info.blockchain.clone(),
 			kind: LegacyTransferKind::Native,
@@ -2533,7 +2530,7 @@ fn fail_transfer_should_work() {
 		let _ = test_info.create_deal_order();
 
 		let tx = "0xafafaf".hex_to_address();
-		let transfer_id = TransferId::new::<Test>(&Blockchain::Rinkeby, &tx);
+		let transfer_id = TransferId::new::<Test>(&OldBlockchain::Rinkeby, &tx);
 
 		let failure_cause = crate::ocw::errors::VerificationFailureCause::TaskFailed;
 		let deadline = Test::unverified_transfer_deadline();
@@ -2567,7 +2564,7 @@ fn fail_transfer_should_error_when_not_signed() {
 		let _ = test_info.create_deal_order();
 
 		let tx = "0xafafaf".hex_to_address();
-		let transfer_id = TransferId::new::<Test>(&Blockchain::Rinkeby, &tx);
+		let transfer_id = TransferId::new::<Test>(&OldBlockchain::Rinkeby, &tx);
 
 		let failure_cause = crate::ocw::errors::VerificationFailureCause::TaskFailed;
 		let deadline = Test::unverified_transfer_deadline();
@@ -2589,7 +2586,7 @@ fn fail_transfer_should_error_when_not_authority() {
 		let _ = test_info.create_deal_order();
 
 		let tx = "0xafafaf".hex_to_address();
-		let transfer_id = TransferId::new::<Test>(&Blockchain::Rinkeby, &tx);
+		let transfer_id = TransferId::new::<Test>(&OldBlockchain::Rinkeby, &tx);
 
 		let failure_cause = crate::ocw::errors::VerificationFailureCause::TaskFailed;
 		let deadline = Test::unverified_transfer_deadline();
@@ -2650,9 +2647,9 @@ fn on_initialize_removes_expired_deals_without_transfers() {
 			let seed2 = format!("{:02}1", expiration_block.clone());
 
 			let test_info = TestInfo {
-				lender: RegisteredAddress::new(&seed1, Blockchain::Rinkeby),
-				borrower: RegisteredAddress::new(&seed2, Blockchain::Rinkeby),
-				blockchain: Blockchain::Rinkeby,
+				lender: RegisteredAddress::new(&seed1, OldBlockchain::Rinkeby),
+				borrower: RegisteredAddress::new(&seed2, OldBlockchain::Rinkeby),
+				blockchain: OldBlockchain::Rinkeby,
 				loan_terms: LoanTerms {
 					amount: 2_000_000u64.into(),
 					interest_rate: Default::default(),
@@ -2810,7 +2807,7 @@ fn register_transfer_internal_legacy_should_error_with_non_existent_lender_addre
 		let (deal_order, deal_order_id) = test_info.create_deal_order();
 		let tx = "0xabcabcabc";
 		let bogus_address =
-			AddressId::new::<Test>(&Blockchain::Rinkeby, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 0]);
+			AddressId::new::<Test>(&OldBlockchain::Rinkeby, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 0]);
 
 		let result = Creditcoin::register_transfer_internal_legacy(
 			test_info.lender.account_id,
@@ -2834,7 +2831,7 @@ fn register_transfer_internal_legacy_should_error_with_non_existent_borrower_add
 		let (deal_order, deal_order_id) = test_info.create_deal_order();
 		let tx = "0xabcabcabc";
 		let bogus_address =
-			AddressId::new::<Test>(&Blockchain::Rinkeby, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 0]);
+			AddressId::new::<Test>(&OldBlockchain::Rinkeby, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 0]);
 
 		let result = Creditcoin::register_transfer_internal_legacy(
 			test_info.lender.account_id,
@@ -2878,7 +2875,7 @@ fn register_transfer_internal_legacy_should_error_when_addresses_are_not_on_the_
 	ExtBuilder::default().build_and_execute(|| {
 		let test_info = TestInfo::new_defaults();
 		let (deal_order, deal_order_id) = test_info.create_deal_order();
-		let second_borrower = RegisteredAddress::new("borrower2", Blockchain::Luniverse);
+		let second_borrower = RegisteredAddress::new("borrower2", OldBlockchain::Luniverse);
 		let tx = "0xabcabcabc";
 
 		let result = Creditcoin::register_transfer_internal_legacy(
@@ -2907,7 +2904,7 @@ fn register_transfer_internal_legacy_should_error_when_transfer_kind_is_not_supp
 			test_info.lender.account_id,
 			deal_order.lender_address_id,
 			deal_order.borrower_address_id,
-			// not supported on Blockchain::Rinkeby
+			// not supported on OldBlockchain::Rinkeby
 			LegacyTransferKind::Other(BoundedVec::try_from(b"other".to_vec()).unwrap()),
 			deal_order.terms.amount,
 			deal_order_id,

--- a/pallets/creditcoin/src/tests.rs
+++ b/pallets/creditcoin/src/tests.rs
@@ -5,7 +5,7 @@ use crate::{
 	AddressId, AskOrder, AskOrderId, Authorities, BidOrder, BidOrderId, Currency, CurrencyId,
 	DealOrder, DealOrderId, DealOrders, Duration, EvmInfo, EvmTransferKind, ExternalAddress,
 	ExternalAmount, Guid, Id, LegacySighash, LegacyTransferKind, LoanTerms, Offer, OfferId,
-	OldBlockchain, Transfer, TransferId, Transfers,
+	OldBlockchain, Transfer, TransferId, Transfers, WeightInfo,
 };
 
 use assert_matches::assert_matches;
@@ -788,8 +788,7 @@ fn add_offer_basic() {
 		let test_info = TestInfo::new_defaults();
 
 		let (offer, _) = test_info.create_offer();
-		let Offer { expiration_block, block, ask_id, bid_id, lender, .. } =
-			offer.clone();
+		let Offer { expiration_block, block, ask_id, bid_id, lender, .. } = offer.clone();
 
 		let new_offer = Offer { expiration_block, block, ask_id, bid_id, lender };
 
@@ -821,12 +820,9 @@ fn add_offer_should_error_when_blockchain_differs_between_ask_and_bid_order() {
 		let Offer { expiration_block, ask_id, bid_id, lender, .. } = offer;
 
 		// simulate deal transfer
-		crate::Addresses::<Test>::mutate(
-			&test_info.lender.address_id,
-			|address_storage| {
-				address_storage.as_mut().unwrap().blockchain = OldBlockchain::Bitcoin;
-			},
-		);
+		crate::Addresses::<Test>::mutate(&test_info.lender.address_id, |address_storage| {
+			address_storage.as_mut().unwrap().blockchain = OldBlockchain::Bitcoin;
+		});
 
 		assert_noop!(
 			Creditcoin::add_offer(Origin::signed(lender), ask_id, bid_id, expiration_block,),

--- a/pallets/creditcoin/src/tests.rs
+++ b/pallets/creditcoin/src/tests.rs
@@ -4,8 +4,8 @@ use crate::{
 	types::DoubleMapExt,
 	AddressId, AskOrder, AskOrderId, Authorities, BidOrder, BidOrderId, Blockchain, Currency,
 	CurrencyId, DealOrder, DealOrderId, DealOrders, Duration, EvmInfo, EvmTransferKind,
-	ExternalAddress, ExternalAmount, Guid, Id, LegacySighash, LoanTerms, Offer, OfferId, OrderId,
-	Transfer, TransferId, TransferKind, Transfers, WeightInfo,
+	ExternalAddress, ExternalAmount, Guid, Id, LegacySighash, LoanTerms, Offer, OfferId, Transfer,
+	TransferId, TransferKind, Transfers, WeightInfo,
 };
 
 use assert_matches::assert_matches;
@@ -297,7 +297,7 @@ impl TestInfo {
 				kind: transfer_kind.into().unwrap_or(TransferKind::Native),
 				from: from.address_id.clone(),
 				to: to.address_id.clone(),
-				order_id: OrderId::Deal(deal_order_id.clone()),
+				deal_order_id: deal_order_id.clone(),
 				amount: amount.into(),
 				tx_id: tx,
 				block: System::block_number(),
@@ -463,10 +463,10 @@ fn verify_ethless_transfer() {
 
 		let from = get_mock_from_address().hex_to_address();
 		let to = get_mock_to_address().hex_to_address();
-		let order_id = crate::OrderId::Deal(crate::DealOrderId::with_expiration_hash::<Test>(
+		let deal_order_id = crate::DealOrderId::with_expiration_hash::<Test>(
 			10000,
 			H256::from_uint(&get_mock_nonce()),
-		));
+		);
 		let amount = get_mock_amount();
 		let tx_id = tx_hash.hex_to_address();
 
@@ -475,7 +475,7 @@ fn verify_ethless_transfer() {
 			&contract,
 			&from,
 			&to,
-			&order_id,
+			&deal_order_id,
 			&amount,
 			&tx_id,
 		));
@@ -1231,7 +1231,7 @@ fn fund_deal_order_should_error_when_transfer_order_id_doesnt_match_deal_order_i
 			second_test_info.create_funding_transfer(&bogus_deal_order_id);
 
 		// try funding DealOrder from Person1 with the transfer from Person2,
-		// which points to a different order_id
+		// which points to a different deal_order_id
 		assert_noop!(
 			Creditcoin::fund_deal_order(
 				Origin::signed(test_info.lender.account_id),
@@ -2277,7 +2277,7 @@ fn close_deal_order_should_succeed() {
 			test_info.lender.address_id.clone(),
 			TransferKind::Ethless(contract),
 			33u64.into(),
-			OrderId::Deal(deal_order_id.clone()),
+			deal_order_id.clone(),
 			tx_hash
 		));
 
@@ -2486,7 +2486,7 @@ fn verify_transfer_should_work() {
 			kind: TransferKind::Native,
 			from: test_info.lender.address_id.clone(),
 			to: test_info.borrower.address_id.clone(),
-			order_id: OrderId::Deal(deal_order_id),
+			deal_order_id,
 			amount: deal_order.terms.amount,
 			tx_id: tx,
 			block: System::block_number(),
@@ -2818,7 +2818,7 @@ fn register_transfer_internal_should_error_with_non_existent_lender_address() {
 			deal_order.borrower_address_id,
 			TransferKind::Native,
 			deal_order.terms.amount,
-			OrderId::Deal(deal_order_id),
+			deal_order_id,
 			tx.as_bytes().into_bounded(),
 		)
 		.unwrap_err();
@@ -2842,7 +2842,7 @@ fn register_transfer_internal_should_error_with_non_existent_borrower_address() 
 			bogus_address,
 			TransferKind::Native,
 			deal_order.terms.amount,
-			OrderId::Deal(deal_order_id),
+			deal_order_id,
 			tx.as_bytes().into_bounded(),
 		)
 		.unwrap_err();
@@ -2864,7 +2864,7 @@ fn register_transfer_internal_should_error_when_signer_doesnt_own_from_address()
 			deal_order.lender_address_id,
 			TransferKind::Native,
 			deal_order.terms.amount,
-			OrderId::Deal(deal_order_id),
+			deal_order_id,
 			tx.as_bytes().into_bounded(),
 		)
 		.unwrap_err();
@@ -2887,7 +2887,7 @@ fn register_transfer_internal_should_error_when_addresses_are_not_on_the_same_bl
 			second_borrower.address_id,
 			TransferKind::Native,
 			deal_order.terms.amount,
-			OrderId::Deal(deal_order_id),
+			deal_order_id,
 			tx.as_bytes().into_bounded(),
 		)
 		.unwrap_err();
@@ -2910,7 +2910,7 @@ fn register_transfer_internal_should_error_when_transfer_kind_is_not_supported()
 			// not supported on Blockchain::Rinkeby
 			TransferKind::Other(BoundedVec::try_from(b"other".to_vec()).unwrap()),
 			deal_order.terms.amount,
-			OrderId::Deal(deal_order_id),
+			deal_order_id,
 			tx.as_bytes().into_bounded(),
 		)
 		.unwrap_err();
@@ -2932,7 +2932,7 @@ fn register_transfer_internal_should_error_when_transfer_is_already_registered()
 			deal_order.borrower_address_id,
 			TransferKind::Native,
 			deal_order.terms.amount,
-			OrderId::Deal(deal_order_id),
+			deal_order_id,
 			transfer.tx_id,
 		)
 		.unwrap_err();

--- a/pallets/creditcoin/src/tests.rs
+++ b/pallets/creditcoin/src/tests.rs
@@ -2271,7 +2271,7 @@ fn close_deal_order_should_succeed() {
 		let tx_hash = "0".as_bytes().into_bounded();
 		let contract = "0x0ad1439a0e0bfdcd49939f9722866651a4aa9b3c".as_bytes().into_bounded();
 
-		assert_ok!(Creditcoin::register_transfer_internal(
+		assert_ok!(Creditcoin::register_transfer_internal_legacy(
 			test_info.borrower.account_id.clone(),
 			test_info.borrower.address_id.clone(),
 			test_info.lender.address_id.clone(),
@@ -2804,7 +2804,7 @@ fn register_repayment_transfer_should_error_when_not_deal_order_not_found() {
 }
 
 #[test]
-fn register_transfer_internal_should_error_with_non_existent_lender_address() {
+fn register_transfer_internal_legacy_should_error_with_non_existent_lender_address() {
 	ExtBuilder::default().build_and_execute(|| {
 		let test_info = TestInfo::new_defaults();
 		let (deal_order, deal_order_id) = test_info.create_deal_order();
@@ -2812,7 +2812,7 @@ fn register_transfer_internal_should_error_with_non_existent_lender_address() {
 		let bogus_address =
 			AddressId::new::<Test>(&Blockchain::Rinkeby, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 0]);
 
-		let result = Creditcoin::register_transfer_internal(
+		let result = Creditcoin::register_transfer_internal_legacy(
 			test_info.lender.account_id,
 			bogus_address,
 			deal_order.borrower_address_id,
@@ -2828,7 +2828,7 @@ fn register_transfer_internal_should_error_with_non_existent_lender_address() {
 }
 
 #[test]
-fn register_transfer_internal_should_error_with_non_existent_borrower_address() {
+fn register_transfer_internal_legacy_should_error_with_non_existent_borrower_address() {
 	ExtBuilder::default().build_and_execute(|| {
 		let test_info = TestInfo::new_defaults();
 		let (deal_order, deal_order_id) = test_info.create_deal_order();
@@ -2836,7 +2836,7 @@ fn register_transfer_internal_should_error_with_non_existent_borrower_address() 
 		let bogus_address =
 			AddressId::new::<Test>(&Blockchain::Rinkeby, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 0]);
 
-		let result = Creditcoin::register_transfer_internal(
+		let result = Creditcoin::register_transfer_internal_legacy(
 			test_info.lender.account_id,
 			deal_order.lender_address_id,
 			bogus_address,
@@ -2852,13 +2852,13 @@ fn register_transfer_internal_should_error_with_non_existent_borrower_address() 
 }
 
 #[test]
-fn register_transfer_internal_should_error_when_signer_doesnt_own_from_address() {
+fn register_transfer_internal_legacy_should_error_when_signer_doesnt_own_from_address() {
 	ExtBuilder::default().build_and_execute(|| {
 		let test_info = TestInfo::new_defaults();
 		let (deal_order, deal_order_id) = test_info.create_deal_order();
 		let tx = "0xabcabcabc";
 
-		let result = Creditcoin::register_transfer_internal(
+		let result = Creditcoin::register_transfer_internal_legacy(
 			test_info.lender.account_id,
 			deal_order.borrower_address_id, // should match 1st argument
 			deal_order.lender_address_id,
@@ -2874,14 +2874,14 @@ fn register_transfer_internal_should_error_when_signer_doesnt_own_from_address()
 }
 
 #[test]
-fn register_transfer_internal_should_error_when_addresses_are_not_on_the_same_blockchain() {
+fn register_transfer_internal_legacy_should_error_when_addresses_are_not_on_the_same_blockchain() {
 	ExtBuilder::default().build_and_execute(|| {
 		let test_info = TestInfo::new_defaults();
 		let (deal_order, deal_order_id) = test_info.create_deal_order();
 		let second_borrower = RegisteredAddress::new("borrower2", Blockchain::Luniverse);
 		let tx = "0xabcabcabc";
 
-		let result = Creditcoin::register_transfer_internal(
+		let result = Creditcoin::register_transfer_internal_legacy(
 			test_info.lender.account_id,
 			deal_order.lender_address_id,
 			second_borrower.address_id,
@@ -2897,13 +2897,13 @@ fn register_transfer_internal_should_error_when_addresses_are_not_on_the_same_bl
 }
 
 #[test]
-fn register_transfer_internal_should_error_when_transfer_kind_is_not_supported() {
+fn register_transfer_internal_legacy_should_error_when_transfer_kind_is_not_supported() {
 	ExtBuilder::default().build_and_execute(|| {
 		let test_info = TestInfo::new_defaults();
 		let (deal_order, deal_order_id) = test_info.create_deal_order();
 		let tx = "0xabcabcabc";
 
-		let result = Creditcoin::register_transfer_internal(
+		let result = Creditcoin::register_transfer_internal_legacy(
 			test_info.lender.account_id,
 			deal_order.lender_address_id,
 			deal_order.borrower_address_id,
@@ -2920,13 +2920,13 @@ fn register_transfer_internal_should_error_when_transfer_kind_is_not_supported()
 }
 
 #[test]
-fn register_transfer_internal_should_error_when_transfer_is_already_registered() {
+fn register_transfer_internal_legacy_should_error_when_transfer_is_already_registered() {
 	ExtBuilder::default().build_and_execute(|| {
 		let test_info = TestInfo::new_defaults();
 		let (deal_order, deal_order_id) = test_info.create_deal_order();
 		let (transfer, _transfer_id) = test_info.create_funding_transfer(&deal_order_id);
 
-		let result = Creditcoin::register_transfer_internal(
+		let result = Creditcoin::register_transfer_internal_legacy(
 			test_info.lender.account_id,
 			deal_order.lender_address_id,
 			deal_order.borrower_address_id,

--- a/pallets/creditcoin/src/types.rs
+++ b/pallets/creditcoin/src/types.rs
@@ -240,6 +240,13 @@ pub struct OfferId<BlockNum, Hash>(BlockNum, Hash);
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct TransferId<Hash>(Hash);
 
+#[cfg(test)]
+impl<Hash> TransferId<Hash> {
+	pub fn make(hash: Hash) -> Self {
+		Self(hash)
+	}
+}
+
 #[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]

--- a/pallets/creditcoin/src/types.rs
+++ b/pallets/creditcoin/src/types.rs
@@ -60,7 +60,7 @@ impl Blockchain {
 #[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
-pub enum TransferKind {
+pub enum LegacyTransferKind {
 	#[cfg_attr(feature = "std", serde(with = "bounded_serde"))]
 	Erc20(ExternalAddress),
 	#[cfg_attr(feature = "std", serde(with = "bounded_serde"))]
@@ -101,7 +101,7 @@ pub struct CollectedCoins<Hash, Balance> {
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct Transfer<AccountId, BlockNum, Hash, Moment> {
 	pub blockchain: Blockchain,
-	pub kind: TransferKind,
+	pub kind: LegacyTransferKind,
 	pub from: AddressId<Hash>,
 	pub to: AddressId<Hash>,
 	pub deal_order_id: DealOrderId<BlockNum, Hash>,
@@ -194,6 +194,13 @@ pub struct DealOrder<AccountId, BlockNum, Hash, Moment> {
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct AddressId<Hash>(Hash);
+
+#[cfg(test)]
+impl<Hash> AddressId<Hash> {
+	pub fn make(hash: Hash) -> Self {
+		Self(hash)
+	}
+}
 
 #[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]

--- a/pallets/creditcoin/src/types.rs
+++ b/pallets/creditcoin/src/types.rs
@@ -36,7 +36,7 @@ mod bounded_serde;
 #[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
-pub enum Blockchain {
+pub enum OldBlockchain {
 	Ethereum,
 	Rinkeby,
 	Luniverse,
@@ -45,14 +45,14 @@ pub enum Blockchain {
 	Other(OtherChain),
 }
 
-impl Blockchain {
+impl OldBlockchain {
 	pub fn as_bytes(&self) -> &[u8] {
 		match self {
-			Blockchain::Ethereum => b"ethereum",
-			Blockchain::Rinkeby => b"rinkeby",
-			Blockchain::Luniverse => b"luniverse",
-			Blockchain::Bitcoin => b"bitcoin",
-			Blockchain::Other(chain) => chain.as_slice(),
+			OldBlockchain::Ethereum => b"ethereum",
+			OldBlockchain::Rinkeby => b"rinkeby",
+			OldBlockchain::Luniverse => b"luniverse",
+			OldBlockchain::Bitcoin => b"bitcoin",
+			OldBlockchain::Other(chain) => chain.as_slice(),
 		}
 	}
 }
@@ -74,7 +74,7 @@ pub enum LegacyTransferKind {
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct Address<AccountId> {
-	pub blockchain: Blockchain,
+	pub blockchain: OldBlockchain,
 	#[cfg_attr(feature = "std", serde(with = "bounded_serde"))]
 	pub value: ExternalAddress,
 	pub owner: AccountId,
@@ -100,7 +100,7 @@ pub struct CollectedCoins<Hash, Balance> {
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct Transfer<AccountId, BlockNum, Hash, Moment> {
-	pub blockchain: Blockchain,
+	pub blockchain: OldBlockchain,
 	pub kind: LegacyTransferKind,
 	pub from: AddressId<Hash>,
 	pub to: AddressId<Hash>,
@@ -140,7 +140,6 @@ pub struct UnverifiedTransfer<AccountId, BlockNum, Hash, Moment> {
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct Offer<AccountId, BlockNum, Hash> {
-	pub blockchain: Blockchain,
 	pub ask_id: AskOrderId<BlockNum, Hash>,
 	pub bid_id: BidOrderId<BlockNum, Hash>,
 	pub expiration_block: BlockNum,
@@ -152,7 +151,6 @@ pub struct Offer<AccountId, BlockNum, Hash> {
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct AskOrder<AccountId, BlockNum, Hash> {
-	pub blockchain: Blockchain,
 	pub lender_address_id: AddressId<Hash>,
 	pub terms: AskTerms,
 	pub expiration_block: BlockNum,
@@ -164,7 +162,6 @@ pub struct AskOrder<AccountId, BlockNum, Hash> {
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct BidOrder<AccountId, BlockNum, Hash> {
-	pub blockchain: Blockchain,
 	pub borrower_address_id: AddressId<Hash>,
 	pub terms: BidTerms,
 	pub expiration_block: BlockNum,
@@ -176,7 +173,6 @@ pub struct BidOrder<AccountId, BlockNum, Hash> {
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct DealOrder<AccountId, BlockNum, Hash, Moment> {
-	pub blockchain: Blockchain,
 	pub offer_id: OfferId<BlockNum, Hash>,
 	pub lender_address_id: AddressId<Hash>,
 	pub borrower_address_id: AddressId<Hash>,
@@ -266,7 +262,7 @@ macro_rules! concatenate {
 pub(crate) use concatenate;
 
 impl<H> AddressId<H> {
-	pub fn new<Config>(blockchain: &Blockchain, address: &[u8]) -> AddressId<H>
+	pub fn new<Config>(blockchain: &OldBlockchain, address: &[u8]) -> AddressId<H>
 	where
 		Config: frame_system::Config,
 		<Config as frame_system::Config>::Hashing: Hash<Output = H>,
@@ -307,7 +303,7 @@ impl<B, H> RepaymentOrderId<B, H> {
 }
 
 impl<H> TransferId<H> {
-	pub fn new<Config>(blockchain: &Blockchain, blockchain_tx_id: &[u8]) -> TransferId<H>
+	pub fn new<Config>(blockchain: &OldBlockchain, blockchain_tx_id: &[u8]) -> TransferId<H>
 	where
 		Config: frame_system::Config,
 		<Config as frame_system::Config>::Hashing: Hash<Output = H>,

--- a/pallets/creditcoin/src/types.rs
+++ b/pallets/creditcoin/src/types.rs
@@ -104,7 +104,7 @@ pub struct Transfer<AccountId, BlockNum, Hash, Moment> {
 	pub kind: TransferKind,
 	pub from: AddressId<Hash>,
 	pub to: AddressId<Hash>,
-	pub order_id: OrderId<BlockNum, Hash>,
+	pub deal_order_id: DealOrderId<BlockNum, Hash>,
 	pub amount: ExternalAmount,
 	#[cfg_attr(feature = "std", serde(with = "bounded_serde"))]
 	pub tx_id: ExternalTxId,
@@ -225,14 +225,6 @@ pub struct RepaymentOrderId<BlockNum, Hash>(BlockNum, Hash);
 #[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
-pub enum OrderId<BlockNum, Hash> {
-	Deal(DealOrderId<BlockNum, Hash>),
-	Repayment(RepaymentOrderId<BlockNum, Hash>),
-}
-
-#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
-#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct OfferId<BlockNum, Hash>(BlockNum, Hash);
 
 #[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
@@ -252,16 +244,6 @@ impl<Hash> TransferId<Hash> {
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct CollectedCoinsId<Hash>(Hash);
 
-fn bytes_to_hex(bytes: &[u8]) -> Vec<u8> {
-	const HEX_CHARS_LOWER: &[u8; 16] = b"0123456789abcdef";
-	let mut hex = Vec::with_capacity(bytes.len() * 2);
-	for byte in bytes {
-		hex.push(HEX_CHARS_LOWER[(byte >> 4) as usize]);
-		hex.push(HEX_CHARS_LOWER[(byte & 0x0F) as usize]);
-	}
-	hex
-}
-
 macro_rules! concatenate {
 	(@strip_plus + $($rest: tt)*) => {
 		$($rest)*
@@ -275,19 +257,6 @@ macro_rules! concatenate {
 	};
 }
 pub(crate) use concatenate;
-
-impl<B, H> OrderId<B, H>
-where
-	H: AsRef<[u8]>,
-{
-	pub fn to_hex(&self) -> Vec<u8> {
-		let bytes = match self {
-			OrderId::Deal(deal) => deal.1.as_ref(),
-			OrderId::Repayment(repay) => repay.1.as_ref(),
-		};
-		bytes_to_hex(bytes)
-	}
-}
 
 impl<H> AddressId<H> {
 	pub fn new<Config>(blockchain: &Blockchain, address: &[u8]) -> AddressId<H>
@@ -432,39 +401,6 @@ impl_id!(AskOrderId);
 impl_id!(BidOrderId);
 impl_id!(OfferId);
 impl_id!(RepaymentOrderId);
-
-impl<'a, B, H> Id<B, H> for &'a OrderId<B, H>
-where
-	B: Clone,
-	H: Clone,
-{
-	fn expiration(&self) -> B {
-		match self {
-			OrderId::Deal(deal) => deal.expiration(),
-			OrderId::Repayment(repay) => repay.expiration(),
-		}
-	}
-
-	fn hash(&self) -> H {
-		match self {
-			OrderId::Deal(deal) => deal.hash(),
-			OrderId::Repayment(repay) => repay.hash(),
-		}
-	}
-}
-impl<B, H> Id<B, H> for OrderId<B, H>
-where
-	B: Clone,
-	H: Clone,
-{
-	fn expiration(&self) -> B {
-		(&self).expiration()
-	}
-
-	fn hash(&self) -> H {
-		(&self).hash()
-	}
-}
 
 #[ext(name = DoubleMapExt)]
 pub(crate) impl<Prefix, Hasher1, Key1, Hasher2, Key2, Value, QueryKind, OnEmpty, MaxValues, IdTy>

--- a/pallets/creditcoin/src/types/platform.rs
+++ b/pallets/creditcoin/src/types/platform.rs
@@ -77,7 +77,7 @@ pub enum Currency {
 #[derive(
 	Clone, RuntimeDebug, PartialEq, Eq, PartialOrd, Encode, Decode, TypeInfo, MaxEncodedLen,
 )]
-pub enum NewTransferKind {
+pub enum TransferKind {
 	Evm(EvmTransferKind),
 }
 


### PR DESCRIPTION
Description of proposed changes:
Start of migrations. Main changes:
- remove orderid
- rename `TransferKind` -> `LegacyTransferKind`
- remove `Blockchain` from ask/bid/deal orders and offer
- rename `Blockchain` -> `OldBlockchain`

Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
