### PR TITLE
CSUB-573: Check if transactions fail or succeed before exiting

### DIFF
--- a/scripts/cc-cli/src/commands/chill.ts
+++ b/scripts/cc-cli/src/commands/chill.ts
@@ -35,8 +35,8 @@ async function chillAction(options: OptionValues) {
 
   console.log("Creating chill transaction...");
 
-  const chillTxHash = await chill(controllerSeed, api);
+  const result = await chill(controllerSeed, api);
 
-  console.log("Chill transaction sent with hash:", chillTxHash.toHex());
+  console.log(result.info);
   process.exit(0);
 }

--- a/scripts/cc-cli/src/commands/distributeRewards.ts
+++ b/scripts/cc-cli/src/commands/distributeRewards.ts
@@ -4,6 +4,7 @@ import {
   getCallerSeedFromEnvOrPrompt,
   initKeyringPair,
 } from "../utils/account";
+import { signSendAndWatch } from "../utils/tx";
 
 export function makeDistributeRewardsCommand() {
   const cmd = new Command("distribute-rewards");
@@ -37,8 +38,12 @@ async function distributeRewardsAction(options: OptionValues) {
     options.era
   );
 
-  const hash = await distributeTx.signAndSend(initKeyringPair(callerSeed));
+  const result = await signSendAndWatch(
+    distributeTx,
+    api,
+    initKeyringPair(callerSeed)
+  );
 
-  console.log("Payout stakers transaction sent with hash:", hash.toHex());
+  console.log(result.info);
   process.exit(0);
 }

--- a/scripts/cc-cli/src/commands/send.ts
+++ b/scripts/cc-cli/src/commands/send.ts
@@ -8,6 +8,7 @@ import {
   initKeyringPair,
 } from "../utils/account";
 import { getBalance, parseCTCString } from "../utils/balance";
