### PR TITLE
CSUB-571: Rename Balance fields & add --json flag

### DIFF
--- a/scripts/cc-cli/package.json
+++ b/scripts/cc-cli/package.json
@@ -23,6 +23,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "cli-table3": "^0.6.3",
     "commander": "^11.0.0",
     "creditcoin-js": "file:../../creditcoin-js/creditcoin-js-v0.9.5.tgz",
     "prompts": "^2.4.2"

--- a/scripts/cc-cli/src/commands/balance.ts
+++ b/scripts/cc-cli/src/commands/balance.ts
@@ -1,17 +1,23 @@
 import { Command, OptionValues } from "commander";
 import { newApi } from "../api";
-import { getBalance, printBalance } from "../utils/balance";
-import { parseAddresOrExit, requiredInput } from "../utils/parsing";
+import { getBalance, logBalance } from "../utils/balance";
+import {
+  parseAddresOrExit,
+  parseBoolean,
+  requiredInput,
+} from "../utils/parsing";
 
 export function makeBalanceCommand() {
   const cmd = new Command("balance");
   cmd.description("Get balance of an account");
   cmd.option("-a, --address [address]", "Specify address to get balance of");
+  cmd.option("--json", "Output as JSON");
   cmd.action(balanceAction);
   return cmd;
 }
 
 async function balanceAction(options: OptionValues) {
+  const json = parseBoolean(options.json);
   const { api } = await newApi(options.url);
 
   const address = parseAddresOrExit(
@@ -22,7 +28,7 @@ async function balanceAction(options: OptionValues) {
   );
 
   const balance = await getBalance(address, api);
-  printBalance(balance);
+  logBalance(balance, !json);
 
   process.exit(0);
 }

--- a/scripts/cc-cli/src/commands/bond.ts
+++ b/scripts/cc-cli/src/commands/bond.ts
@@ -78,11 +78,10 @@ async function checkBalance(amount: BN, api: any, address: string) {
 }
 
 function checkBalanceAgainstBondAmount(balance: AccountBalance, amount: BN) {
-  const available = balance.free.sub(balance.miscFrozen);
-  if (available.lt(amount)) {
+  if (balance.transferable.lt(amount)) {
     console.error(
       `Insufficient funds to bond ${toCTCString(amount)}, only ${toCTCString(
-        available
+        balance.transferable
       )} available`
     );
     process.exit(1);

--- a/scripts/cc-cli/src/commands/bond.ts
+++ b/scripts/cc-cli/src/commands/bond.ts
@@ -4,7 +4,7 @@ import { getStashSeedFromEnvOrPrompt, initKeyringPair } from "../utils/account";
 import { bond, checkRewardDestination } from "../utils/bond";
 import { promptContinue } from "../utils/promptContinue";
 import {
-  Balance,
+  AccountBalance,
   getBalance,
   toCTCString,
   checkAmount,
@@ -77,7 +77,7 @@ async function checkBalance(amount: BN, api: any, address: string) {
   checkBalanceAgainstBondAmount(balance, amount);
 }
 
-function checkBalanceAgainstBondAmount(balance: Balance, amount: BN) {
+function checkBalanceAgainstBondAmount(balance: AccountBalance, amount: BN) {
   const available = balance.free.sub(balance.miscFrozen);
   if (available.lt(amount)) {
     console.error(

--- a/scripts/cc-cli/src/commands/bond.ts
+++ b/scripts/cc-cli/src/commands/bond.ts
@@ -59,7 +59,7 @@ async function bondAction(options: OptionValues) {
 
   await promptContinue();
 
-  const bondTxHash = await bond(
+  const bondTxResult = await bond(
     stashSeed,
     controller,
     amount,
@@ -68,7 +68,7 @@ async function bondAction(options: OptionValues) {
     extra
   );
 
-  console.log("Bond transaction sent with hash:", bondTxHash);
+  console.log(bondTxResult.info);
   process.exit(0);
 }
 

--- a/scripts/cc-cli/src/commands/send.ts
+++ b/scripts/cc-cli/src/commands/send.ts
@@ -68,7 +68,7 @@ async function checkEnoughFundsToSend(
   api: ApiPromise
 ) {
   const balance = await getBalance(address, api);
-  if (balance.free.sub(balance.miscFrozen).lt(amount)) {
+  if (balance.transferable.lt(amount)) {
     console.log(
       `Caller ${address} has insufficient funds to send ${amount.toString()}`
     );

--- a/scripts/cc-cli/src/commands/unbond.ts
+++ b/scripts/cc-cli/src/commands/unbond.ts
@@ -57,7 +57,7 @@ async function checkIfUnbodingMax(
   api: ApiPromise
 ) {
   const balance = await getBalance(address, api);
-  if (balance.miscFrozen.lt(unbondAmount)) {
+  if (balance.bonded.lt(unbondAmount)) {
     console.error(
       "Warning: amount specified exceeds total bonded funds, will unbond all funds"
     );

--- a/scripts/cc-cli/src/commands/wizard.ts
+++ b/scripts/cc-cli/src/commands/wizard.ts
@@ -7,7 +7,7 @@ import {
   initKeyringPair,
 } from "../utils/account";
 import {
-  Balance,
+  AccountBalance,
   getBalance,
   parseCTCString,
   printBalance,
@@ -175,7 +175,11 @@ export function makeWizardCommand() {
   return cmd;
 }
 
-function checkControllerBalance(address: string, balance: Balance, amount: BN) {
+function checkControllerBalance(
+  address: string,
+  balance: AccountBalance,
+  amount: BN
+) {
   if (balance.free.lt(amount)) {
     console.log(
       "Controller account does not have enough funds to pay transaction fees"
@@ -190,7 +194,11 @@ function checkControllerBalance(address: string, balance: Balance, amount: BN) {
   }
 }
 
-function checkStashBalance(address: string, balance: Balance, amount: BN) {
+function checkStashBalance(
+  address: string,
+  balance: AccountBalance,
+  amount: BN
+) {
   if (balance.free.sub(balance.miscFrozen).lt(amount)) {
     console.log(
       `Stash account does not have enough funds to bond ${toCTCString(amount)}`
@@ -201,7 +209,7 @@ function checkStashBalance(address: string, balance: Balance, amount: BN) {
   }
 }
 
-function checkIfAlreadyBonded(balance: Balance) {
+function checkIfAlreadyBonded(balance: AccountBalance) {
   if (balance.miscFrozen.gt(new BN(0))) {
     return true;
   } else {

--- a/scripts/cc-cli/src/commands/wizard.ts
+++ b/scripts/cc-cli/src/commands/wizard.ts
@@ -180,7 +180,7 @@ function checkControllerBalance(
   balance: AccountBalance,
   amount: BN
 ) {
-  if (balance.free.lt(amount)) {
+  if (balance.transferable.lt(amount)) {
     console.log(
       "Controller account does not have enough funds to pay transaction fees"
     );
@@ -199,7 +199,7 @@ function checkStashBalance(
   balance: AccountBalance,
   amount: BN
 ) {
-  if (balance.free.sub(balance.miscFrozen).lt(amount)) {
+  if (balance.transferable.lt(amount)) {
     console.log(
       `Stash account does not have enough funds to bond ${toCTCString(amount)}`
     );
@@ -210,7 +210,7 @@ function checkStashBalance(
 }
 
 function checkIfAlreadyBonded(balance: AccountBalance) {
-  if (balance.miscFrozen.gt(new BN(0))) {
+  if (balance.bonded.gt(new BN(0))) {
     return true;
   } else {
     return false;

--- a/scripts/cc-cli/src/utils/balance.ts
+++ b/scripts/cc-cli/src/utils/balance.ts
@@ -79,9 +79,12 @@ function calcUnbonding(stakingInfo?: DeriveStakingAccount) {
         value.gt(new BN(0)) && remainingEras.gt(new BN(0))
     )
     .map((unlock) => unlock.value);
-  const total = filtered.reduce((total, value) => total.iadd(value), new BN(0));
+  const unbonding = filtered.reduce(
+    (total, value) => total.iadd(value),
+    new BN(0)
+  );
 
-  return total;
+  return unbonding;
 }
 
 export function logBalance(balance: AccountBalance, human = true) {

--- a/scripts/cc-cli/src/utils/balance.ts
+++ b/scripts/cc-cli/src/utils/balance.ts
@@ -27,7 +27,7 @@ export function readAmountFromHex(amount: string): BN {
   return new BN(amount.slice(2), 16);
 }
 
-export interface Balance {
+export interface AccountBalance {
   free: BN;
   reserved: BN;
   miscFrozen: BN;
@@ -39,7 +39,7 @@ export async function getBalance(address: string, api: any) {
   return balanceFromData(account.data);
 }
 
-function balanceFromData(data: any): Balance {
+function balanceFromData(data: any): AccountBalance {
   return {
     free: data.free,
     reserved: data.reserved,
@@ -48,7 +48,7 @@ function balanceFromData(data: any): Balance {
   };
 }
 
-export function printBalance(balance: Balance) {
+export function printBalance(balance: AccountBalance) {
   console.log("Available:", toCTCString(balance.free.sub(balance.miscFrozen)));
   console.log("Free:", toCTCString(balance.free));
   console.log("Reserved:", toCTCString(balance.reserved));

--- a/scripts/cc-cli/yarn.lock
+++ b/scripts/cc-cli/yarn.lock
@@ -322,6 +322,11 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@colors/colors@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
+  integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
+
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
@@ -1933,6 +1938,15 @@ cjs-module-lexer@^1.0.0:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz#6c370ab19f8a3394e318fe682686ec0ac684d107"
   integrity sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==
+
+cli-table3@^0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.6.3.tgz#61ab765aac156b52f222954ffc607a6f01dbeeb2"
+  integrity sha512-w5Jac5SykAeZJKntOxJCrm63Eg5/4dhMWIcuTbo9rpE+brgaSZo0RuNJZeOyMgsUdhDeojvgyQLmjI+K50ZGyg==
+  dependencies:
+    string-width "^4.2.0"
+  optionalDependencies:
+    "@colors/colors" "1.5.0"
 
 cliui@^8.0.1:
   version "8.0.1"


### PR DESCRIPTION
# Description of proposed changes

This PR switches the Balance type to better represent funds on-chain and adds some minor improvements to the Balance command.

- Balance was renamed to AccountBalance (there is a Balance type in creditcoin-js to represent amounts)

- AccountBalance fields are now closer to the user than the current data from the API (also more in sync with the polkadot-js-apps UI representation):
  - `transferable`: spendable funds
  - `bonded`: funds locked by the staking system that are active (not unbonding)
  - `locked`: the total locked balance (any locked funds, including bonded CTC)
  - `total`: the total balance in the account (including reserved CTC)
  - `unbonding`: tokens waiting for the unbonding period to end

- Old field's information is included in the new ones:
  - `free` and `reserved` are included in `total`
  - `available` is now `transferable`
  - `miscFrozen` was replaced with `bonded` which better represents staking data
  - `feeFrozen` was removed as a stand alone field but it is included in `locked`

- Refactored `printBalance`, now using `logBalance` in the `balance` command, which calls either `jsonBalance` or `printBalance` by checking the `--json` flag
- `printBalance` now prints a table

---
Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
