### PR TITLE
CSUB-266: Rename docker image gluwa/creditcoin-substrate -> gluwa/creditcoin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Build docker image
         run: |
-          docker build -t gluwa/creditcoin-substrate .
+          docker build -t gluwa/creditcoin .
 
   fmt:
     name: Rustfmt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,5 +187,4 @@ jobs:
         with:
           files: 'artifact/creditcoin-${{ env.TAG_NAME }}-*'
           fail_on_unmatched_files: true
-          draft: true
-          name: 'Testing release for ${{ env.TAG_NAME }}'
+          name: ${{ env.TAG_NAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,12 +150,12 @@ jobs:
 
       - name: Build docker image
         run: |
-          docker build -t gluwa/creditcoin-substrate:${{ env.TAG_NAME }} .
-          docker tag gluwa/creditcoin-substrate:${{ env.TAG_NAME }} gluwa/creditcoin-substrate:latest
+          docker build -t gluwa/creditcoin:${{ env.TAG_NAME }} .
+          docker tag gluwa/creditcoin:${{ env.TAG_NAME }} gluwa/creditcoin-substrate:latest
 
           echo "${{ secrets.DOCKER_PUSH_PASSWORD }}" | docker login -u="${{ secrets.DOCKER_PUSH_USERNAME }}" --password-stdin
-          docker push gluwa/creditcoin-substrate:${{ env.TAG_NAME }}
-          docker push gluwa/creditcoin-substrate:latest
+          docker push gluwa/creditcoin:${{ env.TAG_NAME }}
+          docker push gluwa/creditcoin:latest
           docker logout
 
   create-release:


### PR DESCRIPTION
b/c gluwa/creditcoin-substrate does not exist

Description of proposed changes:


Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