+import { signSendAndWatch } from "../utils/tx";
 
 export function makeSendCommand() {
   const cmd = new Command("send");
@@ -45,6 +46,7 @@ async function sendAction(options: OptionValues) {
 
   console.log("Transfer transaction hash: " + hash.toHex());
 
+  /// TODO: this needs to be fixed
   process.exit(0);
 }
 

--- a/scripts/cc-cli/src/commands/send.ts
+++ b/scripts/cc-cli/src/commands/send.ts
@@ -42,9 +42,8 @@ async function sendAction(options: OptionValues) {
 
   const tx = api.tx.balances.transfer(recipient, amount.toString());
 
-  const hash = await tx.signAndSend(caller);
-
-  console.log("Transfer transaction hash: " + hash.toHex());
+  const result = await signSendAndWatch(tx, api, caller);
+  console.log(result.info);
 
   /// TODO: this needs to be fixed
   process.exit(0);
@@ -79,7 +78,7 @@ async function sendFromSr25519(options: OptionValues, api: ApiPromise) {
   // Send transaction
   const tx = api.tx.balances.transfer(
     options.to,
-    toMicrounits(options.amount).toString()
+    parseCTCString(options.amount).toString()
   );
 
   const result = await signSendAndWatch(tx, api, caller);
@@ -90,13 +89,12 @@ async function sendFromECDSA(options: OptionValues, api: ApiPromise) {
   // Build account
   const callerSeed = await getCallerSeedFromEnvOrPrompt();
   const caller = initECDSAKeyringPairFromPK(callerSeed);
-  console.log(caller.address);
 
   // Send transaction
   const tx = api.tx.balances.transfer(
     options.to,
-    toMicrounits(options.amount).toString()
+    parseCTCString(options.amount).toString()
   );
-  const hash = await tx.signAndSend(caller);
-  return hash;
+  const result = signSendAndWatch(tx, api, caller);
+  return result;
 }

--- a/scripts/cc-cli/src/commands/send.ts
+++ b/scripts/cc-cli/src/commands/send.ts
@@ -69,32 +69,3 @@ async function checkEnoughFundsToSend(
     process.exit(1);
   }
 }
-
-async function sendFromSr25519(options: OptionValues, api: ApiPromise) {
-  // Build account
-  const callerSeed = await getCallerSeedFromEnvOrPrompt();
-  const caller = initKeyringPair(callerSeed);
-
-  // Send transaction
-  const tx = api.tx.balances.transfer(
-    options.to,
-    parseCTCString(options.amount).toString()
-  );
-
-  const result = await signSendAndWatch(tx, api, caller);
-  return result;
-}
-
-async function sendFromECDSA(options: OptionValues, api: ApiPromise) {
-  // Build account
-  const callerSeed = await getCallerSeedFromEnvOrPrompt();
-  const caller = initECDSAKeyringPairFromPK(callerSeed);
-
-  // Send transaction
-  const tx = api.tx.balances.transfer(
-    options.to,
-    parseCTCString(options.amount).toString()
-  );
-  const result = signSendAndWatch(tx, api, caller);
-  return result;
-}

--- a/scripts/cc-cli/src/commands/send.ts
+++ b/scripts/cc-cli/src/commands/send.ts
@@ -70,3 +70,33 @@ async function checkEnoughFundsToSend(
     process.exit(1);
   }
 }
+
+async function sendFromSr25519(options: OptionValues, api: ApiPromise) {
+  // Build account
+  const callerSeed = await getCallerSeedFromEnvOrPrompt();
+  const caller = initKeyringPair(callerSeed);
+
+  // Send transaction
+  const tx = api.tx.balances.transfer(
+    options.to,
+    toMicrounits(options.amount).toString()
+  );
+
+  const result = await signSendAndWatch(tx, api, caller);
+  return result;
+}
+
+async function sendFromECDSA(options: OptionValues, api: ApiPromise) {
+  // Build account
+  const callerSeed = await getCallerSeedFromEnvOrPrompt();
+  const caller = initECDSAKeyringPairFromPK(callerSeed);
+  console.log(caller.address);
+
+  // Send transaction
+  const tx = api.tx.balances.transfer(
+    options.to,
+    toMicrounits(options.amount).toString()
+  );
+  const hash = await tx.signAndSend(caller);
+  return hash;
+}

--- a/scripts/cc-cli/src/commands/setKeys.ts
+++ b/scripts/cc-cli/src/commands/setKeys.ts
@@ -4,6 +4,7 @@ import {
   getControllerSeedFromEnvOrPrompt,
   initKeyringPair,
 } from "../utils/account";
+import { signSendAndWatch } from "../utils/tx";
 
 export function makeSetKeysCommand() {
   const cmd = new Command("set-keys");
@@ -35,9 +36,9 @@ async function setKeysAction(options: OptionValues) {
   }
 
   const tx = api.tx.session.setKeys(keys, "");
-  const hash = await tx.signAndSend(controller);
+  const result = await signSendAndWatch(tx, api, controller);
 
-  console.log("Set keys transaction hash: " + hash.toHex());
+  console.log(result.info);
 
   process.exit(0);
 }

--- a/scripts/cc-cli/src/commands/unbond.ts
+++ b/scripts/cc-cli/src/commands/unbond.ts
@@ -9,6 +9,7 @@ import { getStatus, requireStatus } from "../utils/status";
 import {signSendAndWatch} from "../utils/tx";
 import { ApiPromise, BN } from "creditcoin-js";
 import { promptContinue } from "../utils/promptContinue";
+import { signSendAndWatch } from "../utils/tx";
 
 export function makeUnbondCommand() {
   const cmd = new Command("unbond");
@@ -46,7 +47,8 @@ async function unbondAction(options: OptionValues) {
   const tx = api.tx.staking.unbond(amount.toString());
 
   const result = await signSendAndWatch(tx, api, controllerKeyring);
-  console.log(`Unbond Result: ${JSON.stringify(result)}`);
+
+  console.log(result.info);
   process.exit(0);
 }
 

--- a/scripts/cc-cli/src/commands/unbond.ts
+++ b/scripts/cc-cli/src/commands/unbond.ts
@@ -6,7 +6,7 @@ import {
 } from "../utils/account";
 import { getBalance, parseCTCString } from "../utils/balance";
 import { getStatus, requireStatus } from "../utils/status";
-import {signSendAndWatch} from "../utils/tx";
+import { signSendAndWatch } from "../utils/tx";
 import { ApiPromise, BN } from "creditcoin-js";
 import { promptContinue } from "../utils/promptContinue";
 import { toCTCString } from "../utils/balance";

--- a/scripts/cc-cli/src/commands/unbond.ts
+++ b/scripts/cc-cli/src/commands/unbond.ts
@@ -6,6 +6,7 @@ import {
 } from "../utils/account";
 import { getBalance, parseCTCString } from "../utils/balance";
 import { getStatus, requireStatus } from "../utils/status";
+import {signSendAndWatch} from "../utils/tx";
 import { ApiPromise, BN } from "creditcoin-js";
 import { promptContinue } from "../utils/promptContinue";
 
@@ -44,9 +45,8 @@ async function unbondAction(options: OptionValues) {
   // Unbond transaction
   const tx = api.tx.staking.unbond(amount.toString());
 
-  const hash = await tx.signAndSend(controllerKeyring);
-
-  console.log("Unbond transaction hash: " + hash.toHex());
+  const result = await signSendAndWatch(tx, api, controllerKeyring);
+  console.log(`Unbond Result: ${JSON.stringify(result)}`);
   process.exit(0);
 }
 

--- a/scripts/cc-cli/src/commands/unbond.ts
+++ b/scripts/cc-cli/src/commands/unbond.ts
@@ -9,7 +9,6 @@ import { getStatus, requireStatus } from "../utils/status";
 import {signSendAndWatch} from "../utils/tx";
 import { ApiPromise, BN } from "creditcoin-js";
 import { promptContinue } from "../utils/promptContinue";
-import { signSendAndWatch } from "../utils/tx";
 
 export function makeUnbondCommand() {
   const cmd = new Command("unbond");

--- a/scripts/cc-cli/src/commands/unbond.ts
+++ b/scripts/cc-cli/src/commands/unbond.ts
@@ -9,6 +9,7 @@ import { getStatus, requireStatus } from "../utils/status";
 import {signSendAndWatch} from "../utils/tx";
 import { ApiPromise, BN } from "creditcoin-js";
 import { promptContinue } from "../utils/promptContinue";
+import { toCTCString } from "../utils/balance";
 
 export function makeUnbondCommand() {
   const cmd = new Command("unbond");
@@ -43,7 +44,7 @@ async function unbondAction(options: OptionValues) {
   await checkIfUnbodingMax(controllerAddress, amount, api);
 
   // Unbond transaction
-  const tx = api.tx.staking.unbond(amount.toString());
+  const tx = api.tx.staking.unbond(toCTCString(options.amount).toString());
 
   const result = await signSendAndWatch(tx, api, controllerKeyring);
 

--- a/scripts/cc-cli/src/commands/validate.ts
+++ b/scripts/cc-cli/src/commands/validate.ts
@@ -32,8 +32,8 @@ async function validateAction(options: OptionValues) {
 
   console.log("Creating validate transaction...");
 
-  const validateTxHash = await validate(controllerSeed, preferences, api);
+  const result = await validate(controllerSeed, preferences, api);
 
-  console.log("Validate transaction sent with hash:", validateTxHash.toHex());
+  console.log(result.info);
   process.exit(0);
 }

--- a/scripts/cc-cli/src/commands/withdrawUnbonded.ts
+++ b/scripts/cc-cli/src/commands/withdrawUnbonded.ts
@@ -5,6 +5,7 @@ import {
   getControllerSeedFromEnvOrPrompt,
   initKeyringPair,
 } from "../utils/account";
+import { signSendAndWatch } from "../utils/tx";
 
 export function makeWithdrawUnbondedCommand() {
   const cmd = new Command("withdraw-unbonded");
@@ -42,8 +43,8 @@ async function withdrawUnbondedAction(options: OptionValues) {
     ? slashingSpans.unwrap().lastNonzeroSlash
     : 0;
   const withdrawUnbondTx = api.tx.staking.withdrawUnbonded(slashingSpansCount);
-  const hash = await withdrawUnbondTx.signAndSend(controller);
+  const result = await signSendAndWatch(withdrawUnbondTx, api, controller);
 
-  console.log("Withdraw unbonded transaction sent with hash:", hash.toHex());
+  console.log(result.info);
   process.exit(0);
 }

--- a/scripts/cc-cli/src/commands/wizard.ts
+++ b/scripts/cc-cli/src/commands/wizard.ts
@@ -18,7 +18,6 @@ import { bond, parseRewardDestination } from "../utils/bond";
 import { perbillFromPercent, percentFromPerbill } from "../utils/perbill";
 import { promptContinue, promptContinueOrSkip } from "../utils/promptContinue";
 import { StakingPalletValidatorPrefs } from "../utils/validate";
-import { BN } from "creditcoin-js";
 import { TxStatus, signSendAndWatch } from "../utils/tx";
 
 export function makeWizardCommand() {

--- a/scripts/cc-cli/src/utils/bond.ts
+++ b/scripts/cc-cli/src/utils/bond.ts
@@ -1,6 +1,7 @@
 import { ApiPromise, BN } from "creditcoin-js";
 import { initKeyringPair } from "./account";
 import { MICROUNITS_PER_CTC } from "./balance";
+import { signSendAndWatch } from "./tx";
 
 export async function bond(
   stashSeed: string,
@@ -30,9 +31,9 @@ export async function bond(
 
   const stashKeyring = initKeyringPair(stashSeed);
 
-  const hash = await bondTx.signAndSend(stashKeyring);
+  const result = await signSendAndWatch(bondTx, api, stashKeyring);
 
-  return hash.toHex();
+  return result;
 }
 
 export function parseRewardDestination(

--- a/scripts/cc-cli/src/utils/tx.ts
+++ b/scripts/cc-cli/src/utils/tx.ts
@@ -8,7 +8,6 @@ export async function signSendAndWatch(
   api: ApiPromise,
   signer: KeyringPair
 ): Promise<TxResult> {
-
   return new Promise((resolve, reject) => {
     console.log("Sending transaction...");
     let maybeUnsub: (() => void) | undefined;
@@ -48,11 +47,13 @@ export async function signSendAndWatch(
           unsubAndResolve(result);
         }
       }
-    }).then((unsub) => {
-      maybeUnsub = unsub;
-    }).catch((err) => {
-      reject(err)
-    });
+    })
+      .then((unsub) => {
+        maybeUnsub = unsub;
+      })
+      .catch((err) => {
+        reject(err);
+      });
   });
 }
 

--- a/scripts/cc-cli/src/utils/tx.ts
+++ b/scripts/cc-cli/src/utils/tx.ts
@@ -1,0 +1,35 @@
+import { ISubmittableResult } from "@polkadot/types/types";
+import { ApiPromise } from "creditcoin-js";
+
+export function handleTxStatusAndExit(
+  result: ISubmittableResult,
+  api: ApiPromise
+): void {
+  const { status, dispatchError } = result;
+
+  if (status.isFinalized) {
+    console.log(
+      `Transaction succeeded and included at blockHash ${status.asFinalized.toString()}`
+    );
+    process.exit(0);
+  }
+
+  if (dispatchError) {
+    if (dispatchError.isModule) {
+      // for module errors, the section is indexed, lookup
+      const decoded = api.registry.findMetaError(dispatchError.asModule);
+      const { docs, name, section } = decoded;
+
+      const error = `${section}.${name}: ${docs.join(" ")}`;
+
+      console.log(`Transaction failed with error: "${error}"`);
+      process.exit(1);
+    } else {
+      // Other, CannotLookup, BadOrigin, no extra info
+      console.log(
+        `Transaction failed with error: "${dispatchError.toString()}"`
+      );
+      process.exit(1);
+    }
+  }
+}

--- a/scripts/cc-cli/src/utils/tx.ts
+++ b/scripts/cc-cli/src/utils/tx.ts
@@ -9,7 +9,7 @@ export async function signSendAndWatch(
   signer: KeyringPair
 ): Promise<TxResult> {
 
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     console.log("Sending transaction...");
     let maybeUnsub: (() => void) | undefined;
     const unsubAndResolve = (result: TxResult) => {
@@ -50,6 +50,8 @@ export async function signSendAndWatch(
       }
     }).then((unsub) => {
       maybeUnsub = unsub;
+    }).catch((err) => {
+      reject(err)
     });
   });
 }

--- a/scripts/cc-cli/src/utils/tx.ts
+++ b/scripts/cc-cli/src/utils/tx.ts
@@ -14,6 +14,7 @@ export async function signSendAndWatch(
   return new Promise(async (resolve) => {
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
     const out: TxResult = await new Promise(async (resolveInner) => {
+      console.log("Sending transaction...");
       // Sign and send with callback
       await tx.signAndSend(signer, ({ status, dispatchError }) => {
         // Called every time the status changes

--- a/scripts/cc-cli/src/utils/validate.ts
+++ b/scripts/cc-cli/src/utils/validate.ts
@@ -1,5 +1,6 @@
 import { ApiPromise } from "creditcoin-js";
 import { initKeyringPair } from "./account";
+import { signSendAndWatch } from "./tx";
 
 export interface StakingPalletValidatorPrefs {
   // The validator's commission.
@@ -26,10 +27,9 @@ export async function validate(
 
   const validateTx = api.tx.staking.validate(preferences);
 
-  const hash = await validateTx.signAndSend(controller);
+  const result = await signSendAndWatch(validateTx, api, controller);
 
-  console.log(`Validate transaction sent with hash: ${hash.toHex()}`);
-  return hash;
+  return result;
 }
 
 export async function chill(controllerSeed: string, api: ApiPromise) {
@@ -37,7 +37,7 @@ export async function chill(controllerSeed: string, api: ApiPromise) {
 
   const chillTx = api.tx.staking.chill();
 
-  const hash = await chillTx.signAndSend(account);
+  const result = await signSendAndWatch(chillTx, api, account);
 
-  return hash;
+  return result;
 }

--- a/scripts/cc-cli/yarn.lock
+++ b/scripts/cc-cli/yarn.lock
@@ -1893,9 +1893,9 @@ camelcase@^6.2.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001503:
-  version "1.0.30001505"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001505.tgz#10a343e49d31cbbfdae298ef73cb0a9f46670dc5"
-  integrity sha512-jaAOR5zVtxHfL0NjZyflVTtXm3D3J9P15zSJ7HmQF8dSKGA6tqzQq+0ZI3xkjyQj46I4/M0K2GbMpcAFOcbr3A==
+  version "1.0.30001506"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001506.tgz#35bd814b310a487970c585430e9e80ee23faf14b"
+  integrity sha512-6XNEcpygZMCKaufIcgpQNZNf00GEqc7VQON+9Rd0K1bMYo8xhMZRAo5zpbnbMNizi4YNgIDAFrdykWsvY3H4Hw==
 
 chalk@^2.0.0:
   version "2.4.2"
@@ -2119,9 +2119,9 @@ ed2curve@^0.3.0:
     tweetnacl "1.x.x"
 
 electron-to-chromium@^1.4.431:
-  version "1.4.435"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.435.tgz#761c34300603b9f1234f0b6155870d3002435db6"
-  integrity sha512-B0CBWVFhvoQCW/XtjRzgrmqcgVWg6RXOEM/dK59+wFV93BFGR6AeNKc4OyhM+T3IhJaOOG8o/V+33Y2mwJWtzw==
+  version "1.4.438"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.438.tgz#425f0d51862d36f90817d6dfb7fa2a53ff6a0a73"
+  integrity sha512-x94U0FhphEsHsOloCvlsujHCvoir0ZQ73ZAs/QN4PLx98uNvyEU79F75rq1db75Bx/atvuh7KPeuxelh+xfYJw==
 
 elliptic@6.5.4:
   version "6.5.4"


### PR DESCRIPTION
# Description of proposed changes

- Add new `Tx` utility: `signSendAndWatch` to subscribe to transaction status and return its result
- Implement new utility in all commands

---
Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
