### PR TITLE
Fix dependabot ignore directive

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -71,7 +71,7 @@ updates:
       interval: "monthly"
     ignore:
       - dependency-name: "*"
-      - update-types: ["version-update:semver-patch"]
+        update-types: ["version-update:semver-patch"]
 
   - package-ecosystem: "npm"
     directory: "/creditcoin-js"
@@ -79,7 +79,7 @@ updates:
       interval: "monthly"
     ignore:
       - dependency-name: "*"
-      - update-types: ["version-update:semver-patch"]
+        update-types: ["version-update:semver-patch"]
 
   - package-ecosystem: "npm"
     directory: "/scripts/js"
@@ -87,4 +87,4 @@ updates:
       interval: "monthly"
     ignore:
       - dependency-name: "*"
-      - update-types: ["version-update:semver-patch"]
+        update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
Description of proposed changes:
Dependabot [still wasn't happy with our config](https://github.com/gluwa/creditcoin/runs/8753815915), looking at the example for `ignore` in the [docs](https://github.com/gluwa/creditcoin/runs/8753815915), it seems like dependency-name and update-types should be in the same list item.

Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
