### PR TITLE
Fix typo in container name for :latest & build job on Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
           sudo apt install -y cmake pkg-config libssl-dev git build-essential clang libclang-dev curl
 
       - name: Configure rustc version
+        shell: bash
         run: |
           source ci/env
           echo "RUSTC_VERSION=$RUSTC_VERSION" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,7 +156,7 @@ jobs:
       - name: Build docker image
         run: |
           docker build -t gluwa/creditcoin:${{ env.TAG_NAME }} .
-          docker tag gluwa/creditcoin:${{ env.TAG_NAME }} gluwa/creditcoin-substrate:latest
+          docker tag gluwa/creditcoin:${{ env.TAG_NAME }} gluwa/creditcoin:latest
 
           echo "${{ secrets.DOCKER_PUSH_PASSWORD }}" | docker login -u="${{ secrets.DOCKER_PUSH_USERNAME }}" --password-stdin
           docker push gluwa/creditcoin:${{ env.TAG_NAME }}


### PR DESCRIPTION
otherwise `docker push gluwa/creditcoin:latest` fails! 