### PR TITLE
CSUB-556: Add Status check to Withdraw Unbonded command

### DIFF
--- a/scripts/cc-cli/src/commands/withdrawUnbonded.ts
+++ b/scripts/cc-cli/src/commands/withdrawUnbonded.ts
@@ -20,7 +20,7 @@ async function withdrawUnbondedAction(options: OptionValues) {
   const controllerSeed = await getControllerSeedFromEnvOrPrompt();
   const controller = initKeyringPair(controllerSeed);
 
-  let status = await getStatus(controller.address, api);
+  const status = await getStatus(controller.address, api);
   requireStatus(
     status,
     "canWithdraw",

--- a/scripts/cc-cli/src/commands/withdrawUnbonded.ts
+++ b/scripts/cc-cli/src/commands/withdrawUnbonded.ts
@@ -1,5 +1,6 @@
 import { Command, OptionValues } from "commander";
 import { newApi } from "../api";
+import { getStatus, requireStatus } from "../utils/status";
 import {
   getControllerSeedFromEnvOrPrompt,
   initKeyringPair,
@@ -18,6 +19,14 @@ async function withdrawUnbondedAction(options: OptionValues) {
 
   const controllerSeed = await getControllerSeedFromEnvOrPrompt();
   const controller = initKeyringPair(controllerSeed);
+
+  let status = await getStatus(controller.address, api);
+  requireStatus(
+    status,
+    "canWithdraw",
+    "Cannot perform action, there are no unlocked funds to withdraw"
+  );
+
   const slashingSpans = await api.query.staking.slashingSpans(
     controller.address
   );

--- a/scripts/cc-cli/src/commands/withdrawUnbonded.ts
+++ b/scripts/cc-cli/src/commands/withdrawUnbonded.ts
@@ -22,7 +22,9 @@ async function withdrawUnbondedAction(options: OptionValues) {
   const controllerStatus = await getStatus(controller.address, api);
 
   if (!controllerStatus.stash) {
-    console.error(`Cannot withdraw, ${controller.address} is not staked`);
+    console.error(
+      `Could not find stash account associated with the provided controller address: ${controller.address}. Please ensure the address is actually a controller.`
+    );
     process.exit(1);
   }
 

--- a/scripts/cc-cli/src/commands/withdrawUnbonded.ts
+++ b/scripts/cc-cli/src/commands/withdrawUnbonded.ts
@@ -9,7 +9,6 @@ import {
 export function makeWithdrawUnbondedCommand() {
   const cmd = new Command("withdraw-unbonded");
   cmd.description("Withdraw unbonded funds from a stash account");
-  cmd.option("-a, --amount [amount]", "Amount to withdraw");
   cmd.action(withdrawUnbondedAction);
   return cmd;
 }
@@ -20,7 +19,14 @@ async function withdrawUnbondedAction(options: OptionValues) {
   const controllerSeed = await getControllerSeedFromEnvOrPrompt();
   const controller = initKeyringPair(controllerSeed);
 
-  const status = await getStatus(controller.address, api);
+  const controllerStatus = await getStatus(controller.address, api);
+
+  if (!controllerStatus.stash) {
+    console.error(`Cannot withdraw, ${controller.address} is not staked`);
+    process.exit(1);
+  }
+
+  const status = await getStatus(controllerStatus.stash, api);
   requireStatus(
     status,
     "canWithdraw",

--- a/scripts/cc-cli/src/utils/status.ts
+++ b/scripts/cc-cli/src/utils/status.ts
@@ -103,7 +103,12 @@ export async function printValidatorStatus(status: Status, api: ApiPromise) {
 
   console.log("Can withdraw: ", status.canWithdraw);
   if (status.canWithdraw) {
-    console.log("Unlocking chunks: ", status.readyForWithdraw);
+    console.log("Unlocked chunks: ");
+    status.readyForWithdraw.forEach((chunk) => {
+      console.log(
+        `  ${toCTCString(chunk.value)} unlocked since era ${chunk.era}`
+      );
+    });
   }
 
   let nextUnlocking = "None";

--- a/scripts/cc-cli/src/utils/status.ts
+++ b/scripts/cc-cli/src/utils/status.ts
@@ -124,10 +124,16 @@ export async function printValidatorStatus(status: Status, api: ApiPromise) {
   console.log(`Next unbonding chunk: ${nextUnlocking}`);
 }
 
-export function requireStatus(status: Status, condition: keyof Status) {
+export function requireStatus(
+  status: Status,
+  condition: keyof Status,
+  message?: string
+) {
   if (!status[condition]) {
     console.error(
-      `Cannot perform action, validator is not ${condition.toString()}`
+      message
+        ? message
+        : `Cannot perform action, validator is not ${condition.toString()}`
     );
     process.exit(1);
   }


### PR DESCRIPTION
# Description of proposed changes

- Added `canWithdraw` field to `Status`
- Reformatted how `printStatus` shows unlocked chunks
- `withdraw-unbonded` command now checks if there are unlocked funds before submitting the extrinstic

---
Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
