### PR TITLE
Use `cargo run` in tests instead of pointing to the binary directly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,7 +188,7 @@ jobs:
           fi
 
           echo "INFO: MINING_KEY=$MINING_KEY"
-          ./target/release/creditcoin-node --dev --mining-key $MINING_KEY >~/creditcoin-node.log 2>&1 &
+          cargo run -- --dev --mining-key $MINING_KEY >~/creditcoin-node.log 2>&1 &
 
       - name: Start local Ethereum node
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,7 +188,7 @@ jobs:
           fi
 
           echo "INFO: MINING_KEY=$MINING_KEY"
-          cargo run -- --dev --mining-key $MINING_KEY >~/creditcoin-node.log 2>&1 &
+          cargo run --release -- --dev --mining-key $MINING_KEY >~/creditcoin-node.log 2>&1 &
 
       - name: Start local Ethereum node
         run: |

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -9,11 +9,11 @@ sudo npm install -g yarn
 
 ## Getting Started
 
-0. Build the software under test, see **Single-Node Development Chain** in `../README.md`
-   and execute it locally:
+0. Start the software under test, see **Single-Node Development Chain** in `../README.md`
+   for more information:
 
 ```bash
-./target/release/creditcoin-node --dev --mining-key XYZ
+cargo run -- --dev --mining-key XYZ
 ```
 
 1. Execute a local Ethereum node:

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -13,7 +13,7 @@ sudo npm install -g yarn
    for more information:
 
 ```bash
-cargo run -- --dev --mining-key XYZ
+cargo run --release -- --dev --mining-key XYZ
 ```
 
 1. Execute a local Ethereum node:


### PR DESCRIPTION
This will prevent running tests with stale locally and help you not
end-up in a release vs debug situation where you are compiling one thing
but unknowingly running the other.

Description of proposed changes:


Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
