### PR TITLE
CSUB-305: Add test for nonce monitoring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,7 +213,10 @@ jobs:
           fi
 
           echo "INFO: MINING_KEY=$MINING_KEY"
-          cargo run --release -- --dev --mining-key $MINING_KEY >~/creditcoin-node.log 2>&1 &
+          KEYSTORE_PATH=$(mktemp -d)
+          # this is the key for Alice
+          cp 637463730238bcdc4d9ab1ef09a2f18ea49e512aafabaab02d21a8c6ff7d2ecee1f2a34d $KEYSTORE_PATH
+          cargo run --release -- --dev --keystore-path $KEYSTORE_PATH --mining-key $MINING_KEY >~/creditcoin-node.log 2>&1 &
 
       - name: Start local Ethereum node
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -999,6 +999,7 @@ dependencies = [
  "sp-consensus-pow",
  "sp-core",
  "sp-inherents",
+ "sp-keystore",
  "sp-offchain",
  "sp-runtime",
  "sp-timestamp",

--- a/integration-tests/637463730238bcdc4d9ab1ef09a2f18ea49e512aafabaab02d21a8c6ff7d2ecee1f2a34d
+++ b/integration-tests/637463730238bcdc4d9ab1ef09a2f18ea49e512aafabaab02d21a8c6ff7d2ecee1f2a34d
@@ -1,0 +1,1 @@
+"version energy retire rely olympic figure shop stumble fence trust spider civil"

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -13,7 +13,9 @@ sudo npm install -g yarn
    for more information:
 
 ```bash
-cargo run --release -- --dev --mining-key XYZ
+KEYSTORE_PATH=$(mktemp -d)
+cp 637463730238bcdc4d9ab1ef09a2f18ea49e512aafabaab02d21a8c6ff7d2ecee1f2a34d $KEYSTORE_PATH
+cargo run --release -- --dev --keystore-path $KEYSTORE_PATH --mining-key XYZ
 ```
 
 1. Execute a local Ethereum node:

--- a/integration-tests/src/test/metrics.test.ts
+++ b/integration-tests/src/test/metrics.test.ts
@@ -26,3 +26,11 @@ test('Hashrate prometheus metric works', async () => {
         }
     }
 });
+
+test('Nonce metrics are returned', async () => {
+    const metricsBase: string = (global as any).CREDITCOIN_METRICS_BASE;
+    const { data } = await axios.get<string>(`${metricsBase}/metrics`);
+
+    expect(data).toContain('authority_offchain_nonce');
+    expect(data).toContain('authority_onchain_nonce');
+});

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -194,6 +194,11 @@ git = "https://github.com/gluwa/substrate.git"
 version = '4.0.0-dev'
 rev = "973dd744f5f7c6322799bbfa29366588e0267b0a"
 
+[dependencies.sp-keystore]
+git = "https://github.com/gluwa/substrate.git"
+version = '0.10.0-dev'
+rev = "973dd744f5f7c6322799bbfa29366588e0267b0a"
+
 [features]
 default = ['std']
 runtime-benchmarks = ['creditcoin-node-runtime/runtime-benchmarks']

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -1,4 +1,6 @@
+use creditcoin_node_runtime::AccountId;
 use sc_cli::RunCmd;
+use sp_core::crypto::{PublicError, Ss58Codec};
 use structopt::StructOpt;
 
 fn parse_rpc_pair(input: &str) -> Result<(String, String), String> {
@@ -57,9 +59,28 @@ pub struct Cli {
 	pub rpc_mapping: Option<Vec<(String, String)>>,
 
 	#[structopt(long)]
-	/// An authority account ID to monitor the nonce of (must be an account actively running as an authority on this node).
-	pub monitor_nonce: Option<String>,
+	/// An authority account ID to monitor the nonce of (must be an account actively running as an authority on this node), or
+	/// `auto` to find the authority account automatically.
+	pub monitor_nonce: Option<NonceMonitorTarget>,
 }
+
+#[derive(Debug)]
+pub enum NonceMonitorTarget {
+	Auto,
+	Account(AccountId),
+}
+
+impl std::str::FromStr for NonceMonitorTarget {
+	type Err = PublicError;
+
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		Ok(match s {
+			"auto" | "AUTO" | "Auto" => Self::Auto,
+			acct => Self::Account(AccountId::from_string(acct)?),
+		})
+	}
+}
+
 #[derive(Debug, StructOpt)]
 pub enum Subcommand {
 	/// Key management cli utilities

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -2,19 +2,21 @@
 
 mod nonce_monitor;
 
+use crate::cli::{Cli, NonceMonitorTarget};
 use codec::Encode;
-use creditcoin_node_runtime::{self, opaque::Block, RuntimeApi};
+use creditcoin_node_runtime::{self, opaque::Block, AccountId, RuntimeApi};
 use sc_client_api::{Backend, ExecutorProvider};
 pub use sc_executor::NativeElseWasmExecutor;
 use sc_keystore::LocalKeystore;
-use sc_service::{error::Error as ServiceError, Configuration, TaskManager};
+use sc_service::{error::Error as ServiceError, Configuration, KeystoreContainer, TaskManager};
 use sc_telemetry::{Telemetry, TelemetryWorker};
 use sha3pow::Sha3Algorithm;
 use sp_inherents::CreateInherentDataProviders;
-use sp_runtime::{app_crypto::Ss58Codec, offchain::DbExternalities, traits::IdentifyAccount};
-use std::{sync::Arc, thread, time::Duration};
-
-use crate::cli::Cli;
+use sp_keystore::CryptoStore;
+use sp_runtime::{
+	app_crypto::Ss58Codec, offchain::DbExternalities, traits::IdentifyAccount, MultiSigner,
+};
+use std::{convert::TryInto, sync::Arc, thread, time::Duration};
 
 // Our native executor instance.
 pub struct ExecutorDispatch;
@@ -181,6 +183,34 @@ pub fn decode_mining_key(
 	}
 }
 
