### PR TITLE
CSUB-373: Enable Build WASM Runtime job for PRs againt dev/tesnet

### DIFF
--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -3,6 +3,8 @@ name: Build WASM Runtime
 on:
   push:
     branches: [main, testnet, dev]
+  pull_request:
+    branches: [testnet, dev]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
automatic update of WASM blob will still happen only on merged to dev

Description of proposed changes:


Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
