### PR TITLE
Revert "build(deps): bump thedoctor0/zip-release from 0.7.1 to 0.7.2"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
           args: --release --target aarch64-apple-darwin
 
       - name: Compress
-        uses: thedoctor0/zip-release@0.7.2
+        uses: thedoctor0/zip-release@0.7.1
         with:
           type: "zip"
           directory: "target/release/"
@@ -92,7 +92,7 @@ jobs:
 
       - name: Compress MacOS aarch64 target
         if: matrix.operating-system == 'macos-11'
-        uses: thedoctor0/zip-release@0.7.2
+        uses: thedoctor0/zip-release@0.7.1
         with:
           type: "zip"
           directory: "target/aarch64-apple-darwin/release/"


### PR DESCRIPTION
This reverts commit 9b611a1c8b37d2daedbfb8b6d76b3066f3f1b28d.

Version 0.7.2 is nowhere to be found upstream. Could have been yanked after the commit was originally merged.

That's why we've got failures here: https://github.com/gluwa/creditcoin/actions/runs/4877734019/jobs/8702666438
