### PR TITLE
CSUB-617: Check era is valid before distributing rewards

### DIFF
--- a/scripts/cc-cli/src/commands/distributeRewards.ts
+++ b/scripts/cc-cli/src/commands/distributeRewards.ts
@@ -68,5 +68,12 @@ function parseOptions(options: OptionValues) {
     )
   );
 
+  if (era < 0) {
+    console.error(
+      `Failed to distribute rewards: Era ${era} is invalid; must be a positive integer`
+    );
+    process.exit(1);
+  }
+
   return { validator, era };
 }

--- a/scripts/cc-cli/src/commands/distributeRewards.ts
+++ b/scripts/cc-cli/src/commands/distributeRewards.ts
@@ -32,7 +32,7 @@ async function distributeRewardsAction(options: OptionValues) {
   const eraIsValid = await checkEraIsInHistory(era, api);
   if (!eraIsValid) {
     console.error(
-      `Failed to distribute rewards: Era ${era} is not included in history; only the past 84 eras are elegible`
+      `Failed to distribute rewards: Era ${era} is not included in history; only the past 84 eras are eligible`
     );
     process.exit(1);
   }

--- a/scripts/cc-cli/src/test/era.test.ts
+++ b/scripts/cc-cli/src/test/era.test.ts
@@ -1,0 +1,19 @@
+import { eraIsInHistory } from "../utils/era";
+
+describe("eraIsInHistory", () => {
+  it("should return false when checking the current era", () => {
+    expect(eraIsInHistory(1, 84, 1)).toBe(false);
+  });
+
+  it("should return true when checking the previous era", () => {
+    expect(eraIsInHistory(1, 84, 2)).toBe(true);
+  });
+
+  it("should return false when checking anera past the history depth", () => {
+    expect(eraIsInHistory(1, 84, 86)).toBe(false);
+  });
+
+  it("should return false when checking an era in the future", () => {
+    expect(eraIsInHistory(2, 84, 1)).toBe(false);
+  });
+});

--- a/scripts/cc-cli/src/test/era.test.ts
+++ b/scripts/cc-cli/src/test/era.test.ts
@@ -11,7 +11,7 @@ describe("eraIsInHistory", () => {
     expect(eraIsInHistory(1, historyDepth, 2)).toBe(true);
   });
 
-  it("should return false when checking anera past the history depth", () => {
+  it("should return false when checking an era past the history depth", () => {
     expect(eraIsInHistory(1, historyDepth, 86)).toBe(false);
   });
 

--- a/scripts/cc-cli/src/test/era.test.ts
+++ b/scripts/cc-cli/src/test/era.test.ts
@@ -1,19 +1,21 @@
 import { eraIsInHistory } from "../utils/era";
 
+const historyDepth = 84;
+
 describe("eraIsInHistory", () => {
   it("should return false when checking the current era", () => {
-    expect(eraIsInHistory(1, 84, 1)).toBe(false);
+    expect(eraIsInHistory(1, historyDepth, 1)).toBe(false);
   });
 
   it("should return true when checking the previous era", () => {
-    expect(eraIsInHistory(1, 84, 2)).toBe(true);
+    expect(eraIsInHistory(1, historyDepth, 2)).toBe(true);
   });
 
   it("should return false when checking anera past the history depth", () => {
-    expect(eraIsInHistory(1, 84, 86)).toBe(false);
+    expect(eraIsInHistory(1, historyDepth, 86)).toBe(false);
   });
 
   it("should return false when checking an era in the future", () => {
-    expect(eraIsInHistory(2, 84, 1)).toBe(false);
+    expect(eraIsInHistory(2, historyDepth, 1)).toBe(false);
   });
 });

--- a/scripts/cc-cli/src/test/era.test.ts
+++ b/scripts/cc-cli/src/test/era.test.ts
@@ -18,4 +18,8 @@ describe("eraIsInHistory", () => {
   it("should return false when checking an era in the future", () => {
     expect(eraIsInHistory(2, historyDepth, 1)).toBe(false);
   });
+
+  it("should return false if era is negative", () => {
+    expect(eraIsInHistory(-1, historyDepth, 1)).toBe(false);
+  });
 });

--- a/scripts/cc-cli/src/utils/era.ts
+++ b/scripts/cc-cli/src/utils/era.ts
@@ -36,6 +36,9 @@ export function eraIsInHistory(
   historyDepth: number,
   currentEra: number
 ): boolean {
+  if (eraToCheck < 0) {
+    return false;
+  }
   // The oldest era in history is currentEra - historyDepth
   // https://polkadot.js.org/docs/kusama/constants/#historydepth-u32
   const oldestEraInHistory = currentEra - historyDepth;

--- a/scripts/cc-cli/src/utils/era.ts
+++ b/scripts/cc-cli/src/utils/era.ts
@@ -21,3 +21,27 @@ export async function timeTillEra(api: ApiPromise, era: number) {
 
   return timeTillTargetEra;
 }
+
+export async function checkEraIsInHistory(
+  era: number,
+  api: ApiPromise
+): Promise<boolean> {
+  const currentEra = (await api.query.staking.currentEra()).value.toNumber();
+  const historyDepth = api.consts.staking.historyDepth.toNumber();
+  return eraIsInHistory(era, historyDepth, currentEra);
+}
+
+export function eraIsInHistory(
+  era: number,
+  historyDepth: number,
+  currentEra: number
+): boolean {
+  // The oldest era in history is currentEra - historyDepth
+  // https://polkadot.js.org/docs/kusama/constants/#historydepth-u32
+  const oldestEraInHistory = currentEra - historyDepth;
+  if (era < oldestEraInHistory || era >= currentEra) {
+    return false;
+  } else {
+    return true;
+  }
+}

--- a/scripts/cc-cli/src/utils/era.ts
+++ b/scripts/cc-cli/src/utils/era.ts
@@ -32,14 +32,14 @@ export async function checkEraIsInHistory(
 }
 
 export function eraIsInHistory(
-  era: number,
+  eraToCheck: number,
   historyDepth: number,
   currentEra: number
 ): boolean {
   // The oldest era in history is currentEra - historyDepth
   // https://polkadot.js.org/docs/kusama/constants/#historydepth-u32
   const oldestEraInHistory = currentEra - historyDepth;
-  if (era < oldestEraInHistory || era >= currentEra) {
+  if (eraToCheck < oldestEraInHistory || eraToCheck >= currentEra) {
     return false;
   } else {
     return true;


### PR DESCRIPTION
# Description of proposed changes

Adds a simple check using `historyDepth` and `currentEra` before attempting to distribute rewards.

---
Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
