### PR TITLE
CSUB-305: Authority nonce monitoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1006,6 +1006,7 @@ dependencies = [
  "substrate-build-script-utils",
  "substrate-frame-rpc-system",
  "substrate-prometheus-endpoint",
+ "thiserror",
  "tiny-bip39 1.0.0",
  "tokio",
 ]
@@ -7171,18 +7172,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.31"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
+checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.31"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
+checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -999,12 +999,15 @@ dependencies = [
  "sp-consensus-pow",
  "sp-core",
  "sp-inherents",
+ "sp-offchain",
  "sp-runtime",
  "sp-timestamp",
  "structopt",
  "substrate-build-script-utils",
  "substrate-frame-rpc-system",
+ "substrate-prometheus-endpoint",
  "tiny-bip39 1.0.0",
+ "tokio",
 ]
 
 [[package]]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -38,6 +38,7 @@ hex = "0.4.3"
 creditcoin-node-rpc = { version = "2.0.0-beta.8", path = "./rpc" }
 creditcoin-runtime-api = { version = "2.0.0-beta.8", path = "../pallets/creditcoin/runtime-api" }
 primitives = { path = "../primitives" }
+thiserror = "1.0.37"
 
 [dependencies.tokio]
 version = "1.18.2"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -39,6 +39,10 @@ creditcoin-node-rpc = { version = "2.0.0-beta.8", path = "./rpc" }
 creditcoin-runtime-api = { version = "2.0.0-beta.8", path = "../pallets/creditcoin/runtime-api" }
 primitives = { path = "../primitives" }
 
+[dependencies.tokio]
+version = "1.18.2"
+default-features = false
+features = ["time"]
 
 [dependencies.frame-benchmarking]
 git = "https://github.com/gluwa/substrate.git"
@@ -175,6 +179,16 @@ version = '4.0.0-dev'
 rev = "973dd744f5f7c6322799bbfa29366588e0267b0a"
 
 [dependencies.substrate-frame-rpc-system]
