### PR TITLE
Use the same rustc version everywhere

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -25,10 +25,15 @@ jobs:
           sudo apt-get update
           sudo apt install -y cmake pkg-config libssl-dev git build-essential clang libclang-dev curl
 
+      - name: Configure rustc version
+        run: |
+          source ci/env
+          echo "RUSTC_VERSION=$RUSTC_VERSION" >> $GITHUB_ENV
+
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-09-01
+          toolchain: ${{ env.RUSTC_VERSION }}
           target: wasm32-unknown-unknown
           profile: minimal
           override: true

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-03-21
+          toolchain: nightly-2022-09-01
           target: wasm32-unknown-unknown
           profile: minimal
           override: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-03-21
+          toolchain: nightly-2022-09-01
           profile: minimal
           override: true
           components: rustfmt
@@ -58,7 +58,7 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-03-21
+          toolchain: nightly-2022-09-01
           target: wasm32-unknown-unknown
           profile: minimal
           override: true
@@ -88,7 +88,7 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-03-21
+          toolchain: nightly-2022-09-01
           target: wasm32-unknown-unknown
           profile: minimal
           override: true
@@ -115,7 +115,7 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-03-21
+          toolchain: nightly-2022-09-01
           target: wasm32-unknown-unknown
           profile: minimal
           override: true
@@ -166,7 +166,7 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-03-21
+          toolchain: nightly-2022-09-01
           target: wasm32-unknown-unknown
           profile: minimal
           override: true
@@ -363,7 +363,7 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-03-21
+          toolchain: nightly-2022-09-01
           target: wasm32-unknown-unknown
           profile: minimal
           override: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
+      - name: Configure rustc version
+        run: |
+          source ci/env
+          echo "RUSTC_VERSION=$RUSTC_VERSION" >> $GITHUB_ENV
+
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-09-01
+          toolchain: ${{ env.RUSTC_VERSION }}
           profile: minimal
           override: true
           components: rustfmt
@@ -55,10 +61,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
+      - name: Configure rustc version
+        run: |
+          source ci/env
+          echo "RUSTC_VERSION=$RUSTC_VERSION" >> $GITHUB_ENV
+
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-09-01
+          toolchain: ${{ env.RUSTC_VERSION }}
           target: wasm32-unknown-unknown
           profile: minimal
           override: true
@@ -85,10 +97,15 @@ jobs:
           sudo apt-get update
           sudo apt install -y cmake pkg-config libssl-dev git build-essential clang libclang-dev curl
 
+      - name: Configure rustc version
+        run: |
+          source ci/env
+          echo "RUSTC_VERSION=$RUSTC_VERSION" >> $GITHUB_ENV
+
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-09-01
+          toolchain: ${{ env.RUSTC_VERSION }}
           target: wasm32-unknown-unknown
           profile: minimal
           override: true
@@ -112,10 +129,15 @@ jobs:
           sudo apt-get update
           sudo apt install -y cmake pkg-config libssl-dev git build-essential clang libclang-dev curl
 
+      - name: Configure rustc version
+        run: |
+          source ci/env
+          echo "RUSTC_VERSION=$RUSTC_VERSION" >> $GITHUB_ENV
+
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-09-01
+          toolchain: ${{ env.RUSTC_VERSION }}
           target: wasm32-unknown-unknown
           profile: minimal
           override: true
@@ -163,10 +185,15 @@ jobs:
           sudo apt-get update
           sudo apt install -y cmake pkg-config libssl-dev git build-essential clang libclang-dev curl
 
+      - name: Configure rustc version
+        run: |
+          source ci/env
+          echo "RUSTC_VERSION=$RUSTC_VERSION" >> $GITHUB_ENV
+
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-09-01
+          toolchain: ${{ env.RUSTC_VERSION }}
           target: wasm32-unknown-unknown
           profile: minimal
           override: true
@@ -360,10 +387,15 @@ jobs:
           sudo apt-get update
           sudo apt install -y cmake pkg-config libssl-dev git build-essential clang libclang-dev curl
 
+      - name: Configure rustc version
+        run: |
+          source ci/env
+          echo "RUSTC_VERSION=$RUSTC_VERSION" >> $GITHUB_ENV
+
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-09-01
+          toolchain: ${{ env.RUSTC_VERSION }}
           target: wasm32-unknown-unknown
           profile: minimal
           override: true

--- a/.github/workflows/llvm-cov.yml
+++ b/.github/workflows/llvm-cov.yml
@@ -20,10 +20,15 @@ jobs:
           sudo apt-get update
           sudo apt install -y cmake pkg-config libssl-dev git build-essential clang libclang-dev curl
 
+      - name: Configure rustc version
+        run: |
+          source ci/env
+          echo "RUSTC_VERSION=$RUSTC_VERSION" >> $GITHUB_ENV
+
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-09-01
+          toolchain: ${{ env.RUSTC_VERSION }}
           components: llvm-tools-preview
           target: wasm32-unknown-unknown
           profile: minimal

