### PR TITLE
CSUB-478: Revert "Switch to Sepolia for testing against devnet & testnet"

### DIFF
--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -91,7 +91,7 @@ yarn install
 2. Execute the test suite:
 
 ```bash
-export ETHEREUM_NODE_URL=https://sepolia.infura.io/v3/abcdef
+export ETHEREUM_NODE_URL=https://goerli.infura.io/v3/abcdef
 export LENDER_PRIVATE_KEY=XXXXXX
 export BORROWER_PRIVATE_KEY=YYYY
 

--- a/integration-tests/src/devnetSetup.ts
+++ b/integration-tests/src/devnetSetup.ts
@@ -37,8 +37,8 @@ const setup = async () => {
     (global as any).CREDITCOIN_METRICS_BASE = 'http://dev-rpc-creditcoin-rpc-2.centralus.cloudapp.azure.com:9615';
     (global as any).CREDITCOIN_REUSE_EXISTING_ADDRESSES = true;
 
-    // This is on sepolis, https://sepolia.etherscan.io/address/0x37CA379066f061f1983FabAF72705d2604a24590
-    (global as any).CREDITCOIN_CTC_CONTRACT_ADDRESS = '0x37CA379066f061f1983FabAF72705d2604a24590';
+    // This is on Goerli, https://goerli.etherscan.io/address/0x80C9A853B906fc4a30A5F9E4982F1F5AC1798cd0
+    (global as any).CREDITCOIN_CTC_CONTRACT_ADDRESS = '0x80C9A853B906fc4a30A5F9E4982F1F5AC1798cd0';
     // we need a new tx hash every time so we call .burn() in globalSetup()! See ctc-deploy.ts
     (global as any).CREDITCOIN_CTC_BURN_TX_HASH = undefined;
 

--- a/integration-tests/src/testnetSetup.ts
+++ b/integration-tests/src/testnetSetup.ts
@@ -37,8 +37,8 @@ const setup = async () => {
     (global as any).CREDITCOIN_METRICS_BASE = 'http://test-rpc-creditcoin-rpc-2.eastus.cloudapp.azure.com:9615';
     (global as any).CREDITCOIN_REUSE_EXISTING_ADDRESSES = true;
 
-    // This should be on Sepolia
-    (global as any).CREDITCOIN_CTC_CONTRACT_ADDRESS = undefined; // '';
+    // This is on Goerli, https://goerli.etherscan.io/address/0x833cc7c2598D80d327767De33B22ac426f4248e2
+    (global as any).CREDITCOIN_CTC_CONTRACT_ADDRESS = '0x833cc7c2598D80d327767De33B22ac426f4248e2';
     // we need a new tx hash every time so we call .burn() in globalSetup()! See ctc-deploy.ts
     (global as any).CREDITCOIN_CTC_BURN_TX_HASH = undefined;
 


### PR DESCRIPTION
back to using Goerli b/c other teams are using it too

This reverts commit 1f0e2c93375e0ff13822b350ac6ef5deb322e974

NOTE: ETHEREUM_NODE_URL in 1Password has been updated

# Description of proposed changes

<describe what this PR is about and why we want it>

---
Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
