### PR TITLE
Don't use a wildcard version requirement for `schnorrkel` dependency

### DIFF
--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -16,7 +16,7 @@ num = { version = "0.4.0", default-features = false, features = [
     "num-bigint",
     "alloc",
 ] }
-schnorrkel = { version = "*", features = ["u64_backend"] }
+schnorrkel = { version = "0.9", features = ["u64_backend"] }
 sp-arithmetic = { workspace = true }
 sp-keystore = { workspace = true }
 sp-runtime-interface = { workspace = true }


### PR DESCRIPTION
Description of proposed changes:
Glancing over our dependencies I noticed we weren't specifying a requirement, which makes it easy to accidentally get a breaking update when a new version is released.

Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
