### PR TITLE
CSUB-617: Fix: requireEnoughFunds was being passed a seed in some commands

### DIFF
--- a/scripts/cc-cli/src/commands/distributeRewards.ts
+++ b/scripts/cc-cli/src/commands/distributeRewards.ts
@@ -39,15 +39,12 @@ async function distributeRewardsAction(options: OptionValues) {
 
   // Any account can call the distribute_rewards extrinsic
   const callerSeed = await getCallerSeedFromEnvOrPrompt();
+  const caller = initKeyringPair(callerSeed);
   const distributeTx = api.tx.staking.payoutStakers(validator, era);
 
-  await requireEnoughFundsToSend(distributeTx, callerSeed, api);
+  await requireEnoughFundsToSend(distributeTx, caller.address, api);
 
-  const result = await signSendAndWatch(
-    distributeTx,
-    api,
-    initKeyringPair(callerSeed)
-  );
+  const result = await signSendAndWatch(distributeTx, api, caller);
 
   console.log(result.info);
   process.exit(0);

--- a/scripts/cc-cli/src/commands/setKeys.ts
+++ b/scripts/cc-cli/src/commands/setKeys.ts
@@ -43,7 +43,7 @@ async function setKeysAction(options: OptionValues) {
 
   const tx = api.tx.session.setKeys(keys, "");
 
-  await requireEnoughFundsToSend(tx, controllerSeed, api);
+  await requireEnoughFundsToSend(tx, controller.address, api);
 
   const result = await signSendAndWatch(tx, api, controller);
 

--- a/scripts/cc-cli/src/commands/unbond.ts
+++ b/scripts/cc-cli/src/commands/unbond.ts
@@ -28,13 +28,12 @@ async function unbondAction(options: OptionValues) {
 
   // Build account
   const controllerSeed = await getControllerSeedFromEnvOrPrompt();
-  const controllerKeyring = initKeyringPair(controllerSeed);
-  const controllerAddress = controllerKeyring.address;
+  const controller = initKeyringPair(controllerSeed);
 
-  const controllerStatus = await getValidatorStatus(controllerAddress, api);
+  const controllerStatus = await getValidatorStatus(controller.address, api);
   if (!controllerStatus.stash) {
     console.error(
-      `Cannot unbond, ${controllerAddress} is not a controller account`
+      `Cannot unbond, ${controller.address} is not a controller account`
     );
     process.exit(1);
   }
@@ -46,9 +45,9 @@ async function unbondAction(options: OptionValues) {
 
   // Unbond transaction
   const tx = api.tx.staking.unbond(amount.toString());
-  await requireEnoughFundsToSend(tx, controllerAddress, api);
+  await requireEnoughFundsToSend(tx, controller.address, api);
 
-  const result = await signSendAndWatch(tx, api, controllerKeyring);
+  const result = await signSendAndWatch(tx, api, controller);
 
   console.log(result.info);
   process.exit(0);


### PR DESCRIPTION
# Description of proposed changes

This was causing some commands to fail when checking for funds in `distribute-rewards`, `set-keys` and `unbond`. Was found when working on the CLI integration tests.

---
Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