+git = "https://github.com/gluwa/substrate.git"
+version = '4.0.0-dev'
+rev = "973dd744f5f7c6322799bbfa29366588e0267b0a"
+
+[dependencies.substrate-prometheus-endpoint]
+git = "https://github.com/gluwa/substrate.git"
+version = "0.10.0-dev"
+rev = "973dd744f5f7c6322799bbfa29366588e0267b0a"
+
+[dependencies.sp-offchain]
 git = "https://github.com/gluwa/substrate.git"
 version = '4.0.0-dev'
 rev = "973dd744f5f7c6322799bbfa29366588e0267b0a"

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -55,6 +55,9 @@ pub struct Cli {
 	#[structopt(long, parse(try_from_str = parse_rpc_pair))]
 	/// If the node is an oracle authority, the RPC URL to use for a given external chain.
 	pub rpc_mapping: Option<Vec<(String, String)>>,
+
+	#[structopt(long)]
+	pub monitor_nonce: Option<String>,
 }
 #[derive(Debug, StructOpt)]
 pub enum Subcommand {

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -57,6 +57,7 @@ pub struct Cli {
 	pub rpc_mapping: Option<Vec<(String, String)>>,
 
 	#[structopt(long)]
+	/// An authority account ID to monitor the nonce of (must be an account actively running as an authority on this node).
 	pub monitor_nonce: Option<String>,
 }
 #[derive(Debug, StructOpt)]

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -123,12 +123,7 @@ pub fn run() -> sc_cli::Result<()> {
 			runner.run_node_until_exit(|config| async move {
 				match config.role {
 					Role::Light => Err("Light clients are not supported at this time".into()),
-					_ => service::new_full(
-						config,
-						cli.mining_key.as_deref(),
-						cli.mining_threads,
-						cli.rpc_mapping,
-					),
+					_ => service::new_full(config, cli),
 				}
 				.map_err(sc_cli::Error::Service)
 			})

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod chain_spec;
+pub mod cli;
 pub mod rpc;
 pub mod service;

--- a/node/src/service/nonce_monitor.rs
+++ b/node/src/service/nonce_monitor.rs
@@ -124,8 +124,13 @@ async fn get_off_chain_nonce_key(
 }
 
 async fn get_off_chain_nonce(backend: &FullBackend, key: &[u8]) -> Result<Option<u64>, Error> {
-	let off = backend.offchain_storage().expect("offchain storage must be accessible in a creditcoin node. \
-		we only support the file-backed storage backend which always has offchain storage; qed").get(sp_offchain::STORAGE_PREFIX, key);
+	let off = backend
+		.offchain_storage()
+		.expect(
+			"offchain storage must be accessible in a creditcoin node. \
+				we only support the file-backed storage backend which always has offchain storage; qed",
+		)
+		.get(sp_offchain::STORAGE_PREFIX, key);
 
 	let off = match off {
 		None => return Ok(None),

--- a/node/src/service/nonce_monitor.rs
+++ b/node/src/service/nonce_monitor.rs
@@ -124,7 +124,8 @@ async fn get_off_chain_nonce_key(
 }
 
 async fn get_off_chain_nonce(backend: &FullBackend, key: &[u8]) -> Result<Option<u64>, Error> {
-	let off = backend.offchain_storage().unwrap().get(sp_offchain::STORAGE_PREFIX, key);
+	let off = backend.offchain_storage().expect("offchain storage must be accessible in a creditcoin node. \
+		we only support the file-backed storage backend which always has offchain storage; qed").get(sp_offchain::STORAGE_PREFIX, key);
 
 	let off = match off {
 		None => return Ok(None),

--- a/node/src/service/nonce_monitor.rs
+++ b/node/src/service/nonce_monitor.rs
@@ -7,36 +7,86 @@ use sc_client_api::Backend;
 use sc_service::{Arc, RpcHandlers, RpcSession};
 use sp_runtime::{app_crypto::Ss58Codec, offchain::OffchainStorage};
 use substrate_prometheus_endpoint::Registry;
+use thiserror::Error;
 
 use super::FullBackend;
+
+#[derive(Clone, Copy, PartialEq, Debug, Error)]
+enum ErrorKind {
+	#[error("Serde error")]
+	Serde,
+	#[error("RPC error")]
+	Rpc,
+	#[error("Codec error")]
+	Codec,
+}
+
+#[derive(Debug, Error)]
+#[error("{kind}: {value}")]
+struct Error {
+	kind: ErrorKind,
+	#[source]
+	value: Box<dyn std::error::Error + Send>,
+}
+
+macro_rules! error_fn {
+	($($fn_id: ident : $kind: ident),+ $(,)?) => {
+		impl Error {
+			$(
+				fn $fn_id(err: impl std::error::Error + Send + 'static) -> Self {
+					Self::new(ErrorKind::$kind, err)
+				}
+			)+
+		}
+	};
+}
+
+error_fn!(serde: Serde, rpc: Rpc, codec: Codec);
+
+impl Error {
+	fn new(kind: ErrorKind, err: impl std::error::Error + Send + 'static) -> Self {
+		Self { kind, value: Box::new(err) }
+	}
+}
+
+#[derive(Clone, PartialEq, Debug, Error)]
+#[error("{message}")]
+struct AdhocError {
+	message: String,
+}
+
+fn adhoc(message: impl Into<String>) -> AdhocError {
+	AdhocError { message: message.into() }
+}
 
 async fn rpc_request(
 	handlers: &RpcHandlers,
 	request: &str,
-) -> Result<jsonrpc_core::serde_json::Value, String> {
+) -> Result<jsonrpc_core::serde_json::Value, Error> {
 	let (tx, _rx) = mpsc::unbounded();
 	let session = RpcSession::new(tx);
 
 	let response = handlers
 		.rpc_query(&session, request)
 		.await
-		.ok_or_else(|| "empty response".to_string())?;
+		.ok_or_else(|| Error::rpc(adhoc("empty response")))?;
 
-	let response: Response =
-		jsonrpc_core::serde_json::from_str(&response).map_err(|e| e.to_string())?;
+	let response: Response = jsonrpc_core::serde_json::from_str(&response).map_err(Error::serde)?;
 
 	let result = match response {
 		Response::Single(out) => match out {
 			jsonrpc_core::Output::Success(Success { result, .. }) => result,
-			jsonrpc_core::Output::Failure(Failure { error, .. }) => return Err(error.to_string()),
+			jsonrpc_core::Output::Failure(Failure { error, .. }) => return Err(Error::rpc(error)),
 		},
-		Response::Batch(_) => unreachable!(),
+		Response::Batch(_) => {
+			unreachable!("we don't send any batch requests, so we cannot receive batch responses")
+		},
 	};
 
 	Ok(result)
 }
 
-async fn get_on_chain_nonce(handlers: &RpcHandlers, acct: &AccountId) -> Result<u64, String> {
+async fn get_on_chain_nonce(handlers: &RpcHandlers, acct: &AccountId) -> Result<u64, Error> {
 	let request = format!(
 		r#"{{
             "jsonrpc": "2.0",
@@ -49,13 +99,13 @@ async fn get_on_chain_nonce(handlers: &RpcHandlers, acct: &AccountId) -> Result<
 
 	let result = rpc_request(handlers, &request).await?;
 
-	result.as_u64().ok_or_else(|| "expected u64 response".to_string())
+	result.as_u64().ok_or_else(|| Error::rpc(adhoc("expected u64 response")))
 }
 
 async fn get_off_chain_nonce_key(
 	handlers: &RpcHandlers,
 	acct: &AccountId,
-) -> Result<Vec<u8>, String> {
+) -> Result<Vec<u8>, Error> {
 	let request = format!(
 		r#"{{
             "jsonrpc": "2.0",
@@ -68,19 +118,19 @@ async fn get_off_chain_nonce_key(
 
 	let result = rpc_request(handlers, &request).await?;
 
-	let key: Vec<u8> = jsonrpc_core::serde_json::from_value(result).map_err(|e| e.to_string())?;
+	let key: Vec<u8> = jsonrpc_core::serde_json::from_value(result).map_err(Error::serde)?;
 
 	Ok(key)
 }
 
-async fn get_off_chain_nonce(backend: &FullBackend, key: &[u8]) -> Result<Option<u64>, String> {
+async fn get_off_chain_nonce(backend: &FullBackend, key: &[u8]) -> Result<Option<u64>, Error> {
 	let off = backend.offchain_storage().unwrap().get(sp_offchain::STORAGE_PREFIX, key);
 
 	let off = match off {
 		None => return Ok(None),
 		Some(v) => v,
 	};
-	let nonce = u32::decode(&mut off.as_slice()).map_err(|e| e.to_string())?;
+	let nonce = u32::decode(&mut off.as_slice()).map_err(Error::codec)?;
 
 	Ok(Some(nonce.into()))
 }
@@ -91,13 +141,10 @@ type UIntGauge = substrate_prometheus_endpoint::prometheus::core::GenericGauge<
 
 fn register_u64_gauge(registry: &Registry, name: &str, help: &str) -> UIntGauge {
 	substrate_prometheus_endpoint::register(
-		substrate_prometheus_endpoint::prometheus::core::GenericGauge::<
-			substrate_prometheus_endpoint::prometheus::core::AtomicU64,
-		>::new(name, help)
-		.unwrap(),
+		UIntGauge::new(name, help).expect("gauge creation should not fail"),
 		&registry,
 	)
-	.unwrap()
+	.expect("registering prometheus gauge should not fail")
 }
 
 const POLL_INTERVAL: Duration = Duration::from_secs(30);
@@ -119,8 +166,11 @@ pub(super) async fn task(
 		"the nonce for the authority in onchain storage",
 	);
 
-	let acc = AccountId::from_string(&nonce_account).unwrap();
-	let key = get_off_chain_nonce_key(&handlers, &acc).await.unwrap();
+	let acc = AccountId::from_string(&nonce_account)
+		.expect("Invalid account ID provided for nonce monitoring");
+	let key = get_off_chain_nonce_key(&handlers, &acc)
+		.await
+		.expect("Failed to get key for the offchain nonce");
 
 	loop {
 		let onchain = get_on_chain_nonce(&handlers, &acc).await;
@@ -130,6 +180,9 @@ pub(super) async fn task(
 				log::info!("Onchain: {}, offchain: {:?}", on, off);
 				offchain_gauge.set(off.unwrap_or(on));
 				onchain_gauge.set(on);
+			},
+			(Err(e), Err(e2)) => {
+				log::error!("Errors during nonce monitoring: {e} ; {e2}");
 			},
 			(Err(e), _) | (_, Err(e)) => {
 				log::error!("Error during nonce monitoring: {e}");

--- a/node/src/service/nonce_monitor.rs
+++ b/node/src/service/nonce_monitor.rs
@@ -142,7 +142,7 @@ type UIntGauge = substrate_prometheus_endpoint::prometheus::core::GenericGauge<
 fn register_u64_gauge(registry: &Registry, name: &str, help: &str) -> UIntGauge {
 	substrate_prometheus_endpoint::register(
 		UIntGauge::new(name, help).expect("gauge creation should not fail"),
-		&registry,
+		registry,
 	)
 	.expect("registering prometheus gauge should not fail")
 }

--- a/node/src/service/nonce_monitor.rs
+++ b/node/src/service/nonce_monitor.rs
@@ -1,0 +1,140 @@
+use std::time::Duration;
+
+use codec::Decode;
+use creditcoin_node_runtime::AccountId;
+use jsonrpc_core::{futures::channel::mpsc, Failure, Response, Success};
+use sc_client_api::Backend;
+use sc_service::{Arc, RpcHandlers, RpcSession};
+use sp_runtime::{app_crypto::Ss58Codec, offchain::OffchainStorage};
+use substrate_prometheus_endpoint::Registry;
+
+use super::FullBackend;
+
+async fn rpc_request(
+	handlers: &RpcHandlers,
+	request: &str,
+) -> Result<jsonrpc_core::serde_json::Value, String> {
+	let (tx, _rx) = mpsc::unbounded();
+	let session = RpcSession::new(tx);
+
+	let response = handlers
+		.rpc_query(&session, request)
+		.await
+		.ok_or_else(|| "empty response".to_string())?;
+
+	let response: Response =
+		jsonrpc_core::serde_json::from_str(&response).map_err(|e| e.to_string())?;
+
+	let result = match response {
+		Response::Single(out) => match out {
+			jsonrpc_core::Output::Success(Success { result, .. }) => result,
+			jsonrpc_core::Output::Failure(Failure { error, .. }) => return Err(error.to_string()),
+		},
+		Response::Batch(_) => unreachable!(),
+	};
+
+	Ok(result)
+}
+
+async fn get_on_chain_nonce(handlers: &RpcHandlers, acct: &AccountId) -> Result<u64, String> {
+	let request = format!(
+		r#"{{
+            "jsonrpc": "2.0",
+            "method": "system_accountNextIndex",
+            "params": ["{}"],
+            "id": 0
+        }}"#,
+		acct.to_ss58check()
+	);
+
+	let result = rpc_request(handlers, &request).await?;
+
+	result.as_u64().ok_or_else(|| "expected u64 response".to_string())
+}
+
+async fn get_off_chain_nonce_key(
+	handlers: &RpcHandlers,
+	acct: &AccountId,
+) -> Result<Vec<u8>, String> {
+	let request = format!(
+		r#"{{
+            "jsonrpc": "2.0",
+            "method": "task_getOffchainNonceKey",
+            "params": ["{}"],
+            "id": 0
+        }}"#,
+		acct.to_ss58check()
+	);
+
+	let result = rpc_request(handlers, &request).await?;
+
+	let key: Vec<u8> = jsonrpc_core::serde_json::from_value(result).map_err(|e| e.to_string())?;
+
+	Ok(key)
+}
+
+async fn get_off_chain_nonce(backend: &FullBackend, key: &[u8]) -> Result<Option<u64>, String> {
+	let off = backend.offchain_storage().unwrap().get(sp_offchain::STORAGE_PREFIX, key);
+
+	let off = match off {
+		None => return Ok(None),
+		Some(v) => v,
+	};
+	let nonce = u32::decode(&mut off.as_slice()).map_err(|e| e.to_string())?;
+
+	Ok(Some(nonce.into()))
+}
+
+type UIntGauge = substrate_prometheus_endpoint::prometheus::core::GenericGauge<
+	substrate_prometheus_endpoint::prometheus::core::AtomicU64,
+>;
+
+fn register_u64_gauge(registry: &Registry, name: &str, help: &str) -> UIntGauge {
+	substrate_prometheus_endpoint::register(
+		substrate_prometheus_endpoint::prometheus::core::GenericGauge::<
+			substrate_prometheus_endpoint::prometheus::core::AtomicU64,
+		>::new(name, help)
+		.unwrap(),
+		&registry,
+	)
+	.unwrap()
+}
+
+const POLL_INTERVAL: Duration = Duration::from_secs(30);
+
+pub(super) async fn task(
+	registry: Registry,
+	nonce_account: String,
+	handlers: RpcHandlers,
+	backend: Arc<FullBackend>,
+) {
+	let offchain_gauge = register_u64_gauge(
+		&registry,
+		"authority_offchain_nonce",
+		"the nonce for the authority in offchain storage",
+	);
+	let onchain_gauge = register_u64_gauge(
+		&registry,
+		"authority_onchain_nonce",
+		"the nonce for the authority in onchain storage",
+	);
+
+	let acc = AccountId::from_string(&nonce_account).unwrap();
+	let key = get_off_chain_nonce_key(&handlers, &acc).await.unwrap();
+
+	loop {
+		let onchain = get_on_chain_nonce(&handlers, &acc).await;
+		let offchain = get_off_chain_nonce(&backend, &key).await;
+		match (onchain, offchain) {
+			(Ok(on), Ok(off)) => {
+				log::info!("Onchain: {}, offchain: {:?}", on, off);
+				offchain_gauge.set(off.unwrap_or(on));
+				onchain_gauge.set(on);
+			},
+			(Err(e), _) | (_, Err(e)) => {
+				log::error!("Error during nonce monitoring: {e}");
+			},
+		}
+		tokio::time::sleep(POLL_INTERVAL).await;
+	}
+}


### PR DESCRIPTION
Description of proposed changes:
Adds a CLI option `--monitor-nonce <accountId>` to monitor the nonce of a given authority account.
If the option is passed, a task will run in the background the polls the off-chain and on-chain values for the nonce and exposes them as prometheus metrics (under `authority_offchain_nonce` and `authority_onchain_nonce`, respectively).

Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
