### PR TITLE
CSUB-263: Integration test for new rpc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -957,6 +957,7 @@ version = "2.0.0-beta.7"
 dependencies = [
  "creditcoin-node-rpc",
  "creditcoin-node-runtime",
+ "creditcoin-runtime-api",
  "frame-benchmarking",
  "frame-benchmarking-cli",
  "futures-lite",
@@ -1002,6 +1003,9 @@ name = "creditcoin-node-rpc"
 version = "2.0.0-beta.7"
 dependencies = [
  "assert_matches",
+ "creditcoin-node-runtime",
+ "creditcoin-runtime-api",
+ "frame-system",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
@@ -1009,7 +1013,9 @@ dependencies = [
  "primitives",
  "sc-rpc",
  "serde",
- "serde_json",
+ "sp-api",
+ "sp-blockchain",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -1017,6 +1023,7 @@ name = "creditcoin-node-runtime"
 version = "2.0.0-beta.7"
 dependencies = [
  "assert_matches",
+ "creditcoin-runtime-api",
  "frame-benchmarking",
  "frame-executive",
  "frame-support",
@@ -1051,6 +1058,14 @@ dependencies = [
  "sp-transaction-pool",
  "sp-version",
  "substrate-wasm-builder",
+]
+
+[[package]]
+name = "creditcoin-runtime-api"
+version = "2.0.0-beta.8"
+dependencies = [
+ "parity-scale-codec",
+ "sp-api",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     'pallets/rewards',
     'pallets/difficulty',
     'pallets/creditcoin',
+    'pallets/creditcoin/runtime-api',
     'runtime',
     "sha3pow",
     "primitives",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -36,6 +36,7 @@ codec = { package = "parity-scale-codec", version = "2.3.1" }
 tiny-bip39 = "1.0.0"
 hex = "0.4.3"
 creditcoin-node-rpc = { version = "2.0.0-beta.7", path = "./rpc" }
+creditcoin-runtime-api = { version = "2.0.0-beta.7", path = "../pallets/creditcoin/runtime-api" }
 primitives = { path = "../primitives" }
 
 

--- a/node/rpc/Cargo.toml
+++ b/node/rpc/Cargo.toml
@@ -11,9 +11,14 @@ jsonrpc-core-client = "18.0.0"
 jsonrpc-derive = "18.0.0"
 primitives = { path = "../../primitives", features = ["std", "prometheus"] }
 serde = { version = "1.0.144", features = ["derive"] }
-serde_json = "1.0.85"
-sc-rpc = { version = "4.0.0-dev", git = "https://github.com/gluwa/substrate.git", rev = "973dd744f5f7c6322799bbfa29366588e0267b0a" }
+sc-rpc = { git = "https://github.com/gluwa/substrate.git", rev = "973dd744f5f7c6322799bbfa29366588e0267b0a" }
+sp-runtime = { git = "https://github.com/gluwa/substrate.git", rev = "973dd744f5f7c6322799bbfa29366588e0267b0a" }
+sp-blockchain = { git = "https://github.com/gluwa/substrate.git", rev = "973dd744f5f7c6322799bbfa29366588e0267b0a" }
+sp-api = { git = "https://github.com/gluwa/substrate.git", rev = "973dd744f5f7c6322799bbfa29366588e0267b0a" }
 jsonrpc-pubsub = "18.0.0"
+frame-system = { git = "https://github.com/gluwa/substrate.git", rev = "973dd744f5f7c6322799bbfa29366588e0267b0a" }
+creditcoin-runtime-api = { path = "../../pallets/creditcoin/runtime-api" }
+creditcoin-node-runtime = { path = "../../runtime" }
 
 [dev-dependencies.assert_matches]
 version = "1.5.0"

--- a/node/rpc/src/lib.rs
+++ b/node/rpc/src/lib.rs
@@ -25,6 +25,7 @@ pub enum Error {
 	StorageError = 1,
 	DecodeError,
 	SubscriptionError,
+	RuntimeError,
 }
 
 impl From<Error> for i64 {
@@ -50,6 +51,9 @@ pub struct MiningStats {
 	elapsed: std::time::Duration,
 	rate: f64,
 }
+
+mod task;
+pub use task::{Task, TaskRpc};
 
 #[cfg(test)]
 mod test {

--- a/node/rpc/src/task.rs
+++ b/node/rpc/src/task.rs
@@ -1,0 +1,61 @@
+use super::Error;
+use core::marker::PhantomData;
+use core::str::FromStr;
+use creditcoin_runtime_api::TaskApi;
+use jsonrpc_core::Result as RpcResult;
+use jsonrpc_core::{Error as RpcError, ErrorCode};
+use jsonrpc_derive::rpc;
+use sc_rpc::DenyUnsafe;
+use sp_blockchain::HeaderBackend;
+use sp_runtime::{generic::BlockId, traits};
+use std::sync::Arc;
+
+type AccountId = <creditcoin_node_runtime::Runtime as frame_system::Config>::AccountId;
+
+#[rpc]
+pub trait TaskRpc<AccountId> {
+	#[rpc(name = "task_getOffchainNonceKey")]
+	fn offchain_nonce_key(&self, acc: String) -> RpcResult<Vec<u8>>;
+}
+
+pub struct Task<C, B> {
+	client: Arc<C>,
+	deny_unsafe: DenyUnsafe,
+	_p: PhantomData<B>,
+}
+
+impl<C, B> Task<C, B> {
+	pub fn new(client: Arc<C>, deny_unsafe: DenyUnsafe) -> Self {
+		Self { deny_unsafe, client, _p: Default::default() }
+	}
+}
+
+impl<C, B> TaskRpc<AccountId> for Task<C, B>
+where
+	C: sp_api::ProvideRuntimeApi<B>,
+	C: HeaderBackend<B>,
+	C: Send + Sync + 'static,
+	C::Api: TaskApi<B, AccountId>,
+	B: traits::Block,
+{
+	fn offchain_nonce_key(&self, acc: String) -> RpcResult<Vec<u8>> {
+		self.deny_unsafe.check_if_safe()?;
+		let api = self.client.runtime_api();
+		let at = {
+			let best = self.client.info().best_hash;
+			BlockId::hash(best)
+		};
+
+		let acc = AccountId::from_str(&acc).map_err(|e| RpcError {
+			code: ErrorCode::InvalidParams,
+			message: "Not a valid hex-string or SS58 address".into(),
+			data: Some(format!("{:?}", e).into()),
+		})?;
+
+		api.offchain_nonce_key(&at, &acc).map_err(|e| RpcError {
+			code: ErrorCode::ServerError(Error::RuntimeError.into()),
+			message: "Unable to query offchain nonce key.".into(),
+			data: Some(format!("{:?}", e).into()),
+		})
+	}
+}

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -35,9 +35,10 @@ where
 	C::Api: substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Index>,
 	C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
 	C::Api: BlockBuilder<Block>,
+	C::Api: creditcoin_runtime_api::TaskApi<Block, AccountId>,
 	P: TransactionPool + 'static,
 {
-	use creditcoin_node_rpc::{CreditcoinApi, CreditcoinRpc};
+	use creditcoin_node_rpc::{CreditcoinApi, CreditcoinRpc, Task, TaskRpc};
 	use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApi};
 	use substrate_frame_rpc_system::{FullSystem, SystemApi};
 
@@ -46,9 +47,11 @@ where
 
 	io.extend_with(SystemApi::to_delegate(FullSystem::new(client.clone(), pool, deny_unsafe)));
 
-	io.extend_with(TransactionPaymentApi::to_delegate(TransactionPayment::new(client)));
+	io.extend_with(TransactionPaymentApi::to_delegate(TransactionPayment::new(client.clone())));
 
 	io.extend_with(CreditcoinApi::to_delegate(CreditcoinRpc::new(mining_metrics)));
+
+	io.extend_with(TaskRpc::to_delegate(Task::new(client, deny_unsafe)));
 
 	io
 }

--- a/pallets/creditcoin/runtime-api/Cargo.toml
+++ b/pallets/creditcoin/runtime-api/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "creditcoin-runtime-api"
+version = "2.0.0-beta.8"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "2.3.1", default-features = false }
+
+[dependencies.sp-api]
+git = "https://github.com/gluwa/substrate.git"
+version = '4.0.0-dev'
+rev = "973dd744f5f7c6322799bbfa29366588e0267b0a"
+default-features = false
+
+[features]
+default = ["std"]
+std = ["sp-api/std", "codec/std"]

--- a/pallets/creditcoin/runtime-api/src/lib.rs
+++ b/pallets/creditcoin/runtime-api/src/lib.rs
@@ -1,0 +1,11 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use codec::Codec;
+extern crate alloc;
+use alloc::vec::Vec;
+
+sp_api::decl_runtime_apis! {
+	pub trait TaskApi<AccountId: Codec> {
+		fn offchain_nonce_key(acc: &AccountId) -> Vec<u8>;
+	}
+}

--- a/pallets/creditcoin/src/lib.rs
+++ b/pallets/creditcoin/src/lib.rs
@@ -23,10 +23,10 @@ mod tests;
 #[macro_use]
 mod helpers;
 mod migrations;
-mod ocw;
+pub mod ocw;
 mod types;
 
-use crate::ocw::tasks::collect_coins::GCreContract;
+use ocw::tasks::collect_coins::GCreContract;
 pub use types::*;
 
 pub const KEY_TYPE: KeyTypeId = KeyTypeId(*b"ctcs");

--- a/pallets/creditcoin/src/ocw.rs
+++ b/pallets/creditcoin/src/ocw.rs
@@ -1,7 +1,7 @@
-pub mod errors;
-pub mod nonce;
-pub mod rpc;
-pub mod tasks;
+pub(crate) mod errors;
+mod nonce;
+pub(crate) mod rpc;
+pub(crate) mod tasks;
 
 use self::errors::RpcUrlError;
 use super::{
@@ -10,17 +10,18 @@ use super::{
 };
 use crate::{Blockchain, Call, TransferKind};
 use alloc::string::String;
-pub use errors::{OffchainError, VerificationFailureCause, VerificationResult};
+pub(crate) use errors::{OffchainError, VerificationFailureCause, VerificationResult};
 use frame_support::traits::IsType;
 use frame_system::offchain::{Account, SendSignedTransaction, Signer};
 use frame_system::Config as SystemConfig;
 use frame_system::Pallet as System;
-use nonce::{lock_key, nonce_key};
+use nonce::lock_key;
+pub use nonce::nonce_key;
 use sp_runtime::offchain::storage::StorageValueRef;
 use sp_runtime::traits::{One, Saturating};
 use sp_std::prelude::*;
 
-pub type OffchainResult<T, E = errors::OffchainError> = Result<T, E>;
+pub(crate) type OffchainResult<T, E = errors::OffchainError> = Result<T, E>;
 
 impl Blockchain {
 	pub fn rpc_url(&self) -> OffchainResult<String, errors::RpcUrlError> {

--- a/pallets/creditcoin/src/ocw/nonce.rs
+++ b/pallets/creditcoin/src/ocw/nonce.rs
@@ -12,7 +12,7 @@ pub(super) fn lock_key<Id: Encode>(id: &Id) -> Vec<u8> {
 	id.using_encoded(|encoded_id| SYNCED_NONCE_LOCK.iter().chain(encoded_id).copied().collect())
 }
 
-pub(super) fn nonce_key<Id: Encode>(id: &Id) -> Vec<u8> {
+pub fn nonce_key<Id: Encode>(id: &Id) -> Vec<u8> {
 	id.using_encoded(|encoded_id| SYNCED_NONCE.iter().chain(encoded_id).copied().collect())
 }
 

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -11,13 +11,13 @@ edition = "2021"
 git = "https://github.com/gluwa/substrate.git"
 version = "0.10.0-dev"
 optional = true
-rev = "973dd744f5f7c6322799bbfa29366588e0267b0a" 
+rev = "973dd744f5f7c6322799bbfa29366588e0267b0a"
 
 [dependencies.sp-core]
 default-features = false
 git = "https://github.com/gluwa/substrate.git"
 version = '4.1.0-dev'
-rev = "973dd744f5f7c6322799bbfa29366588e0267b0a" 
+rev = "973dd744f5f7c6322799bbfa29366588e0267b0a"
 
 [dev-dependencies.sp-tracing]
 default-features = false

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -13,6 +13,7 @@ targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies]
 smallvec = "1.8.1"
+creditcoin-runtime-api = { path = "../pallets/creditcoin/runtime-api", default-features = false }
 
 [dependencies.primitives]
 default-features = false
@@ -252,4 +253,5 @@ std = [
     'sp-std/std',
     'sp-transaction-pool/std',
     'sp-version/std',
+    'creditcoin-runtime-api/std',
 ]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -553,6 +553,12 @@ impl_runtime_apis! {
 			Ok(batches)
 		}
 	}
+
+	impl creditcoin_runtime_api::TaskApi<Block, AccountId> for Runtime{
+		fn offchain_nonce_key(acc: &AccountId) -> Vec<u8>{
+			pallet_creditcoin::ocw::nonce_key(acc)
+		}
+	}
 }
 
 impl frame_system::offchain::SigningTypes for Runtime {

--- a/runtime/src/version.rs
+++ b/runtime/src/version.rs
@@ -15,7 +15,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
 	spec_version: 208,
-	impl_version: 1,
+	impl_version: 2,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 7,
 	state_version: 1,


### PR DESCRIPTION
@CAGS295, @nathanwhit I tried adding an integration test and also a definition for the new method on the client side, however I get an error that there's no such function. Not sure what the name should be. 

```
    ✕ getOffchainNonceKey() should return a ..... (358 ms)

  ● Creditcoin RPC › getOffchainNonceKey() should return a .....

    TypeError: api.rpc.task.getOffchainNonceKey is not a function

      70 |
      71 |     it('getOffchainNonceKey() should return a .....', async () => {
    > 72 |         const response = await (api.rpc as any).task.getOffchainNonceKey('0xAlice');
         |                                                      ^
```
