### PR TITLE
[CSUB-297] `TransactionNotFound` error for nonexistent tx hashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -591,9 +591,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11aee792a41973cf54c837d6f344e35a03076328831b01ef30a14d965d47bfbc"
+checksum = "fca0852af221f458706eb0725c03e4ed6c46af9ac98e6a689d5e634215d594dd"
 dependencies = [
  "memchr",
 ]
@@ -1282,9 +1282,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.3"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
 dependencies = [
  "block-buffer 0.10.2",
  "crypto-common",
@@ -2219,7 +2219,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.3",
+ "digest 0.10.5",
 ]
 
 [[package]]
@@ -3989,7 +3989,7 @@ dependencies = [
  "assert_matches",
  "base58",
  "bitcoin-bech32",
- "bstr 1.0.0",
+ "bstr 1.0.1",
  "ethabi",
  "ethereum-types",
  "extend",
@@ -4009,7 +4009,7 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_json",
- "sha2 0.10.5",
+ "sha2 0.10.6",
  "sp-core",
  "sp-io",
  "sp-keystore",
@@ -4376,7 +4376,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
- "digest 0.10.3",
+ "digest 0.10.5",
 ]
 
 [[package]]
@@ -6096,13 +6096,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9db03534dff993187064c4e0c05a5708d2a9728ace9a8959b77bedf415dac5"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures 0.2.2",
- "digest 0.10.3",
+ "digest 0.10.5",
 ]
 
 [[package]]
@@ -6119,11 +6119,11 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.4"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaedf34ed289ea47c2b741bb72e5357a209512d67bcd4bda44359e5bf0470f56"
+checksum = "e2904bea16a1ae962b483322a1c7b81d976029203aea1f461e51cd7705db7ba9"
 dependencies = [
- "digest 0.10.3",
+ "digest 0.10.5",
  "keccak",
 ]
 
@@ -6139,7 +6139,7 @@ dependencies = [
  "sc-consensus-pow",
  "sc-keystore",
  "scale-info",
- "sha3 0.10.4",
+ "sha3 0.10.5",
  "sp-api",
  "sp-application-crypto",
  "sp-consensus-pow",
@@ -6421,7 +6421,7 @@ dependencies = [
  "schnorrkel",
  "secrecy",
  "serde",
- "sha2 0.10.5",
+ "sha2 0.10.6",
  "sp-core-hashing",
  "sp-debug-derive",
  "sp-externalities",
@@ -6445,7 +6445,7 @@ source = "git+https://github.com/gluwa/substrate.git?rev=973dd744f5f7c6322799bbf
 dependencies = [
  "blake2-rfc",
  "byteorder",
- "sha2 0.10.5",
+ "sha2 0.10.6",
  "sp-std",
  "tiny-keccak",
  "twox-hash",
@@ -7206,7 +7206,7 @@ dependencies = [
  "pbkdf2 0.11.0",
  "rand 0.8.5",
  "rustc-hash",
- "sha2 0.10.5",
+ "sha2 0.10.6",
  "thiserror",
  "unicode-normalization",
  "wasm-bindgen",

--- a/pallets/creditcoin/src/ocw/errors.rs
+++ b/pallets/creditcoin/src/ocw/errors.rs
@@ -36,6 +36,7 @@ pub enum VerificationFailureCause {
 	IncorrectSender,
 	InvalidAddress,
 	UnsupportedMethod,
+	TransactionNotFound,
 }
 
 impl VerificationFailureCause {
@@ -45,7 +46,7 @@ impl VerificationFailureCause {
 			TaskFailed | IncorrectContract | MissingSender | MissingReceiver | AbiMismatch
 			| IncorrectInputLength | IncorrectInputType | IncorrectAmount | IncorrectNonce
 			| InvalidAddress | UnsupportedMethod | TaskInFuture | IncorrectSender | EmptyInput
-			| IncorrectReceiver | TaskNonexistent => true,
+			| IncorrectReceiver | TaskNonexistent | TransactionNotFound => true,
 			TaskPending | TaskUnconfirmed => false,
 		}
 	}

--- a/pallets/creditcoin/src/ocw/tasks/verify_transfer.rs
+++ b/pallets/creditcoin/src/ocw/tasks/verify_transfer.rs
@@ -9,10 +9,9 @@ use sp_std::prelude::*;
 
 use crate::{
 	ocw::{
-		parse_eth_address,
-		rpc::{self, errors::RpcError, Address, EthBlock, EthTransaction, EthTransactionReceipt},
-		OffchainError, OffchainResult, VerificationFailureCause, VerificationResult,
-		ETH_CONFIRMATIONS,
+		self, parse_eth_address,
+		rpc::{self, Address, EthBlock, EthTransaction, EthTransactionReceipt},
+		OffchainResult, VerificationFailureCause, VerificationResult, ETH_CONFIRMATIONS,
 	},
 	Blockchain, Config, ExternalAddress, ExternalAmount, ExternalTxId, Id, OrderId, Transfer,
 	TransferKind, UnverifiedTransfer,
@@ -134,13 +133,7 @@ impl<T: Config> crate::Pallet<T> {
 		tx_id: &ExternalTxId,
 	) -> VerificationResult<Option<T::Moment>> {
 		let rpc_url = blockchain.rpc_url()?;
-		let tx = rpc::eth_get_transaction(tx_id, &rpc_url).map_err(|e| {
-			if let RpcError::NoResult = e {
-				OffchainError::InvalidTask(VerificationFailureCause::TaskNonexistent)
-			} else {
-				e.into()
-			}
-		})?;
+		let tx = ocw::eth_get_transaction(tx_id, &rpc_url)?;
 		let tx_receipt = rpc::eth_get_transaction_receipt(tx_id, &rpc_url)?;
 		let eth_tip = rpc::eth_get_block_number(&rpc_url)?;
 

--- a/pallets/creditcoin/src/ocw/tests.rs
+++ b/pallets/creditcoin/src/ocw/tests.rs
@@ -625,7 +625,7 @@ fn verify_transfer_get_transaction_error() {
 
 		assert_matches!(
 			crate::Pallet::<Test>::verify_transfer_ocw(&unverified),
-			Err(OffchainError::InvalidTask(TaskNonexistent))
+			Err(OffchainError::InvalidTask(TransactionNotFound))
 		);
 	});
 }


### PR DESCRIPTION
Description of proposed changes:
If the RPC returns no result when we attempt to get the ethereum transaction by hash, fail the task with a `TransactionNotFound` error.

Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
