### PR TITLE
ci: Shorten comments from LLVM coverage

### DIFF
--- a/.github/workflows/llvm-cov.yml
+++ b/.github/workflows/llvm-cov.yml
@@ -43,13 +43,10 @@ jobs:
         run: |
             export PR_NUMBER=$(echo $GITHUB_REF | sed "s|refs/pull/||" | sed "s|/merge||")
             echo "**For full LLVM coverage report [click here](https://staticsitellvmhtml.z13.web.core.windows.net/$PR_NUMBER/html/)!**" > uncovered-lines.log
-            echo >> uncovered-lines.log
-
-            export RUST_LOG=debug
 
             cargo llvm-cov \
                 --workspace --html --show-missing-lines --doctests --hide-instantiations \
-                --ignore-filename-regex "(tests.rs|mock.rs)" | tee -a uncovered-lines.log
+                --ignore-filename-regex "(tests.rs|mock.rs)"
 
             UNCOVERED_LINES=$(cat uncovered-lines.log | sed "s|$(pwd)|.|")
             # workaround the fact that GitHub Actions doesn't support multi-line output


### PR DESCRIPTION
leave only a hyperlink to the results to reduce visual clutter

Description of proposed changes:


Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
