### PR TITLE
Unrelated: fix weird import

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1155,6 +1155,7 @@ dependencies = [
  "sp-blockchain",
  "sp-core",
  "sp-inherents",
+ "sp-io",
  "sp-keyring",
  "sp-keystore",
  "sp-offchain",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -64,6 +64,7 @@ jsonrpsee = { workspace = true, features = ["server"] }
 serde_json = "1.0.93"
 frame-system = { workspace = true }
 pallet-transaction-payment = { workspace = true }
+sp-io = { workspace = true, optional = true }
 sp-keyring = { workspace = true }
 futures = "0.3.26"
 
@@ -80,4 +81,8 @@ runtime-benchmarks = [
     'frame-benchmarking-cli/runtime-benchmarks',
 ]
 std = ['sp-api/std', 'sp-block-builder/std', 'task-scheduler-runtime-api/std']
-try-runtime = ["creditcoin-node-runtime/try-runtime", "try-runtime-cli/try-runtime"]
+try-runtime = [
+    "creditcoin-node-runtime/try-runtime",
+    "try-runtime-cli/try-runtime",
+    "sp-io",
+]

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -5,7 +5,6 @@ use crate::{
 	service,
 };
 use creditcoin_node_runtime::{Block, ExistentialDeposit};
-use frame_benchmarking::frame_support;
 use frame_benchmarking_cli::{BenchmarkCmd, ExtrinsicFactory, SUBSTRATE_REFERENCE_HARDWARE};
 use sc_cli::{ChainSpec, RuntimeVersion, SubstrateCli};
 use sc_service::PartialComponents;
@@ -113,8 +112,8 @@ pub fn run() -> sc_cli::Result<()> {
 		},
 		#[cfg(feature = "try-runtime")]
 		Some(Subcommand::TryRuntime(cmd)) => {
-			use frame_support::sp_io::SubstrateHostFunctions;
 			use sc_executor::{sp_wasm_interface::ExtendedHostFunctions, NativeExecutionDispatch};
+			use sp_io::SubstrateHostFunctions;
 			let runner = cli.create_runner(cmd)?;
 			runner.async_run(|config| {
 				// we don't need any of the components of new_partial, just a runtime, or a task


### PR DESCRIPTION
Description of proposed changes:
Weird way to import dependencies that are only used with the `try-runtime` feature. `cargo check`  to reproduce.

Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