+pub fn get_authority_account(
+	target: NonceMonitorTarget,
+	keystore_container: &KeystoreContainer,
+) -> Result<Option<AccountId>, ServiceError> {
+	Ok(match target {
+		NonceMonitorTarget::Auto => {
+			let keys = futures_lite::future::block_on(CryptoStore::keys(
+				&*keystore_container.sync_keystore(),
+				sp_runtime::KeyTypeId(*b"ctcs"),
+			))
+			.map_err(|e| e.to_string())?;
+			keys.into_iter()
+				.next()
+				.map(|key| {
+					Ok::<_, String>(MultiSigner::Sr25519(sp_core::sr25519::Public::from_raw(
+						key.1.try_into().map_err(|e| {
+							format!("Invalid authroity account from public key: {}", hex::encode(e))
+						})?,
+					)))
+				})
+				.transpose()?
+				.map(|signer| signer.into_account())
+		},
+
+		NonceMonitorTarget::Account(acct) => Some(acct),
+	})
+}
+
 /// Builds a new service for a full client.
 pub fn new_full(config: Configuration, cli: Cli) -> Result<TaskManager, ServiceError> {
 	let Cli {
@@ -283,9 +313,17 @@ pub fn new_full(config: Configuration, cli: Cli) -> Result<TaskManager, ServiceE
 
 	if let Some(nonce_account) = monitor_nonce_account {
 		if let Some(registry) = prometheus_registry.clone() {
-			task_manager.spawn_handle().spawn("nonce_metrics", None, {
-				nonce_monitor::task(registry, nonce_account, rpc_handlers, backend)
-			});
+			std::thread::sleep(Duration::from_secs(15));
+
+			let nonce_account = get_authority_account(nonce_account, &keystore_container)?;
+
+			if let Some(nonce_account) = nonce_account {
+				task_manager.spawn_handle().spawn("nonce_metrics", None, {
+					nonce_monitor::task(registry, nonce_account, rpc_handlers, backend)
+				});
+			} else {
+				log::warn!("No authority key found in the keystore");
+			}
 		}
 	}
 

--- a/node/src/service/nonce_monitor.rs
+++ b/node/src/service/nonce_monitor.rs
@@ -120,7 +120,7 @@ const POLL_INTERVAL: Duration = Duration::from_secs(30);
 
 pub(super) async fn task(
 	registry: Registry,
-	nonce_account: String,
+	nonce_account: AccountId,
 	handlers: RpcHandlers,
 	backend: Arc<FullBackend>,
 ) {
@@ -135,15 +135,15 @@ pub(super) async fn task(
 		"the nonce for the authority in onchain storage",
 	);
 
-	let acc = AccountId::from_string(&nonce_account)
-		.expect("Invalid account ID provided for nonce monitoring");
-	let key = get_off_chain_nonce_key(&handlers, &acc)
+	let key = get_off_chain_nonce_key(&handlers, &nonce_account)
 		.await
 		.expect("Failed to get key for the offchain nonce");
 
 	loop {
-		let (onchain, offchain) =
-			join!(get_on_chain_nonce(&handlers, &acc), get_off_chain_nonce(&backend, &key));
+		let (onchain, offchain) = join!(
+			get_on_chain_nonce(&handlers, &nonce_account),
+			get_off_chain_nonce(&backend, &key)
+		);
 
 		match (onchain, offchain) {
 			(Ok(on), Ok(off)) => {


### PR DESCRIPTION
Builds on top of #713 (which needs a rebase). Depending on whether or not @nathanwhit changes the implementation of how/when authority keys are discovered this PR may need to drop the initialization commit and leave only the last one which asserts on the two new metrics.