### PR TITLE
Try fixing "Check Runtime and Extrinsics" CI job

### DIFF
--- a/integration-tests/jest.config.ts
+++ b/integration-tests/jest.config.ts
@@ -2,7 +2,7 @@ import type { Config } from "@jest/types";
 const config: Config.InitialOptions = {
   preset: "ts-jest",
   testEnvironment: "node",
-  testTimeout: 30000,
+  testTimeout: 45000,
   globalSetup: "./src/globalSetup.ts",
 };
 

--- a/scripts/check-extrinsics.sh
+++ b/scripts/check-extrinsics.sh
@@ -49,9 +49,9 @@ for RUNTIME in "${runtimes[@]}"; do
   jobs
 
   #Wait for HEAD BINARY
-  ./integration-tests/wait-for-creditcoin.sh 'http://127.0.0.1:9944'
+  ./integration-tests/wait-for-creditcoin.sh 'http://127.0.0.1:9933'
   #Wait for RELEASE BINARY
-  ./integration-tests/wait-for-creditcoin.sh 'http://127.0.0.1:9945'
+  ./integration-tests/wait-for-creditcoin.sh 'http://127.0.0.1:9934'
 
   changed_extrinsics=$(
     polkadot-js-metadata-cmp "$RELEASE_WS" "$HEAD_WS" \


### PR DESCRIPTION
# Description of proposed changes

Since the extrinsics ordering check was passing 2 weeks ago, maybe pinning `@polkadot/metadata-cmp` to the version from >=2 weeks ago will fix it?

---
Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
