### PR TITLE
Fix: Change invalid controller error in unbond command

### DIFF
--- a/scripts/cc-cli/src/commands/unbond.ts
+++ b/scripts/cc-cli/src/commands/unbond.ts
@@ -33,7 +33,9 @@ async function unbondAction(options: OptionValues) {
 
   const controllerStatus = await getStatus(controllerAddress, api);
   if (!controllerStatus.stash) {
-    console.error(`Cannot unbond, ${controllerAddress} is not staked`);
+    console.error(
+      `Cannot unbond, ${controllerAddress} is not a controller account`
+    );
     process.exit(1);
   }
   const stashStatus = await getStatus(controllerStatus.stash, api);


### PR DESCRIPTION
# Description of proposed changes

Simple change to the error message to make it clear that the account introduced should be the controller, not the stash.

---
Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
