### PR TITLE
Add bootnode to PoS testnet spec

### DIFF
--- a/chainspecs/posTestnetSpec.json
+++ b/chainspecs/posTestnetSpec.json
@@ -2,7 +2,9 @@
   "name": "Creditcoin PoS Testnet",
   "id": "creditcoin_pos_testnet",
   "chainType": "Live",
-  "bootNodes": [],
+  "bootNodes": [
+    "/dns4/testnet-bootnode.creditcoin.network/tcp/30333/p2p/12D3KooWG3eEuYxo37LvU1g6SSESu4i9TQ8FrZmJcjvdys7eA3cH"
+  ],
   "telemetryEndpoints": null,
   "protocolId": null,
   "properties": {


### PR DESCRIPTION
# Description of proposed changes

Idk why I forgot this was a thing. It means that, unless you want more bootnodes, you can connect to the network without having to pass any `--bootnodes` on the cli.

---
Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
