### PR TITLE
[CSUB-704] Keep authoring version at 1

### DIFF
--- a/runtime/src/version.rs
+++ b/runtime/src/version.rs
@@ -8,7 +8,7 @@ use sp_version::RuntimeVersion;
 pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("creditcoin-node"),
 	impl_name: create_runtime_str!("creditcoin-node"),
-	authoring_version: 2,
+	authoring_version: 1,
 	// The version of the runtime specification. A full node will not attempt to use its native
 	//   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.


### PR DESCRIPTION


# Description of proposed changes
Sets the authoring version of the runtime to 1.

This will allow non-updated miners to mine once the new runtime upgrade occurs. This prevents the chain from stalling on the runtime upgrade, which (before this PR) would cause the majority of the network's hash power to disappear.

---
Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
