### PR TITLE
CSUB-328: Don't use deprecated GitHub features in CI

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -56,7 +56,7 @@ jobs:
         target: wasm32-unknown-unknown
         profile: minimal
         override: true
-    - uses: Swatinem/rust-cache@v1
+    - uses: Swatinem/rust-cache@v2
 
     - name: Build benchmarks
       uses: actions-rs/cargo@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,7 +250,7 @@ jobs:
 
           if [ -n "$(git status --short)" ]; then
               git diff
-              echo "::set-output name=git_diff::true"
+              echo "git_diff=true" >> $GITHUB_OUTPUT
           fi
 
           popd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
           profile: minimal
           override: true
           components: clippy
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
 
       - name: Run Clippy
         uses: actions-rs/cargo@v1
@@ -108,7 +108,7 @@ jobs:
           target: wasm32-unknown-unknown
           profile: minimal
           override: true
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
 
       - name: Check Build
         run: |
@@ -140,7 +140,7 @@ jobs:
           target: wasm32-unknown-unknown
           profile: minimal
           override: true
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
 
       - name: Configure flags for collecting coverage
         run: |
@@ -195,7 +195,7 @@ jobs:
           target: wasm32-unknown-unknown
           profile: minimal
           override: true
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
 
       - name: Build SUT
         uses: actions-rs/cargo@v1
@@ -402,7 +402,7 @@ jobs:
           target: wasm32-unknown-unknown
           profile: minimal
           override: true
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
 
       - name: Build benchmarks
         uses: actions-rs/cargo@v1

--- a/.github/workflows/llvm-cov.yml
+++ b/.github/workflows/llvm-cov.yml
@@ -53,7 +53,7 @@ jobs:
             UNCOVERED_LINES="${UNCOVERED_LINES//'%'/'%25'}"
             UNCOVERED_LINES="${UNCOVERED_LINES//$'\n'/'%0A'}"
             UNCOVERED_LINES="${UNCOVERED_LINES//$'\r'/'%0D'}"
-            echo "::set-output name=uncovered_lines::$UNCOVERED_LINES"
+            echo "uncovered_lines=$UNCOVERED_LINES" >> $GITHUB_OUTPUT
 
       - name: Azure login
         uses: azure/login@v1

--- a/.github/workflows/llvm-cov.yml
+++ b/.github/workflows/llvm-cov.yml
@@ -32,7 +32,7 @@ jobs:
           target: wasm32-unknown-unknown
           profile: minimal
           override: true
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
           profile: minimal
           override: true
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
 
       - name: Figure out platform
         shell: bash

--- a/.github/workflows/runtime-extrinsics.yml
+++ b/.github/workflows/runtime-extrinsics.yml
@@ -39,7 +39,7 @@ jobs:
           target: wasm32-unknown-unknown
           profile: minimal
           override: true
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
 
       - name: Build Release
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
The LLVM comment posted below uses the new `GITHUB_OUTPUT` syntax so it must be working. The rest of the warning are coming from 3rd party actions which we use. Out of scope for this PR for now.