### PR TITLE
Fix runtime build CI job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,6 +126,7 @@ jobs:
           chain: "creditcoin"
           runtime_dir: runtime
           package: creditcoin-node-runtime
+          tag: "1.66.1" # FIXME: remove this option (use the latest) once we're building w/ stable rust
           workdir: ${{ github.workspace }}
 
       - name: DEBUG

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -23,6 +23,7 @@ jobs:
           runtime_dir: runtime
           package: creditcoin-node-runtime
           workdir: ${{ github.workspace }}
+          tag: "1.66.1" # FIXME: remove this option (use the latest) once we're building w/ stable rust
       - name: Summary
         run: |
           echo '${{ steps.srtool_build.outputs.json }}' | jq . > creditcoin-srtool-digest.json


### PR DESCRIPTION
# Description of proposed changes

Fixes the failures in our "Build WASM Runtime" CI job (seen in #1031 and #1034) by specifying the previous version of the `srtool` image. Once we've updated to a version of substrate that supports building on stable rust, we can remove this tag and use the latest.

---
Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
