### PR TITLE
Fix test CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,6 +214,9 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set-Up
+        env:
+          HOMEBREW_NO_INSTALL_CLEANUP: true
+          HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: true
         run: |
           brew update
           brew install cmake openssl protobuf


### PR DESCRIPTION
# Description of proposed changes

Fixes failures seen in #1128, #1131, and #1125 (maybe others too). The error occurs when upgrading a formula that depends on cmake (python3.11) - we don't need this formula though, so we can just disable the behavior of upgrading dependents through an environment variable.

---
Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
