### PR TITLE
CSUB-245: Start consuming creditcoin-js as gitpkg dependency

### DIFF
--- a/creditcoin-js/tsconfig.json
+++ b/creditcoin-js/tsconfig.json
@@ -16,7 +16,7 @@
         },
         "resolveJsonModule": true
     },
-    "include": ["src"],
+    "include": ["src", "src/examples/ethless/contracts/**/*.json"],
     "exclude": ["node_modules", "**/__tests__/*"],
 
     "ts-node": {

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -17,7 +17,7 @@
         "@polkadot/keyring": "10.1.9",
         "@types/ws": "^8.5.3",
         "axios": "^1.0.0",
-        "creditcoin-js": "file:../creditcoin-js/creditcoin-js-v0.7.0.tgz",
+        "creditcoin-js": "https://gitpkg.now.sh/gluwa/creditcoin/creditcoin-js?dd095499589293b9862651b068286e85a5d1e08f&scripts.postinstall=yarn%20install%20--ignore-scripts%20%26%26%20yarn%20build",
         "ws": "^8.5.0"
     },
     "devDependencies": {

--- a/integration-tests/yarn.lock
+++ b/integration-tests/yarn.lock
@@ -1549,9 +1549,9 @@
     form-data "^3.0.0"
 
 "@types/node@*":
-  version "18.11.3"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.3.tgz#78a6d7ec962b596fc2d2ec102c4dd3ef073fea6a"
-  integrity sha512-fNjDQzzOsZeKZu5NATgXUPsaFaTxeRgFXoosrHivTl8RGeV733OLawXsGfEk9a8/tySyZUyiZ6E8LcjPFZ2y1A==
+  version "18.11.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.5.tgz#1bc94cf2f9ab5fe33353bc7c79c797dcc5325bef"
+  integrity sha512-3JRwhbjI+cHLAkUorhf8RnqUbFXajvzX4q6fMn5JwkgtuwfYtRQYI3u4V92vI6NJuTsbBQWWh3RZjFsuevyMGQ==
 
 "@types/prettier@^2.1.5":
   version "2.7.1"
@@ -2034,9 +2034,9 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
-"creditcoin-js@file:../creditcoin-js/creditcoin-js-v0.7.0.tgz":
+"creditcoin-js@https://gitpkg.now.sh/gluwa/creditcoin/creditcoin-js?dd095499589293b9862651b068286e85a5d1e08f&scripts.postinstall=yarn%20install%20--ignore-scripts%20%26%26%20yarn%20build":
   version "0.7.0"
-  resolved "file:../creditcoin-js/creditcoin-js-v0.7.0.tgz#c6da05e58f61cf81bcb72a311f64005e179bc9f4"
+  resolved "https://gitpkg.now.sh/gluwa/creditcoin/creditcoin-js?dd095499589293b9862651b068286e85a5d1e08f&scripts.postinstall=yarn%20install%20--ignore-scripts%20%26%26%20yarn%20build#99611a410b2cc58ffb3b6f61835b13ad98dd1235"
   dependencies:
     "@polkadot/api" "8.14.1"
     ethers "^5.7.1"

--- a/scripts/js/package.json
+++ b/scripts/js/package.json
@@ -16,7 +16,7 @@
     "dependencies": {
         "@types/ws": "^8.5.3",
         "axios": "^1.1.2",
-        "creditcoin-js": "file:../../creditcoin-js/creditcoin-js-v0.7.0.tgz",
+        "creditcoin-js": "https://gitpkg.now.sh/gluwa/creditcoin/creditcoin-js?dd095499589293b9862651b068286e85a5d1e08f&scripts.postinstall=yarn%20install%20--ignore-scripts%20%26%26%20yarn%20build",
         "ws": "^8.5.0"
     },
     "devDependencies": {

--- a/scripts/js/yarn.lock
+++ b/scripts/js/yarn.lock
@@ -1457,9 +1457,9 @@
     form-data "^3.0.0"
 
 "@types/node@*":
-  version "18.11.3"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.3.tgz#78a6d7ec962b596fc2d2ec102c4dd3ef073fea6a"
-  integrity sha512-fNjDQzzOsZeKZu5NATgXUPsaFaTxeRgFXoosrHivTl8RGeV733OLawXsGfEk9a8/tySyZUyiZ6E8LcjPFZ2y1A==
+  version "18.11.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.5.tgz#1bc94cf2f9ab5fe33353bc7c79c797dcc5325bef"
+  integrity sha512-3JRwhbjI+cHLAkUorhf8RnqUbFXajvzX4q6fMn5JwkgtuwfYtRQYI3u4V92vI6NJuTsbBQWWh3RZjFsuevyMGQ==
 
 "@types/prettier@^2.1.5":
   version "2.7.1"
@@ -1942,9 +1942,9 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
-"creditcoin-js@file:../../creditcoin-js/creditcoin-js-v0.7.0.tgz":
+"creditcoin-js@https://gitpkg.now.sh/gluwa/creditcoin/creditcoin-js?dd095499589293b9862651b068286e85a5d1e08f&scripts.postinstall=yarn%20install%20--ignore-scripts%20%26%26%20yarn%20build":
   version "0.7.0"
-  resolved "file:../../creditcoin-js/creditcoin-js-v0.7.0.tgz#c6da05e58f61cf81bcb72a311f64005e179bc9f4"
+  resolved "https://gitpkg.now.sh/gluwa/creditcoin/creditcoin-js?dd095499589293b9862651b068286e85a5d1e08f&scripts.postinstall=yarn%20install%20--ignore-scripts%20%26%26%20yarn%20build#99611a410b2cc58ffb3b6f61835b13ad98dd1235"
   dependencies:
     "@polkadot/api" "8.14.1"
     ethers "^5.7.1"


### PR DESCRIPTION
this will allow to install instegration-tests/ as a gitpkg dependency in other projects

Description of proposed changes:


Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
