### PR TITLE
CSUB-480: Fix native binary builds in release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,10 @@ jobs:
         if: matrix.operating-system == 'ubuntu-22.04'
         run: |
           sudo apt-get update
-          sudo apt install -y cmake pkg-config libssl-dev git build-essential clang libclang-dev curl protobuf-compiler
+          sudo apt install -y cmake pkg-config libssl-dev git build-essential clang libclang-dev curl
+
+      - name: Install protobuf
+        uses: arduino/setup-protoc@v2
 
       - name: Configure rustc version
         shell: bash

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ members = [
     "test/traced-test",
 ]
 
+resolver = "2"
+
 [workspace.package]
 version = '2.222.0'
 authors = ['Gluwa Inc.', 'Nathan Whitaker <nathan.whitaker@gluwa.com>']


### PR DESCRIPTION
# Description of proposed changes
Successful run based on this branch: https://github.com/gluwa/creditcoin/actions/runs/5204937395


Addresses the failure of the release pipeline during today's testnet tag/release: https://github.com/gluwa/creditcoin/actions/runs/5204502494

The windows builder was missing protobuf, so instead of a bunch of platform specific install I just used a gha (https://github.com/arduino/setup-protoc).

Also needed to specifically set the cargo feature resolver version in the workspace cargo.toml (this also addresses the following warnings you may have seen if you're running on a relatively recent rust toolchain):
```
warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
```


Successful run based on this branch: https://github.com/gluwa/creditcoin/actions/runs/5204937395


---
Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
