### PR TITLE
Support sending from old ECDSA accounts w/o mnemonic

### DIFF
--- a/scripts/cc-cli/src/commands/send.ts
+++ b/scripts/cc-cli/src/commands/send.ts
@@ -3,9 +3,11 @@ import { newApi } from "../api";
 import {
   checkAddress,
   getSeedFromOptions,
+  initECDSAKeyringPairFromPK,
   initKeyringPair,
 } from "../utils/account";
 import { toMicrounits } from "../utils/balance";
+import { ApiPromise } from "creditcoin-js";
 
 export function makeSendCommand() {
   const cmd = new Command("send");
@@ -18,6 +20,10 @@ export function makeSendCommand() {
     "-f, --file [file-name]",
     "Specify file with mnemonic phrase to use for sending CTC"
   );
+  cmd.option(
+    "--use-ecdsa",
+    "Use ECDSA signature scheme and a private key instead of a mnemonic phrase"
+  );
   cmd.option("-a, --amount [amount]", "Amount to send");
   cmd.option("-t, --to [to]", "Specify recipient address");
   cmd.action(sendAction);
@@ -29,8 +35,27 @@ async function sendAction(options: OptionValues) {
 
   // Check options
   checkAmount(options);
-  checkAddress(options.to, api);
+  checkAddress(options.to, api, "send funds to");
 
+  if (options.useEcdsa) {
+    const hash = await sendFromECDSA(options, api);
+    console.log("Transfer transaction hash: " + hash.toHex());
+  } else {
+    const hash = await sendFromSr25519(options, api);
+    console.log("Transfer transaction hash: " + hash.toHex());
+  }
+
+  process.exit(0);
+}
+
+function checkAmount(options: OptionValues) {
+  if (!options.amount) {
+    console.log("Must specify amount to send");
+    process.exit(1);
+  }
+}
+
+async function sendFromSr25519(options: OptionValues, api: ApiPromise) {
   // Build account
   const seed = getSeedFromOptions(options);
   const stash = initKeyringPair(seed);
@@ -41,14 +66,20 @@ async function sendAction(options: OptionValues) {
     toMicrounits(options.amount).toString()
   );
   const hash = await tx.signAndSend(stash);
-
-  console.log("Transfer transaction hash: " + hash.toHex());
-  process.exit(0);
+  return hash;
 }
 
-function checkAmount(options: OptionValues) {
-  if (!options.amount) {
-    console.log("Must specify amount to send");
-    process.exit(1);
-  }
+async function sendFromECDSA(options: OptionValues, api: ApiPromise) {
+  // Build account
+  const seed = getSeedFromOptions(options);
+  const stash = initECDSAKeyringPairFromPK(seed);
+  console.log(stash.address);
+
+  // Send transaction
+  const tx = api.tx.balances.transfer(
+    options.to,
+    toMicrounits(options.amount).toString()
+  );
+  const hash = await tx.signAndSend(stash);
+  return hash;
 }

--- a/scripts/cc-cli/src/utils/account.ts
+++ b/scripts/cc-cli/src/utils/account.ts
@@ -8,6 +8,12 @@ export function initKeyringPair(seed: string) {
   return pair;
 }
 
+export function initECDSAKeyringPairFromPK(pk: string) {
+  const keyring = new Keyring({ type: "ecdsa" });
+  const pair = keyring.addFromUri(`${pk}`);
+  return pair;
+}
+
 export function getSeedFromOptions(options: OptionValues) {
   if (options.seed) {
     return options.seed;
@@ -18,9 +24,13 @@ export function getSeedFromOptions(options: OptionValues) {
   }
 }
 
-export function checkAddress(address: string, api: ApiPromise) {
+export function checkAddress(
+  address: string,
+  api: ApiPromise,
+  action = "interact with."
+) {
   if (!address) {
-    console.log("Must specify address to get balance of");
+    console.log(`Must specify address to ${action}`);
     process.exit(1);
   } else {
     checkIfAddressIsValid(address, api);


### PR DESCRIPTION
# Description of proposed changes

This PR adds the `--scheme` flag to the send command and some utilities to create Keyrings from ECDSA PKs.

---
Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
