### PR TITLE
CSUB-612: Check TX total cost (incl fees) before sending

### DIFF
--- a/scripts/cc-cli/src/commands/distributeRewards.ts
+++ b/scripts/cc-cli/src/commands/distributeRewards.ts
@@ -4,7 +4,7 @@ import {
   getCallerSeedFromEnvOrPrompt,
   initKeyringPair,
 } from "../utils/account";
-import { signSendAndWatch } from "../utils/tx";
+import { requireEnoughFundsToSend, signSendAndWatch } from "../utils/tx";
 import {
   parseAddresOrExit,
   parseIntegerOrExit,
@@ -31,6 +31,8 @@ async function distributeRewardsAction(options: OptionValues) {
   // Any account can call the distribute_rewards extrinsic
   const callerSeed = await getCallerSeedFromEnvOrPrompt();
   const distributeTx = api.tx.staking.payoutStakers(validator, era);
+
+  await requireEnoughFundsToSend(distributeTx, callerSeed, api);
 
   const result = await signSendAndWatch(
     distributeTx,

--- a/scripts/cc-cli/src/commands/setKeys.ts
+++ b/scripts/cc-cli/src/commands/setKeys.ts
@@ -4,7 +4,7 @@ import {
   getControllerSeedFromEnvOrPrompt,
   initKeyringPair,
 } from "../utils/account";
-import { signSendAndWatch } from "../utils/tx";
+import { requireEnoughFundsToSend, signSendAndWatch } from "../utils/tx";
 import { parseHexStringOrExit } from "../utils/parsing";
 
 export function makeSetKeysCommand() {
@@ -42,6 +42,9 @@ async function setKeysAction(options: OptionValues) {
   }
 
   const tx = api.tx.session.setKeys(keys, "");
+
+  await requireEnoughFundsToSend(tx, controllerSeed, api);
+
   const result = await signSendAndWatch(tx, api, controller);
 
   console.log(result.info);

--- a/scripts/cc-cli/src/commands/unbond.ts
+++ b/scripts/cc-cli/src/commands/unbond.ts
@@ -6,7 +6,7 @@ import {
 } from "../utils/account";
 import { getBalance } from "../utils/balance";
 import { getStatus, requireStatus } from "../utils/status";
-import { signSendAndWatch } from "../utils/tx";
+import { requireEnoughFundsToSend, signSendAndWatch } from "../utils/tx";
 import { ApiPromise, BN } from "creditcoin-js";
 import { promptContinue } from "../utils/promptContinue";
 import { parseAmountOrExit, requiredInput } from "../utils/parsing";
@@ -44,6 +44,7 @@ async function unbondAction(options: OptionValues) {
 
   // Unbond transaction
   const tx = api.tx.staking.unbond(amount.toString());
+  await requireEnoughFundsToSend(tx, controllerAddress, api);
 
   const result = await signSendAndWatch(tx, api, controllerKeyring);
 

--- a/scripts/cc-cli/src/commands/withdrawUnbonded.ts
+++ b/scripts/cc-cli/src/commands/withdrawUnbonded.ts
@@ -5,7 +5,7 @@ import {
   getControllerSeedFromEnvOrPrompt,
   initKeyringPair,
 } from "../utils/account";
-import { signSendAndWatch } from "../utils/tx";
+import { requireEnoughFundsToSend, signSendAndWatch } from "../utils/tx";
 
 export function makeWithdrawUnbondedCommand() {
   const cmd = new Command("withdraw-unbonded");
@@ -43,6 +43,9 @@ async function withdrawUnbondedAction(options: OptionValues) {
     ? slashingSpans.unwrap().lastNonzeroSlash
     : 0;
   const withdrawUnbondTx = api.tx.staking.withdrawUnbonded(slashingSpansCount);
+
+  await requireEnoughFundsToSend(withdrawUnbondTx, controller.address, api);
+
   const result = await signSendAndWatch(withdrawUnbondTx, api, controller);
 
   console.log(result.info);

--- a/scripts/cc-cli/src/commands/wizard.ts
+++ b/scripts/cc-cli/src/commands/wizard.ts
@@ -18,7 +18,11 @@ import { bond, checkRewardDestination } from "../utils/bond";
 import { percentFromPerbill } from "../utils/perbill";
 import { promptContinue, promptContinueOrSkip } from "../utils/promptContinue";
 import { StakingPalletValidatorPrefs } from "../utils/validate";
-import { TxStatus, signSendAndWatch } from "../utils/tx";
+import {
+  TxStatus,
+  requireEnoughFundsToSend,
+  signSendAndWatch,
+} from "../utils/tx";
 import {
   inputOrDefault,
   parseAmountOrExit,
@@ -161,6 +165,7 @@ export function makeWizardCommand() {
     const txs = [setKeysTx, validateTx];
 
     const batchTx = api.tx.utility.batchAll(txs);
+    await requireEnoughFundsToSend(batchTx, controllerAddress, api);
 
     const batchResult = await signSendAndWatch(batchTx, api, controllerKeyring);
 

--- a/scripts/cc-cli/src/test/tx.test.ts
+++ b/scripts/cc-cli/src/test/tx.test.ts
@@ -1,0 +1,54 @@
+import { BN } from "creditcoin-js";
+import { AccountBalance } from "../utils/balance";
+import { canPay } from "../utils/tx";
+
+describe("unit test: utils/tx", () => {
+  test("balance can check for negatives", () => {
+    const negOne = new BN(1).sub(new BN(2));
+    expect(negOne.toString()).toStrictEqual("-1");
+  });
+});
+
+describe("unit tests: utils/tx", () => {
+  test("given a payable amount, canPay returns true", () => {
+    const balance: AccountBalance = {
+      address: "fakeAddress",
+      total: new BN(100),
+      bonded: new BN(0),
+      unbonding: new BN(0),
+      transferable: new BN(100),
+      locked: new BN(0),
+    };
+
+    const amountUsedInTx = new BN(10);
+
+    const txFee = new BN(1);
+
+    const totalCost = amountUsedInTx.add(txFee);
+
+    const canPayResult = canPay(balance, totalCost);
+
+    expect(canPayResult).toStrictEqual(true);
+  });
+
+  test("given an unpayable amount, canPay returns false", () => {
+    const balance: AccountBalance = {
+      address: "fakeAddress",
+      total: new BN(100),
+      bonded: new BN(0),
+      unbonding: new BN(0),
+      transferable: new BN(100),
+      locked: new BN(0),
+    };
+
+    const amountUsedInTx = new BN(100);
+
+    const txFee = new BN(1);
+
+    const totalCost = amountUsedInTx.add(txFee);
+
+    const canPayResult = canPay(balance, totalCost);
+
+    expect(canPayResult).toStrictEqual(false);
+  });
+});

--- a/scripts/cc-cli/src/test/tx.test.ts
+++ b/scripts/cc-cli/src/test/tx.test.ts
@@ -2,13 +2,6 @@ import { BN } from "creditcoin-js";
 import { AccountBalance } from "../utils/balance";
 import { canPay } from "../utils/tx";
 
-describe("unit test: utils/tx", () => {
-  test("balance can check for negatives", () => {
-    const negOne = new BN(1).sub(new BN(2));
-    expect(negOne.toString()).toStrictEqual("-1");
-  });
-});
-
 describe("unit tests: utils/tx", () => {
   test("given a payable amount, canPay returns true", () => {
     const balance: AccountBalance = {

--- a/scripts/cc-cli/src/utils/bond.ts
+++ b/scripts/cc-cli/src/utils/bond.ts
@@ -1,7 +1,7 @@
 import { ApiPromise, BN } from "creditcoin-js";
 import { initKeyringPair } from "./account";
 import { MICROUNITS_PER_CTC } from "./balance";
-import { signSendAndWatch } from "./tx";
+import { requireEnoughFundsToSend, signSendAndWatch } from "./tx";
 
 export async function bond(
   stashSeed: string,
@@ -30,6 +30,8 @@ export async function bond(
   }
 
   const stashKeyring = initKeyringPair(stashSeed);
+
+  await requireEnoughFundsToSend(bondTx, stashKeyring.address, api, amount);
 
   const result = await signSendAndWatch(bondTx, api, stashKeyring);
 

--- a/scripts/cc-cli/src/utils/tx.ts
+++ b/scripts/cc-cli/src/utils/tx.ts
@@ -2,7 +2,7 @@ import { ISubmittableResult } from "@polkadot/types/types";
 import { ApiPromise, BN, KeyringPair } from "creditcoin-js";
 
 import { SubmittableExtrinsic } from "@polkadot/api/types";
-import { getBalance } from "./balance";
+import { AccountBalance, getBalance, toCTCString } from "./balance";
 
 export async function signSendAndWatch(
   tx: SubmittableExtrinsic<"promise", ISubmittableResult>,
@@ -84,17 +84,14 @@ export async function getTxFee(
   return fee.partialFee.toBn();
 }
 
-export async function calculateBalanceAfterTx(
-  tx: SubmittableExtrinsic<"promise", ISubmittableResult>,
-  callerAddress: string,
+export function canPay(
+  balance: AccountBalance,
   amount: BN,
-  api: ApiPromise
-): Promise<BN> {
-  const balance = await getBalance(callerAddress, api);
-  const fee = await getTxFee(tx, callerAddress);
+  existentialDeposit = new BN(1)
+) {
   const availableBalance = balance.transferable;
-  const balanceAfterSending = availableBalance.sub(amount).sub(fee);
-  return balanceAfterSending;
+  const availableAfter = availableBalance.sub(amount);
+  return availableAfter.gte(existentialDeposit);
 }
 
 export async function requireEnoughFundsToSend(
@@ -103,15 +100,15 @@ export async function requireEnoughFundsToSend(
   api: ApiPromise,
   amount = new BN(0)
 ) {
-  const balanceAfterSending = await calculateBalanceAfterTx(
-    tx,
-    address,
-    amount,
-    api
-  );
-  if (balanceAfterSending.lt(new BN(1))) {
+  const balance = await getBalance(address, api);
+  const txFee = await getTxFee(tx, address);
+  const totalCost = amount.add(txFee);
+
+  if (!canPay(balance, totalCost)) {
     console.error(
-      `Caller ${address} has insufficient funds to send the transaction and maintain existential deposit; transaction cancelled.`
+      `Caller ${address} has insufficient funds to send the transaction (requires ${toCTCString(
+        totalCost
+      )}); transaction cancelled.`
     );
     process.exit(1);
   }

--- a/scripts/cc-cli/src/utils/tx.ts
+++ b/scripts/cc-cli/src/utils/tx.ts
@@ -100,8 +100,8 @@ export async function calcualteBalanceAfterTx(
 export async function requireEnoughFundsToSend(
   tx: SubmittableExtrinsic<"promise", ISubmittableResult>,
   address: string,
-  amount = new BN(0),
-  api: ApiPromise
+  api: ApiPromise,
+  amount = new BN(0)
 ) {
   const balanceAfterSending = await calcualteBalanceAfterTx(
     tx,

--- a/scripts/cc-cli/src/utils/tx.ts
+++ b/scripts/cc-cli/src/utils/tx.ts
@@ -84,7 +84,7 @@ export async function getTxFee(
   return fee.partialFee.toBn();
 }
 
-export async function calcualteBalanceAfterTx(
+export async function calculateBalanceAfterTx(
   tx: SubmittableExtrinsic<"promise", ISubmittableResult>,
   callerAddress: string,
   amount: BN,

--- a/scripts/cc-cli/src/utils/tx.ts
+++ b/scripts/cc-cli/src/utils/tx.ts
@@ -103,7 +103,7 @@ export async function requireEnoughFundsToSend(
   api: ApiPromise,
   amount = new BN(0)
 ) {
-  const balanceAfterSending = await calcualteBalanceAfterTx(
+  const balanceAfterSending = await calculateBalanceAfterTx(
     tx,
     address,
     amount,

--- a/scripts/cc-cli/src/utils/tx.ts
+++ b/scripts/cc-cli/src/utils/tx.ts
@@ -92,7 +92,7 @@ export async function calculateBalanceAfterTx(
 ): Promise<BN> {
   const balance = await getBalance(callerAddress, api);
   const fee = await getTxFee(tx, callerAddress);
-  const availableBalance = balance.free.sub(balance.miscFrozen);
+  const availableBalance = balance.transferable;
   const balanceAfterSending = availableBalance.sub(amount).sub(fee);
   return balanceAfterSending;
 }

--- a/scripts/cc-cli/src/utils/validate.ts
+++ b/scripts/cc-cli/src/utils/validate.ts
@@ -1,6 +1,6 @@
 import { ApiPromise } from "creditcoin-js";
 import { initKeyringPair } from "./account";
-import { signSendAndWatch } from "./tx";
+import { requireEnoughFundsToSend, signSendAndWatch } from "./tx";
 
 export interface StakingPalletValidatorPrefs {
   // The validator's commission.
@@ -27,6 +27,8 @@ export async function validate(
 
   const validateTx = api.tx.staking.validate(preferences);
 
+  await requireEnoughFundsToSend(validateTx, controller.address, api);
+
   const result = await signSendAndWatch(validateTx, api, controller);
 
   return result;
@@ -36,6 +38,8 @@ export async function chill(controllerSeed: string, api: ApiPromise) {
   const account = initKeyringPair(controllerSeed);
 
   const chillTx = api.tx.staking.chill();
+
+  await requireEnoughFundsToSend(chillTx, account.address, api);
 
   const result = await signSendAndWatch(chillTx, api, account);
 


### PR DESCRIPTION
# Description of proposed changes

This PR introduces some utils for checking TX fees. The main one is `requireEnoughFundsToSend` which calculates the account balance after sending the transaction and checks if it's able to maintain the existential deposit (1 CTC). It also implements it in all commands that submit extrinsics.

---
Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