--- a/.github/workflows/llvm-cov.yml
+++ b/.github/workflows/llvm-cov.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-03-21
+          toolchain: nightly-2022-09-01
           components: llvm-tools-preview
           target: wasm32-unknown-unknown
           profile: minimal

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-03-21
+          toolchain: nightly-2022-09-01
           target: wasm32-unknown-unknown
           profile: minimal
           override: true
@@ -35,7 +35,7 @@ jobs:
         if: matrix.operating-system == 'macos-11'
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-03-21
+          toolchain: nightly-2022-09-01
           target: aarch64-apple-darwin
           profile: minimal
           override: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,10 +23,15 @@ jobs:
           sudo apt-get update
           sudo apt install -y cmake pkg-config libssl-dev git build-essential clang libclang-dev curl
 
+      - name: Configure rustc version
+        run: |
+          source ci/env
+          echo "RUSTC_VERSION=$RUSTC_VERSION" >> $GITHUB_ENV
+
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-09-01
+          toolchain: ${{ env.RUSTC_VERSION }}
           target: wasm32-unknown-unknown
           profile: minimal
           override: true
@@ -35,7 +40,7 @@ jobs:
         if: matrix.operating-system == 'macos-11'
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-09-01
+          toolchain: ${{ env.RUSTC_VERSION }}
           target: aarch64-apple-darwin
           profile: minimal
           override: true

--- a/.github/workflows/runtime-extrinsics.yml
+++ b/.github/workflows/runtime-extrinsics.yml
@@ -27,10 +27,15 @@ jobs:
           sudo apt-get update
           sudo apt install -y cmake pkg-config libssl-dev git build-essential clang libclang-dev curl
 
+      - name: Configure rustc version
+        run: |
+          source ci/env
+          echo "RUSTC_VERSION=$RUSTC_VERSION" >> $GITHUB_ENV
+
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-09-01
+          toolchain: ${{ env.RUSTC_VERSION }}
           target: wasm32-unknown-unknown
           profile: minimal
           override: true

--- a/.github/workflows/runtime-extrinsics.yml
+++ b/.github/workflows/runtime-extrinsics.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-03-21
+          toolchain: nightly-2022-09-01
           target: wasm32-unknown-unknown
           profile: minimal
           override: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM gluwa/ci-linux:production AS builder
 ENV DEBIAN_FRONTEND=noninteractive
-RUN source ~/.cargo/env && rustup default nightly && rustup update nightly && rustup target add wasm32-unknown-unknown --toolchain nightly
+ENV RUSTC_VERSION=nightly-2022-09-01
+RUN source ~/.cargo/env && rustup default $RUSTC_VERSION && rustup update $RUSTC_VERSION && rustup target add wasm32-unknown-unknown --toolchain $RUSTC_VERSION
 WORKDIR /creditcoin-node
 COPY Cargo.toml .
 COPY Cargo.lock .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,14 @@
 FROM gluwa/ci-linux:production AS builder
 ENV DEBIAN_FRONTEND=noninteractive
-ENV RUSTC_VERSION=nightly-2022-09-01
-RUN source ~/.cargo/env && rustup default $RUSTC_VERSION && rustup update $RUSTC_VERSION && rustup target add wasm32-unknown-unknown --toolchain $RUSTC_VERSION
+
 WORKDIR /creditcoin-node
+COPY ci/env .
+RUN source ~/.cargo/env && \
+    source ./env && \
+    rustup default $RUSTC_VERSION && \
+    rustup update $RUSTC_VERSION && \
+    rustup target add wasm32-unknown-unknown --toolchain $RUSTC_VERSION
+
 COPY Cargo.toml .
 COPY Cargo.lock .
 ADD node /creditcoin-node/node

--- a/ci/env
+++ b/ci/env
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+export RUSTC_VERSION=nightly-2022-09-01

--- a/pallets/creditcoin/src/helpers.rs
+++ b/pallets/creditcoin/src/helpers.rs
@@ -66,7 +66,7 @@ impl<T: Config> Pallet<T> {
 
 		Authorities::<T>::iter_keys().find_map(|auth| {
 			let acct = auth.clone().into();
-			local_keys.contains(&acct).then(|| auth)
+			local_keys.contains(&acct).then_some(auth)
 		})
 	}
 

--- a/pallets/creditcoin/src/types/loan_terms.rs
+++ b/pallets/creditcoin/src/types/loan_terms.rs
@@ -93,7 +93,7 @@ impl AskTerms {
 	}
 
 	pub fn agreed_terms(&self, bid_terms: BidTerms) -> Option<LoanTerms> {
-		self.match_with(&bid_terms).then(|| bid_terms.0)
+		self.match_with(&bid_terms).then_some(bid_terms.0)
 	}
 }
 


### PR DESCRIPTION
rust version 1.65.0-nightly (289279de1 2022-09-04) fails with compiler
panic

Description of proposed changes:


Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
