### PR TITLE
CSUB-295: Fix bug in creditcoin-js error handling / add `requestCollectCoins` to `Extrinsics`

### DIFF
--- a/creditcoin-js/package.json
+++ b/creditcoin-js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "creditcoin-js",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "author": "Jeremy Frank <jeremy.frank@gluwa.com>",
     "license": "MIT",
     "main": "lib/index.js",

--- a/creditcoin-js/src/extrinsics/add-ask-order.ts
+++ b/creditcoin-js/src/extrinsics/add-ask-order.ts
@@ -2,7 +2,7 @@ import { ApiPromise, SubmittableResult } from '@polkadot/api';
 import { AddressId, AskOrder, AskOrderId, LoanTerms, EventReturnJoinType } from '../model';
 import { KeyringPair } from '@polkadot/keyring/types';
 import { handleTransaction, processEvents } from './common';
-import { TxCallback } from '../types';
+import { TxCallback, TxFailureCallback } from '../types';
 import { createAskOrder, createCreditcoinLoanTerms } from '../transforms';
 import { Guid } from 'js-guid';
 import { blake2AsHex } from '@polkadot/util-crypto';
@@ -20,7 +20,7 @@ export const addAskOrder = async (
     guid: Guid,
     signer: KeyringPair,
     onSuccess: TxCallback,
-    onFail: TxCallback,
+    onFail: TxFailureCallback,
 ) => {
     const unsubscribe: () => void = await api.tx.creditcoin
         .addAskOrder(lenderAddressId, createCreditcoinLoanTerms(api, loanTerms), expirationBlock, guid.toString())

--- a/creditcoin-js/src/extrinsics/add-authority.ts
+++ b/creditcoin-js/src/extrinsics/add-authority.ts
@@ -2,14 +2,14 @@ import { ApiPromise, SubmittableResult } from '@polkadot/api';
 import { AccountId } from '../model';
 import { KeyringPair } from '@polkadot/keyring/types';
 import { handleTransaction } from './common';
-import { TxCallback } from '../types';
+import { TxCallback, TxFailureCallback } from '../types';
 
 export const addAuthority = async (
     api: ApiPromise,
     authorityAccount: AccountId,
     sudoSigner: KeyringPair,
     onSuccess: TxCallback,
-    onFail: TxCallback,
+    onFail: TxFailureCallback,
 ) => {
     const unsubscribe: () => void = await api.tx.sudo
         .sudo(api.tx.creditcoin.addAuthority(authorityAccount))

--- a/creditcoin-js/src/extrinsics/add-bid-order.ts
+++ b/creditcoin-js/src/extrinsics/add-bid-order.ts
@@ -2,7 +2,7 @@ import { ApiPromise, SubmittableResult } from '@polkadot/api';
 import { AddressId, BidOrder, BidOrderId, LoanTerms, EventReturnJoinType } from '../model';
 import { KeyringPair } from '@polkadot/keyring/types';
 import { handleTransaction, processEvents } from './common';
-import { TxCallback } from '../types';
+import { TxCallback, TxFailureCallback } from '../types';
 import { createBidOrder, createCreditcoinLoanTerms } from '../transforms';
 import { Guid } from 'js-guid';
 import { blake2AsHex } from '@polkadot/util-crypto';
@@ -20,7 +20,7 @@ export const addBidOrder = async (
     guid: Guid,
     signer: KeyringPair,
     onSuccess: TxCallback,
-    onFail: TxCallback,
+    onFail: TxFailureCallback,
 ) => {
     const unsubscribe: () => void = await api.tx.creditcoin
         .addBidOrder(borrowerAddressId, createCreditcoinLoanTerms(api, loanTerms), expirationBlock, guid.toString())

--- a/creditcoin-js/src/extrinsics/add-deal-order.ts
+++ b/creditcoin-js/src/extrinsics/add-deal-order.ts
@@ -2,7 +2,7 @@ import { ApiPromise, SubmittableResult } from '@polkadot/api';
 import { blake2AsHex } from '@polkadot/util-crypto';
 import { DealOrderAdded, DealOrderId, OfferId } from '../model';
 import { createDealOrder } from '../transforms';
-import { TxCallback } from '../types';
+import { TxCallback, TxFailureCallback } from '../types';
 import { handleTransaction, processEvents } from './common';
 import { KeyringPair } from '@polkadot/keyring/types';
 
@@ -17,7 +17,7 @@ export const addDealOrder = async (
     expirationBlock: number,
     borrower: KeyringPair,
     onSuccess: TxCallback,
-    onFail: TxCallback,
+    onFail: TxFailureCallback,
 ) => {
     const ccOfferId = api.createType('PalletCreditcoinOfferId', offerId);
     const unsubscribe: () => void = await api.tx.creditcoin

--- a/creditcoin-js/src/extrinsics/add-offer.ts
+++ b/creditcoin-js/src/extrinsics/add-offer.ts
@@ -2,7 +2,7 @@ import { ApiPromise, SubmittableResult } from '@polkadot/api';
 import { AskOrderId, BidOrderId, Offer, OfferId, EventReturnJoinType } from '../model';
 import { KeyringPair } from '@polkadot/keyring/types';
 import { handleTransaction, processEvents } from './common';
-import { TxCallback } from '../types';
+import { TxCallback, TxFailureCallback } from '../types';
 import { createOffer } from '../transforms';
 import { blake2AsHex } from '@polkadot/util-crypto';
 import { u8aConcat } from '@polkadot/util';
@@ -21,7 +21,7 @@ export const addOffer = async (
     expirationBlock: number,
     signer: KeyringPair,
     onSuccess: TxCallback,
-    onFail: TxCallback,
+    onFail: TxFailureCallback,
 ) => {
     const ccAskOrderId = api.createType('PalletCreditcoinAskOrderId', askOrderId);
     const ccBidOrderId = api.createType('PalletCreditcoinBidOrderId', bidOrderId);

--- a/creditcoin-js/src/extrinsics/close-deal-order.ts
+++ b/creditcoin-js/src/extrinsics/close-deal-order.ts
@@ -1,7 +1,7 @@
 import { ApiPromise, SubmittableResult } from '@polkadot/api';
 import { DealOrderId, TransferId } from '../model';
 import { createDealOrder, createTransfer } from '../transforms';
-import { TxCallback } from '../types';
+import { TxCallback, TxFailureCallback } from '../types';
 import { handleTransaction, processEvents } from './common';
 import { KeyringPair } from '@polkadot/keyring/types';
 import { DealOrderClosed, TransferProcessed } from '../model';
@@ -12,7 +12,7 @@ export const closeDealOrder = async (
     transferId: TransferId,
     borrower: KeyringPair,
     onSuccess: TxCallback,
-    onFail: TxCallback,
+    onFail: TxFailureCallback,
 ) => {
     const ccDealOrderId = api.createType('PalletCreditcoinDealOrderId', dealOrderId);
     const unsubscribe: () => void = await api.tx.creditcoin

--- a/creditcoin-js/src/extrinsics/common.ts
+++ b/creditcoin-js/src/extrinsics/common.ts
@@ -19,7 +19,9 @@ export const handleTransaction = (
         if (events) events.forEach((event) => expectNoEventError(api, event));
     } catch (error) {
         unsubscribe();
-        onFail(result, error as Error);
+        onFail(error as Error);
+        // we need to return here, otherwise we'll run the onSuccess handler below
+        return;
     }
 
     if (status.isInBlock) {

--- a/creditcoin-js/src/extrinsics/common.ts
+++ b/creditcoin-js/src/extrinsics/common.ts
@@ -2,13 +2,14 @@ import { ApiPromise, SubmittableResult } from '@polkadot/api';
 import { Codec } from '@polkadot/types-codec/types';
 import { EventReturnType } from '../model';
 import { DispatchError, DispatchResult, EventRecord } from '@polkadot/types/interfaces';
+import { TxCallback, TxFailureCallback } from 'src';
 
 export const handleTransaction = (
     api: ApiPromise,
     unsubscribe: () => void,
     result: SubmittableResult,
-    onSuccess: (r: SubmittableResult) => void,
-    onFail: (r: SubmittableResult, e?: Error) => void,
+    onSuccess: TxCallback,
+    onFail: TxFailureCallback,
 ) => {
     const { status, events, dispatchError } = result;
     console.log(`current status is ${status.toString()}`);

--- a/creditcoin-js/src/extrinsics/exempt.ts
+++ b/creditcoin-js/src/extrinsics/exempt.ts
@@ -1,6 +1,6 @@
 import { ApiPromise, SubmittableResult } from '@polkadot/api';
 import { DealOrderId } from '../model';
-import { TxCallback } from '../types';
+import { TxCallback, TxFailureCallback } from '../types';
 import { handleTransaction } from './common';
 import { KeyringPair } from '@polkadot/keyring/types';
 
@@ -11,7 +11,7 @@ export const exemptLoan = async (
     dealOrderId: DealOrderId,
     lender: KeyringPair,
     onSuccess: TxCallback,
-    onFail: TxCallback,
+    onFail: TxFailureCallback,
 ) => {
     const unsubscribe: () => void = await api.tx.creditcoin
         .exempt(api.createType('PalletCreditcoinDealOrderId', dealOrderId))

--- a/creditcoin-js/src/extrinsics/extrinsics.ts
+++ b/creditcoin-js/src/extrinsics/extrinsics.ts
@@ -19,6 +19,7 @@ import {
     TransferKind,
     DealOrderId,
     TransferId,
+    ExternalAddress,
 } from '../model';
 import { KeyringPair } from '@polkadot/keyring/types';
 import { lockDealOrderAsync } from './lock-deal-order';
@@ -106,7 +107,7 @@ export const extrinsics = (api: ApiPromise) => {
 
     const exemptLoan = (dealOrderId: DealOrderId, lender: KeyringPair) => exemptLoanAsync(api, dealOrderId, lender);
 
-    const requestCollectCoins = (evmAddress: string, collector: KeyringPair, txHash: string) =>
+    const requestCollectCoins = (evmAddress: ExternalAddress, collector: KeyringPair, txHash: string) =>
         requestCollectCoinsAsync(api, evmAddress, collector, txHash);
 
     return {

--- a/creditcoin-js/src/extrinsics/extrinsics.ts
+++ b/creditcoin-js/src/extrinsics/extrinsics.ts
@@ -24,6 +24,7 @@ import { KeyringPair } from '@polkadot/keyring/types';
 import { lockDealOrderAsync } from './lock-deal-order';
 import { closeDealOrderAsync } from './close-deal-order';
 import { exemptLoanAsync } from './exempt';
+import { requestCollectCoinsAsync } from './request-collect-coins';
 
 export const extrinsics = (api: ApiPromise) => {
     const registerAddress = (
@@ -105,6 +106,9 @@ export const extrinsics = (api: ApiPromise) => {
 
     const exemptLoan = (dealOrderId: DealOrderId, lender: KeyringPair) => exemptLoanAsync(api, dealOrderId, lender);
 
+    const requestCollectCoins = (evmAddress: string, collector: KeyringPair, txHash: string) =>
+        requestCollectCoinsAsync(api, evmAddress, collector, txHash);
+
     return {
         registerAddress,
         addAskOrder,
@@ -118,5 +122,6 @@ export const extrinsics = (api: ApiPromise) => {
         registerRepaymentTransfer,
         closeDealOrder,
         exemptLoan,
+        requestCollectCoins,
     };
 };

--- a/creditcoin-js/src/extrinsics/fund-deal-order.ts
+++ b/creditcoin-js/src/extrinsics/fund-deal-order.ts
@@ -1,7 +1,7 @@
 import { ApiPromise, SubmittableResult } from '@polkadot/api';
 import { DealOrderFunded, DealOrderId, TransferId, TransferProcessed } from '../model';
 import { createDealOrder, createTransfer } from '../transforms';
-import { TxCallback } from '../types';
+import { TxCallback, TxFailureCallback } from '../types';
 import { handleTransaction, processEvents } from './common';
 import { KeyringPair } from '@polkadot/keyring/types';
 
@@ -11,7 +11,7 @@ export const fundDealOrder = async (
     transferId: TransferId,
     lender: KeyringPair,
     onSuccess: TxCallback,
-    onFail: TxCallback,
+    onFail: TxFailureCallback,
 ) => {
     const ccDealOrderId = api.createType('PalletCreditcoinDealOrderId', dealOrderId);
     const unsubscribe: () => void = await api.tx.creditcoin

--- a/creditcoin-js/src/extrinsics/lock-deal-order.ts
+++ b/creditcoin-js/src/extrinsics/lock-deal-order.ts
@@ -1,7 +1,7 @@
 import { ApiPromise, SubmittableResult } from '@polkadot/api';
 import { DealOrderLocked, DealOrderId } from '../model';
 import { createDealOrder } from '../transforms';
-import { TxCallback } from '../types';
+import { TxCallback, TxFailureCallback } from '../types';
 import { handleTransaction, processEvents } from './common';
 import { KeyringPair } from '@polkadot/keyring/types';
 
@@ -10,7 +10,7 @@ export const lockDealOrder = async (
     dealOrderId: DealOrderId,
     borrower: KeyringPair,
     onSuccess: TxCallback,
-    onFail: TxCallback,
+    onFail: TxFailureCallback,
 ) => {
     const ccDealOrderId = api.createType('PalletCreditcoinDealOrderId', dealOrderId);
     const unsubscribe: () => void = await api.tx.creditcoin

--- a/creditcoin-js/src/extrinsics/register-address.ts
+++ b/creditcoin-js/src/extrinsics/register-address.ts
@@ -2,7 +2,7 @@ import { ApiPromise, SubmittableResult } from '@polkadot/api';
 import { Address, AddressId, Blockchain, EventReturnJoinType } from '../model';
 import { KeyringPair } from '@polkadot/keyring/types';
 import { handleTransaction, processEvents } from './common';
-import { TxCallback } from '../types';
+import { TxCallback, TxFailureCallback } from '../types';
 import { createAddress } from '../transforms';
 import { u8aConcat, u8aToU8a } from '@polkadot/util';
 import { blake2AsHex } from '@polkadot/util-crypto';
@@ -22,7 +22,7 @@ export const registerAddress = async (
     ownershipProof: string,
     signer: KeyringPair,
     onSuccess: TxCallback,
-    onFail: TxCallback,
+    onFail: TxFailureCallback,
 ) => {
     const unsubscribe: () => void = await api.tx.creditcoin
         .registerAddress(blockchain, externalAddress, ownershipProof)

--- a/creditcoin-js/src/extrinsics/register-deal-order.ts
+++ b/creditcoin-js/src/extrinsics/register-deal-order.ts
@@ -2,7 +2,7 @@ import { ApiPromise, SubmittableResult } from '@polkadot/api';
 import { u8aConcat } from '@polkadot/util';
 import { AddressId, DealOrderAdded, LoanTerms } from '../model';
 import { createCreditcoinLoanTerms } from '../transforms';
-import { TxCallback } from '../types';
+import { TxCallback, TxFailureCallback } from '../types';
 import { handleTransaction } from './common';
 import { KeyringPair } from '@polkadot/keyring/types';
 import { AskOrderAdded, processAskOrderAdded } from './add-ask-order';
@@ -49,7 +49,7 @@ export const registerDealOrder = async (
     signedParams: Uint8Array,
     lender: KeyringPair,
     onSuccess: TxCallback,
-    onFail: TxCallback,
+    onFail: TxFailureCallback,
 ) => {
     const ccLoanTerms = createCreditcoinLoanTerms(api, loanTerms);
     const unsubscribe: () => void = await api.tx.creditcoin

--- a/creditcoin-js/src/extrinsics/register-transfers.ts
+++ b/creditcoin-js/src/extrinsics/register-transfers.ts
@@ -6,7 +6,7 @@ import { blake2AsHex } from '@polkadot/util-crypto';
 import { createCreditcoinTransferKind, createTransfer } from '../transforms';
 import { KeyringPair } from '@polkadot/keyring/types';
 import { handleTransaction, processEvents } from './common';
-import { TxCallback } from '..';
+import { TxCallback, TxFailureCallback } from '..';
 import { PalletCreditcoinTransfer } from '@polkadot/types/lookup';
 import { Option } from '@polkadot/types';
 
@@ -31,7 +31,7 @@ export const registerFundingTransfer = async (
     txHash: string,
     lender: KeyringPair,
     onSuccess: TxCallback,
-    onFail: TxCallback,
+    onFail: TxFailureCallback,
 ) => {
     const ccTransferKind = createCreditcoinTransferKind(api, transferKind);
     const ccDealOrderId = api.createType('PalletCreditcoinDealOrderId', dealOrderId);
@@ -48,7 +48,7 @@ export const registerRepaymentTransfer = async (
     txHash: string,
     borrower: KeyringPair,
     onSuccess: TxCallback,
-    onFail: TxCallback,
+    onFail: TxFailureCallback,
 ) => {
     const unsubscribe: () => void = await api.tx.creditcoin
         .registerRepaymentTransfer(

--- a/creditcoin-js/src/extrinsics/remove-authority.ts
+++ b/creditcoin-js/src/extrinsics/remove-authority.ts
@@ -2,14 +2,14 @@ import { ApiPromise, SubmittableResult } from '@polkadot/api';
 import { AccountId } from '../model';
 import { KeyringPair } from '@polkadot/keyring/types';
 import { handleTransaction } from './common';
-import { TxCallback } from '../types';
+import { TxCallback, TxFailureCallback } from '../types';
 
 export const removeAuthority = async (
     api: ApiPromise,
     authorityAccount: AccountId,
     sudoSigner: KeyringPair,
     onSuccess: TxCallback,
-    onFail: TxCallback,
+    onFail: TxFailureCallback,
 ) => {
     const unsubscribe: () => void = await api.tx.sudo
         .sudo(api.tx.creditcoin.removeAuthority(authorityAccount))

--- a/creditcoin-js/src/extrinsics/request-collect-coins.ts
+++ b/creditcoin-js/src/extrinsics/request-collect-coins.ts
@@ -11,7 +11,7 @@ import { u8aConcat, u8aToU8a } from '@polkadot/util';
 import { blake2AsHex } from '@polkadot/util-crypto';
 import { KeyringPair } from '@polkadot/keyring/types';
 import { handleTransaction, processEvents } from './common';
-import { TxCallback } from '..';
+import { TxCallback, TxFailureCallback } from '..';
 import { createCollectedCoins, createUnverifiedCollectedCoins } from '../transforms';
 import { PalletCreditcoinCollectedCoins } from '@polkadot/types/lookup';
 
@@ -37,7 +37,7 @@ export const requestCollectCoins = async (
     collector: KeyringPair,
     txHash: string,
     onSuccess: TxCallback,
-    onFail: TxCallback,
+    onFail: TxFailureCallback,
 ) => {
     const unsubscribe: () => void = await api.tx.creditcoin
         .requestCollectCoins(evmAddress, txHash)
@@ -95,6 +95,8 @@ export const requestCollectCoinsAsync = async (
     return new Promise<CollectCoinsEvent>((resolve, reject) => {
         const onSuccess = (result: SubmittableResult) =>
             resolve(createCollectCoinsRegisteredEvent(api, result, 'CollectCoinsRegistered'));
-        requestCollectCoins(api, evmAddress, collector, txHash, onSuccess, reject).catch((reason) => reject(reason));
+        requestCollectCoins(api, evmAddress, collector, txHash, onSuccess, reject).catch((reason) => {
+            reject(reason);
+        });
     });
 };

--- a/creditcoin-js/src/types.ts
+++ b/creditcoin-js/src/types.ts
@@ -27,6 +27,7 @@ import { DealOrderRegistered } from './extrinsics/register-deal-order';
 import { TransferEvent } from './extrinsics/register-transfers';
 import { LoanExempted } from './extrinsics/exempt';
 import { Wallet } from 'ethers';
+import { CollectCoinsEvent } from './extrinsics/request-collect-coins';
 
 export type TxCallback = (result: SubmittableResult) => void;
 export type TxFailureCallback = (error?: Error) => void;
@@ -96,6 +97,7 @@ export interface Extrinsics {
         borrower: KeyringPair,
     ) => Promise<[DealOrderClosed, TransferProcessed]>;
     exemptLoan: (dealOrderId: DealOrderId, lender: KeyringPair) => Promise<LoanExempted>;
+    requestCollectCoins: (evmAddress: string, collector: KeyringPair, txHash: string) => Promise<CollectCoinsEvent>;
 }
 
 export interface CreditcoinApi {

--- a/creditcoin-js/src/types.ts
+++ b/creditcoin-js/src/types.ts
@@ -13,6 +13,7 @@ import {
     DealOrderFunded,
     DealOrderId,
     DealOrderLocked,
+    ExternalAddress,
     LoanTerms,
     OfferId,
     TransferId,
@@ -97,7 +98,11 @@ export interface Extrinsics {
         borrower: KeyringPair,
     ) => Promise<[DealOrderClosed, TransferProcessed]>;
     exemptLoan: (dealOrderId: DealOrderId, lender: KeyringPair) => Promise<LoanExempted>;
-    requestCollectCoins: (evmAddress: string, collector: KeyringPair, txHash: string) => Promise<CollectCoinsEvent>;
+    requestCollectCoins: (
+        evmAddress: ExternalAddress,
+        collector: KeyringPair,
+        txHash: string,
+    ) => Promise<CollectCoinsEvent>;
 }
 
 export interface CreditcoinApi {

--- a/creditcoin-js/src/types.ts
+++ b/creditcoin-js/src/types.ts
@@ -29,6 +29,7 @@ import { LoanExempted } from './extrinsics/exempt';
 import { Wallet } from 'ethers';
 
 export type TxCallback = (result: SubmittableResult) => void;
+export type TxFailureCallback = (error?: Error) => void;
 export type ExtrinsicFailed = string;
 
 export interface Extrinsics {

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -17,7 +17,7 @@
         "@polkadot/keyring": "10.1.7",
         "@types/ws": "^8.5.3",
         "axios": "^0.27.2",
-        "creditcoin-js": "file:../creditcoin-js/creditcoin-js-v0.4.0.tgz",
+        "creditcoin-js": "file:../creditcoin-js/creditcoin-js-v0.5.0.tgz",
         "ws": "^8.5.0"
     },
     "devDependencies": {

--- a/integration-tests/yarn.lock
+++ b/integration-tests/yarn.lock
@@ -495,10 +495,10 @@
   resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.7.0.tgz#6ce9ae168e74fecf287be17062b590852c311892"
   integrity sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==
 
-"@ethersproject/networks@5.7.0", "@ethersproject/networks@^5.7.0":
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/networks/-/networks-5.7.0.tgz#df72a392f1a63a57f87210515695a31a245845ad"
-  integrity sha512-MG6oHSQHd4ebvJrleEQQ4HhVu8Ichr0RDYEfHzsVAVjHNM+w36x9wp9r+hf1JstMXtseXDtkiVoARAG6M959AA==
+"@ethersproject/networks@5.7.1", "@ethersproject/networks@^5.7.0":
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/networks/-/networks-5.7.1.tgz#118e1a981d757d45ccea6bb58d9fd3d9db14ead6"
+  integrity sha512-n/MufjFYv3yFcUyfhnXotyDlNdFb7onmkSy8aQERi2PjNcnWQ66xXxa3XlS8nCcA8aJKJjIIMNJTC7tu80GwpQ==
   dependencies:
     "@ethersproject/logger" "^5.7.0"
 
@@ -517,10 +517,10 @@
   dependencies:
     "@ethersproject/logger" "^5.7.0"
 
-"@ethersproject/providers@5.7.0":
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.7.0.tgz#a885cfc7650a64385e7b03ac86fe9c2d4a9c2c63"
-  integrity sha512-+TTrrINMzZ0aXtlwO/95uhAggKm4USLm1PbeCBR/3XZ7+Oey+3pMyddzZEyRhizHpy1HXV0FRWRMI1O3EGYibA==
+"@ethersproject/providers@5.7.1":
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.7.1.tgz#b0799b616d5579cd1067a8ebf1fc1ec74c1e122c"
+  integrity sha512-vZveG/DLyo+wk4Ga1yx6jSEHrLPgmTt+dFv0dv8URpVCRf0jVhalps1jq/emN/oXnMRsC7cQgAF32DcXLL7BPQ==
   dependencies:
     "@ethersproject/abstract-provider" "^5.7.0"
     "@ethersproject/abstract-signer" "^5.7.0"
@@ -646,10 +646,10 @@
     "@ethersproject/transactions" "^5.7.0"
     "@ethersproject/wordlists" "^5.7.0"
 
-"@ethersproject/web@5.7.0", "@ethersproject/web@^5.7.0":
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.7.0.tgz#40850c05260edad8b54827923bbad23d96aac0bc"
-  integrity sha512-ApHcbbj+muRASVDSCl/tgxaH2LBkRMEYfLOLVa0COipx0+nlu0QKet7U2lEg0vdkh8XRSLf2nd1f1Uk9SrVSGA==
+"@ethersproject/web@5.7.1", "@ethersproject/web@^5.7.0":
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.7.1.tgz#de1f285b373149bee5928f4eb7bcb87ee5fbb4ae"
+  integrity sha512-Gueu8lSvyjBWL4cYsWsjh6MtMwM0+H4HvqFPZfB6dV8ctbP9zFAO73VG1cMWae0FLPCtz0peKPpZY8/ugJJX2w==
   dependencies:
     "@ethersproject/base64" "^5.7.0"
     "@ethersproject/bytes" "^5.7.0"
@@ -1351,9 +1351,9 @@
     websocket "^1.0.32"
 
 "@substrate/ss58-registry@^1.28.0":
-  version "1.28.0"
-  resolved "https://registry.yarnpkg.com/@substrate/ss58-registry/-/ss58-registry-1.28.0.tgz#39b7fa355d9b97bcb30ef1eedb47b10c3fddcf03"
-  integrity sha512-XPSwSq4CThLyg+OnZ5/LHh3SPDQjRdGS3Ux5ClgWhRCQamlU86FCT1LBwQ/i+ximbdBfqKRRzVhm1ql3AJ9FKQ==
+  version "1.29.0"
+  resolved "https://registry.yarnpkg.com/@substrate/ss58-registry/-/ss58-registry-1.29.0.tgz#0dea078271b5318c5eff7176e1df1f9b2c27e43f"
+  integrity sha512-KTqwZgTjtWPhCAUJJx9qswP/p9cRKUU9GOHYUDKNdISFDiFafWmpI54JHfYLkgjvkSKEUgRZnvLpe0LMF1fXvw==
 
 "@tsconfig/node10@^1.0.7":
   version "1.0.9"
@@ -1463,9 +1463,9 @@
     form-data "^3.0.0"
 
 "@types/node@*":
-  version "18.7.16"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.7.16.tgz#0eb3cce1e37c79619943d2fd903919fc30850601"
-  integrity sha512-EQHhixfu+mkqHMZl1R2Ovuvn47PUw18azMJOTwSZr9/fhzHNGXAJ0ma0dayRVchprpCj0Kc1K1xKoWaATWF1qg==
+  version "18.7.18"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.7.18.tgz#633184f55c322e4fb08612307c274ee6d5ed3154"
+  integrity sha512-m+6nTEOadJZuTPkKR/SYK3A2d7FZrgElol9UP1Kae90VVU4a6mxnPuLiIW1m4Cq4gZ/nWb9GrdVXJCoCazDAbg==
 
 "@types/prettier@^2.1.5":
   version "2.7.0"
@@ -1943,9 +1943,9 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
-"creditcoin-js@file:../creditcoin-js/creditcoin-js-v0.4.0.tgz":
-  version "0.4.0"
-  resolved "file:../creditcoin-js/creditcoin-js-v0.4.0.tgz#2f60bca581b8aa03f39c38eb6bcf948b82e17fa8"
+"creditcoin-js@file:../creditcoin-js/creditcoin-js-v0.5.0.tgz":
+  version "0.5.0"
+  resolved "file:../creditcoin-js/creditcoin-js-v0.5.0.tgz#53238e90d95ee2d62f5c82775c0a94d5fb37431f"
   dependencies:
     "@polkadot/api" "8.14.1"
     ethers "^5.7.0"
@@ -2251,9 +2251,9 @@ esutils@^2.0.2:
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
 ethers@^5.7.0:
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.7.0.tgz#0055da174b9e076b242b8282638bc94e04b39835"
-  integrity sha512-5Xhzp2ZQRi0Em+0OkOcRHxPzCfoBfgtOQA+RUylSkuHbhTEaQklnYi2hsWbRgs3ztJsXVXd9VKBcO1ScWL8YfA==
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.7.1.tgz#48c83a44900b5f006eb2f65d3ba6277047fd4f33"
+  integrity sha512-5krze4dRLITX7FpU8J4WscXqADiKmyeNlylmmDLbS95DaZpBhDe2YSwRQwKXWNyXcox7a3gBgm/MkGXV1O1S/Q==
   dependencies:
     "@ethersproject/abi" "5.7.0"
     "@ethersproject/abstract-provider" "5.7.0"
@@ -2270,10 +2270,10 @@ ethers@^5.7.0:
     "@ethersproject/json-wallets" "5.7.0"
     "@ethersproject/keccak256" "5.7.0"
     "@ethersproject/logger" "5.7.0"
-    "@ethersproject/networks" "5.7.0"
+    "@ethersproject/networks" "5.7.1"
     "@ethersproject/pbkdf2" "5.7.0"
     "@ethersproject/properties" "5.7.0"
-    "@ethersproject/providers" "5.7.0"
+    "@ethersproject/providers" "5.7.1"
     "@ethersproject/random" "5.7.0"
     "@ethersproject/rlp" "5.7.0"
     "@ethersproject/sha2" "5.7.0"
@@ -2283,7 +2283,7 @@ ethers@^5.7.0:
     "@ethersproject/transactions" "5.7.0"
     "@ethersproject/units" "5.7.0"
     "@ethersproject/wallet" "5.7.0"
-    "@ethersproject/web" "5.7.0"
+    "@ethersproject/web" "5.7.1"
     "@ethersproject/wordlists" "5.7.0"
 
 eventemitter3@^4.0.7:

--- a/scripts/js/package.json
+++ b/scripts/js/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@types/ws": "^8.5.3",
     "axios": "^0.27.2",
-    "creditcoin-js": "file:../../creditcoin-js/creditcoin-js-v0.4.0.tgz",
+    "creditcoin-js": "file:../../creditcoin-js/creditcoin-js-v0.5.0.tgz",
     "ws": "^8.5.0"
   },
   "devDependencies": {

--- a/scripts/js/yarn.lock
+++ b/scripts/js/yarn.lock
@@ -495,10 +495,10 @@
   resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.7.0.tgz#6ce9ae168e74fecf287be17062b590852c311892"
   integrity sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==
 
-"@ethersproject/networks@5.7.0", "@ethersproject/networks@^5.7.0":
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/networks/-/networks-5.7.0.tgz#df72a392f1a63a57f87210515695a31a245845ad"
-  integrity sha512-MG6oHSQHd4ebvJrleEQQ4HhVu8Ichr0RDYEfHzsVAVjHNM+w36x9wp9r+hf1JstMXtseXDtkiVoARAG6M959AA==
+"@ethersproject/networks@5.7.1", "@ethersproject/networks@^5.7.0":
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/networks/-/networks-5.7.1.tgz#118e1a981d757d45ccea6bb58d9fd3d9db14ead6"
+  integrity sha512-n/MufjFYv3yFcUyfhnXotyDlNdFb7onmkSy8aQERi2PjNcnWQ66xXxa3XlS8nCcA8aJKJjIIMNJTC7tu80GwpQ==
   dependencies:
     "@ethersproject/logger" "^5.7.0"
 
@@ -517,10 +517,10 @@
   dependencies:
     "@ethersproject/logger" "^5.7.0"
 
-"@ethersproject/providers@5.7.0":
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.7.0.tgz#a885cfc7650a64385e7b03ac86fe9c2d4a9c2c63"
-  integrity sha512-+TTrrINMzZ0aXtlwO/95uhAggKm4USLm1PbeCBR/3XZ7+Oey+3pMyddzZEyRhizHpy1HXV0FRWRMI1O3EGYibA==
+"@ethersproject/providers@5.7.1":
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.7.1.tgz#b0799b616d5579cd1067a8ebf1fc1ec74c1e122c"
+  integrity sha512-vZveG/DLyo+wk4Ga1yx6jSEHrLPgmTt+dFv0dv8URpVCRf0jVhalps1jq/emN/oXnMRsC7cQgAF32DcXLL7BPQ==
   dependencies:
     "@ethersproject/abstract-provider" "^5.7.0"
     "@ethersproject/abstract-signer" "^5.7.0"
@@ -646,10 +646,10 @@
     "@ethersproject/transactions" "^5.7.0"
     "@ethersproject/wordlists" "^5.7.0"
 
-"@ethersproject/web@5.7.0", "@ethersproject/web@^5.7.0":
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.7.0.tgz#40850c05260edad8b54827923bbad23d96aac0bc"
-  integrity sha512-ApHcbbj+muRASVDSCl/tgxaH2LBkRMEYfLOLVa0COipx0+nlu0QKet7U2lEg0vdkh8XRSLf2nd1f1Uk9SrVSGA==
+"@ethersproject/web@5.7.1", "@ethersproject/web@^5.7.0":
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.7.1.tgz#de1f285b373149bee5928f4eb7bcb87ee5fbb4ae"
+  integrity sha512-Gueu8lSvyjBWL4cYsWsjh6MtMwM0+H4HvqFPZfB6dV8ctbP9zFAO73VG1cMWae0FLPCtz0peKPpZY8/ugJJX2w==
   dependencies:
     "@ethersproject/base64" "^5.7.0"
     "@ethersproject/bytes" "^5.7.0"
@@ -1363,9 +1363,9 @@
     websocket "^1.0.32"
 
 "@substrate/ss58-registry@^1.28.0":
-  version "1.28.0"
-  resolved "https://registry.yarnpkg.com/@substrate/ss58-registry/-/ss58-registry-1.28.0.tgz#39b7fa355d9b97bcb30ef1eedb47b10c3fddcf03"
-  integrity sha512-XPSwSq4CThLyg+OnZ5/LHh3SPDQjRdGS3Ux5ClgWhRCQamlU86FCT1LBwQ/i+ximbdBfqKRRzVhm1ql3AJ9FKQ==
+  version "1.29.0"
+  resolved "https://registry.yarnpkg.com/@substrate/ss58-registry/-/ss58-registry-1.29.0.tgz#0dea078271b5318c5eff7176e1df1f9b2c27e43f"
+  integrity sha512-KTqwZgTjtWPhCAUJJx9qswP/p9cRKUU9GOHYUDKNdISFDiFafWmpI54JHfYLkgjvkSKEUgRZnvLpe0LMF1fXvw==
 
 "@tsconfig/node10@^1.0.7":
   version "1.0.9"
@@ -1475,9 +1475,9 @@
     form-data "^3.0.0"
 
 "@types/node@*":
-  version "18.7.16"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.7.16.tgz#0eb3cce1e37c79619943d2fd903919fc30850601"
-  integrity sha512-EQHhixfu+mkqHMZl1R2Ovuvn47PUw18azMJOTwSZr9/fhzHNGXAJ0ma0dayRVchprpCj0Kc1K1xKoWaATWF1qg==
+  version "18.7.18"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.7.18.tgz#633184f55c322e4fb08612307c274ee6d5ed3154"
+  integrity sha512-m+6nTEOadJZuTPkKR/SYK3A2d7FZrgElol9UP1Kae90VVU4a6mxnPuLiIW1m4Cq4gZ/nWb9GrdVXJCoCazDAbg==
 
 "@types/prettier@^2.1.5":
   version "2.7.0"
@@ -1955,9 +1955,9 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
-"creditcoin-js@file:../../creditcoin-js/creditcoin-js-v0.4.0.tgz":
-  version "0.4.0"
-  resolved "file:../../creditcoin-js/creditcoin-js-v0.4.0.tgz#2f60bca581b8aa03f39c38eb6bcf948b82e17fa8"
+"creditcoin-js@file:../../creditcoin-js/creditcoin-js-v0.5.0.tgz":
+  version "0.5.0"
+  resolved "file:../../creditcoin-js/creditcoin-js-v0.5.0.tgz#6be226880cc4e971816bfe665a43db79a878cdde"
   dependencies:
     "@polkadot/api" "8.14.1"
     ethers "^5.7.0"
@@ -2263,9 +2263,9 @@ esutils@^2.0.2:
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
 ethers@^5.7.0:
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.7.0.tgz#0055da174b9e076b242b8282638bc94e04b39835"
-  integrity sha512-5Xhzp2ZQRi0Em+0OkOcRHxPzCfoBfgtOQA+RUylSkuHbhTEaQklnYi2hsWbRgs3ztJsXVXd9VKBcO1ScWL8YfA==
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.7.1.tgz#48c83a44900b5f006eb2f65d3ba6277047fd4f33"
+  integrity sha512-5krze4dRLITX7FpU8J4WscXqADiKmyeNlylmmDLbS95DaZpBhDe2YSwRQwKXWNyXcox7a3gBgm/MkGXV1O1S/Q==
   dependencies:
     "@ethersproject/abi" "5.7.0"
     "@ethersproject/abstract-provider" "5.7.0"
@@ -2282,10 +2282,10 @@ ethers@^5.7.0:
     "@ethersproject/json-wallets" "5.7.0"
     "@ethersproject/keccak256" "5.7.0"
     "@ethersproject/logger" "5.7.0"
-    "@ethersproject/networks" "5.7.0"
+    "@ethersproject/networks" "5.7.1"
     "@ethersproject/pbkdf2" "5.7.0"
     "@ethersproject/properties" "5.7.0"
-    "@ethersproject/providers" "5.7.0"
+    "@ethersproject/providers" "5.7.1"
     "@ethersproject/random" "5.7.0"
     "@ethersproject/rlp" "5.7.0"
     "@ethersproject/sha2" "5.7.0"
@@ -2295,7 +2295,7 @@ ethers@^5.7.0:
     "@ethersproject/transactions" "5.7.0"
     "@ethersproject/units" "5.7.0"
     "@ethersproject/wallet" "5.7.0"
-    "@ethersproject/web" "5.7.0"
+    "@ethersproject/web" "5.7.1"
     "@ethersproject/wordlists" "5.7.0"
 
 eventemitter3@^4.0.7:


### PR DESCRIPTION
Description of proposed changes:
There were 2 small bugs here causing the issue Alex ran into:
1. We weren't returning early in the error case of `handleTransaction`, so we would run the `onFail` callback, then continue on and run the `onSuccess` callback
2. The form of the `onFail` callback in `handleTransaction` was changed from `(result: SubmittableResult) => void)` to `(result: SubmittableResult, error?: Error) => void`, but we were just passing `reject` (with the signature `(reason?: any) => void`) as the `onFail` handler. That meant that when we hit an error we would call `onFail(result, error)` but the `error` argument was just ignored because `reject` only takes one argument.

Then also a quick fix adding `requestCollectCoins` to the `Extrinsics` interface

Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
