### PR TITLE
CSUB-707: Add register-address and collect-coins commands to cc-cli

### DIFF
--- a/scripts/cc-cli/package.json
+++ b/scripts/cc-cli/package.json
@@ -28,7 +28,8 @@
     "cli-table3": "^0.6.3",
     "commander": "^11.0.0",
     "creditcoin-js": "file:../../creditcoin-js/creditcoin-js-v0.9.5.tgz",
-    "prompts": "^2.4.2"
+    "prompts": "^2.4.2",
+    "web3-validator": "^2.0.1"
   },
   "devDependencies": {
     "@polkadot/typegen": "9.14.2",

--- a/scripts/cc-cli/src/commands/collectCoins.ts
+++ b/scripts/cc-cli/src/commands/collectCoins.ts
@@ -1,0 +1,76 @@
+import { Command, Option, OptionValues } from "commander";
+import { fatalErr } from "./registerAddress";
+import { newApi } from "../api";
+import { initCallerKeyring } from "../utils/account";
+import { CollectCoinsEvent } from "creditcoin-js/lib/extrinsics/request-collect-coins";
+import chalk from "chalk";
+import { isAddress } from 'web3-validator';
+
+
+export function makeCollectCoinsCmd() {
+    const externalAddressOpt = new Option(
+        "-e, --external-address <addr> The previously registered external address that called the burn tx",
+    )
+        .env("EXTERNAL_ADDR");
+
+    const burnTxHashOpt = new Option(
+        "-b, --burn-tx-hash <hash> The hash of the burn transaction",
+    )
+        .env("BURN_TX_HASH");
+
+    return new Command("collect-coins")
+        .description("Swap GCRE for CTC")
+        .addOption(externalAddressOpt)
+        .addOption(burnTxHashOpt)
+        .action(collectCoinsAction);
+}
+
+async function collectCoinsAction(options: OptionValues) {
+    validateOptsOrExit(options);
+
+    const {
+        extrinsics: { requestCollectCoins },
+    } = await newApi(options.url);
+    const signer = await initCallerKeyring(options);
+
+    requestCollectCoins(options.externalAddress, signer, options.burnTxHash)
+        .then(handleSuccess)
+        .catch(handleError);
+}
+
+function validateOptsOrExit(options: OptionValues) {
+    if (options.externalAddress === undefined) {
+        fatalErr(`ERROR: No external address specified`);
+    }
+
+    if (options.burnTxHash === undefined) {
+        fatalErr("ERROR: No burn transaction hash specified");
+    }
+
+    if (!isTxHashValid(options.burnTxHash)) {
+        fatalErr(`ERROR: The transaction hash is invalid: ${options.burnTxHash}`)
+    }
+
+    if (!isExternalAddressValid(options.externalAddress)) {
+        fatalErr(`ERROR: The external address is invalid: ${options.externalAddress}`)
+    }
+}
+
+async function handleSuccess(value: CollectCoinsEvent) {
+    const result = await value.waitForVerification(800_000);
+    console.log(chalk.green("Success!"));
+}
+
+function handleError(reason: any) {
+    fatalErr(
+        `ERROR: The call to request_collect_coins was unsuccessful: ${reason}`,
+    );
+}
+
+export function isTxHashValid(hash: string): boolean {
+    return /^0x([A-Fa-f0-9]{64})$/.test(hash);
+}
+
+export function isExternalAddressValid(addr: string): boolean {
+    return isAddress(addr)
+}

--- a/scripts/cc-cli/src/commands/collectCoins.ts
+++ b/scripts/cc-cli/src/commands/collectCoins.ts
@@ -5,6 +5,7 @@ import { initCallerKeyring } from "../utils/account";
 import { CollectCoinsEvent } from "creditcoin-js/lib/extrinsics/request-collect-coins";
 import chalk from "chalk";
 import { isAddress } from "web3-validator";
+import { utils } from "ethers";
 
 export function makeCollectCoinsCmd() {
   const externalAddressOpt = new Option(
@@ -73,7 +74,8 @@ function handleError(reason: any) {
 }
 
 export function isTxHashValid(hash: string): boolean {
-  return /^0x([A-Fa-f0-9]{64})$/.test(hash);
+  // 32 byte hexadecimal, 64 character string, 66 with 0x prefix
+  return utils.isHexString(hash, 32);
 }
 
 export function isExternalAddressValid(addr: string): boolean {

--- a/scripts/cc-cli/src/commands/collectCoins.ts
+++ b/scripts/cc-cli/src/commands/collectCoins.ts
@@ -4,73 +4,78 @@ import { newApi } from "../api";
 import { initCallerKeyring } from "../utils/account";
 import { CollectCoinsEvent } from "creditcoin-js/lib/extrinsics/request-collect-coins";
 import chalk from "chalk";
-import { isAddress } from 'web3-validator';
-
+import { isAddress } from "web3-validator";
 
 export function makeCollectCoinsCmd() {
-    const externalAddressOpt = new Option(
-        "-e, --external-address <addr> The previously registered external address that called the burn tx",
-    )
-        .env("EXTERNAL_ADDR");
+  const externalAddressOpt = new Option(
+    "-e, --external-address <addr> The previously registered external address that called the burn tx",
+  ).env("EXTERNAL_ADDR");
 
-    const burnTxHashOpt = new Option(
-        "-b, --burn-tx-hash <hash> The hash of the burn transaction",
-    )
-        .env("BURN_TX_HASH");
+  const burnTxHashOpt = new Option(
+    "-b, --burn-tx-hash <hash> The hash of the burn transaction",
+  ).env("BURN_TX_HASH");
 
-    return new Command("collect-coins")
-        .description("Swap GCRE for CTC")
-        .addOption(externalAddressOpt)
-        .addOption(burnTxHashOpt)
-        .action(collectCoinsAction);
+  return new Command("collect-coins")
+    .description("Swap GCRE for CTC")
+    .addOption(externalAddressOpt)
+    .addOption(burnTxHashOpt)
+    .action(collectCoinsAction);
 }
 
 async function collectCoinsAction(options: OptionValues) {
-    validateOptsOrExit(options);
+  validateOptsOrExit(options);
 
-    const {
-        extrinsics: { requestCollectCoins },
-    } = await newApi(options.url);
-    const signer = await initCallerKeyring(options);
+  const {
+    extrinsics: { requestCollectCoins },
+  } = await newApi(options.url);
+  const signer = await initCallerKeyring(options);
 
-    requestCollectCoins(options.externalAddress, signer, options.burnTxHash)
-        .then(handleSuccess)
-        .catch(handleError);
+  requestCollectCoins(options.externalAddress, signer, options.burnTxHash)
+    .then(handleSuccess)
+    .catch(handleError);
 }
 
 function validateOptsOrExit(options: OptionValues) {
-    if (options.externalAddress === undefined) {
-        fatalErr(`ERROR: No external address specified`);
-    }
+  if (options.externalAddress === undefined) {
+    fatalErr(`ERROR: No external address specified`);
+  }
 
-    if (options.burnTxHash === undefined) {
-        fatalErr("ERROR: No burn transaction hash specified");
-    }
+  if (options.burnTxHash === undefined) {
+    fatalErr("ERROR: No burn transaction hash specified");
+  }
 
-    if (!isTxHashValid(options.burnTxHash)) {
-        fatalErr(`ERROR: The transaction hash is invalid: ${options.burnTxHash}`)
-    }
+  if (!isTxHashValid(options.burnTxHash)) {
+    fatalErr(
+      `ERROR: The transaction hash is invalid: ${options.burnTxHash as string}`,
+    );
+  }
 
-    if (!isExternalAddressValid(options.externalAddress)) {
-        fatalErr(`ERROR: The external address is invalid: ${options.externalAddress}`)
-    }
+  if (!isExternalAddressValid(options.externalAddress)) {
+    fatalErr(
+      `ERROR: The external address is invalid: ${
+        options.externalAddress as string
+      }`,
+    );
+  }
 }
 
 async function handleSuccess(value: CollectCoinsEvent) {
-    const result = await value.waitForVerification(800_000);
-    console.log(chalk.green("Success!"));
+  await value.waitForVerification(800_000);
+  console.log(chalk.green("Success!"));
 }
 
 function handleError(reason: any) {
-    fatalErr(
-        `ERROR: The call to request_collect_coins was unsuccessful: ${reason}`,
-    );
+  fatalErr(
+    `ERROR: The call to request_collect_coins was unsuccessful: ${
+      reason as string
+    }`,
+  );
 }
 
 export function isTxHashValid(hash: string): boolean {
-    return /^0x([A-Fa-f0-9]{64})$/.test(hash);
+  return /^0x([A-Fa-f0-9]{64})$/.test(hash);
 }
 
 export function isExternalAddressValid(addr: string): boolean {
-    return isAddress(addr)
+  return isAddress(addr);
 }

--- a/scripts/cc-cli/src/commands/registerAddress.ts
+++ b/scripts/cc-cli/src/commands/registerAddress.ts
@@ -5,86 +5,91 @@ import { initCallerKeyring } from "../utils/account";
 import { Wallet } from "ethers";
 import { signAccountId } from "creditcoin-js/lib/utils";
 import { AddressRegistered } from "creditcoin-js/lib/extrinsics/register-address";
-import { utils } from "ethers"
+import { utils } from "ethers";
 
 const blockchains = ["Ethereum", "Rinkeby", "Luniverse", "Bitcoin", "Other"];
 
 export function makeRegisterAddressCmd() {
-    const blockchainOpt = new Option(
-        "-b, --blockchain <chain> The blockchain that this external address belongs to",
+  const blockchainOpt = new Option(
+    "-b, --blockchain <chain> The blockchain that this external address belongs to",
+  )
+    .choices(blockchains)
+    .env("BLOCKCHAIN");
+
+  const privateKeyOpt = new Option(
+    "-p, --private-key <key> The private key for the address that you want to register.",
+  ).env("PRIVATE_KEY");
+
+  return new Command("register-address")
+    .description(
+      "Register an external off-chain address as belonging to a CreditCoin address",
     )
-        .choices(blockchains)
-        .env("BLOCKCHAIN");
-
-    const privateKeyOpt = new Option(
-        "-p, --private-key <key> The private key for the address that you want to register.",
-    ).env("PRIVATE_KEY");
-
-    return new Command("register-address")
-        .description(
-            "Register an external off-chain address as belonging to a CreditCoin address",
-        )
-        .addOption(privateKeyOpt)
-        .addOption(blockchainOpt)
-        .action(registerAddressAction);
+    .addOption(privateKeyOpt)
+    .addOption(blockchainOpt)
+    .action(registerAddressAction);
 }
 
 async function registerAddressAction(options: OptionValues) {
-    validateOptsOrExit(options);
+  validateOptsOrExit(options);
 
-    const {
-        api,
-        extrinsics: { registerAddress },
-    } = await newApi(options.url);
+  const {
+    api,
+    extrinsics: { registerAddress },
+  } = await newApi(options.url);
 
-    // Reads CC_SECRET env variable if it exists or propmpts the user to enter a mneumonic
-    const signer = await initCallerKeyring(options);
-    const wallet = new Wallet(options.privateKey);
+  // Reads CC_SECRET env variable if it exists or propmpts the user to enter a mneumonic
+  const signer = await initCallerKeyring(options);
+  const wallet = new Wallet(options.privateKey);
 
-    // create the cryptographic proof of ownership
-    const proof = signAccountId(api, wallet, signer.address);
+  // create the cryptographic proof of ownership
+  const proof = signAccountId(api, wallet, signer.address);
 
-    registerAddress(wallet.address, options.blockchain, proof, signer)
-        .then(handleSuccess)
-        .catch(handleError);
+  registerAddress(wallet.address, options.blockchain, proof, signer)
+    .then(handleSuccess)
+    .catch(handleError);
 }
 
-function handleSuccess(_: AddressRegistered) {
-    console.log(chalk.green(`Address Registered Successfully!`));
-    process.exit(0);
+function handleSuccess(addressRegistered: AddressRegistered) {
+  console.log(
+    chalk.green(
+      `Address Registered Successfully!: ${addressRegistered.itemId}`,
+    ),
+  );
+  process.exit(0);
 }
 
 function handleError(reason: any) {
-    fatalErr(`ERROR: The call to register address was unsuccessful: ${reason}`);
+  fatalErr(
+    `ERROR: The call to register address was unsuccessful: ${reason as string}`,
+  );
 }
 
 function validateOptsOrExit(options: OptionValues) {
-    if (options.blockchain === undefined) {
-        fatalErr(
-            `ERROR: A blockchain must be specified (possible values: ${blockchains})`,
-        );
-    }
+  if (options.blockchain === undefined) {
+    fatalErr(
+      `ERROR: A blockchain must be specified (possible values: ${blockchains.toString()})`,
+    );
+  }
 
-    if (options.privateKey === undefined) {
-        fatalErr("ERROR: No external address specified");
-    }
+  if (options.privateKey === undefined) {
+    fatalErr("ERROR: No external address specified");
+  }
 
-
-    if (!isValidPrivateKey(options.privateKey)) {
-        fatalErr(`ERROR: Invalid private key: ${options.privateKey}`)
-    }
+  if (!isValidPrivateKey(options.privateKey)) {
+    fatalErr(`ERROR: Invalid private key: ${options.privateKey as string}`);
+  }
 }
 
 export function fatalErr(s: string) {
-    errorMsg(s);
-    process.exit(1);
+  errorMsg(s);
+  process.exit(1);
 }
 
 function errorMsg(s: string) {
-    console.log(chalk.red(s));
+  console.log(chalk.red(s));
 }
 
 // https://github.com/ethers-io/ethers.js/discussions/2939
 export function isValidPrivateKey(pk: string): boolean {
-    return utils.isHexString(pk, 32)
+  return utils.isHexString(pk, 32);
 }

--- a/scripts/cc-cli/src/commands/registerAddress.ts
+++ b/scripts/cc-cli/src/commands/registerAddress.ts
@@ -1,0 +1,90 @@
+import chalk from "chalk";
+import { Command, Option, OptionValues } from "commander";
+import { newApi } from "../api";
+import { initCallerKeyring } from "../utils/account";
+import { Wallet } from "ethers";
+import { signAccountId } from "creditcoin-js/lib/utils";
+import { AddressRegistered } from "creditcoin-js/lib/extrinsics/register-address";
+import { utils } from "ethers"
+
+const blockchains = ["Ethereum", "Rinkeby", "Luniverse", "Bitcoin", "Other"];
+
+export function makeRegisterAddressCmd() {
+    const blockchainOpt = new Option(
+        "-b, --blockchain <chain> The blockchain that this external address belongs to",
+    )
+        .choices(blockchains)
+        .env("BLOCKCHAIN");
+
+    const privateKeyOpt = new Option(
+        "-p, --private-key <key> The private key for the address that you want to register.",
+    ).env("PRIVATE_KEY");
+
+    return new Command("register-address")
+        .description(
+            "Register an external off-chain address as belonging to a CreditCoin address",
+        )
+        .addOption(privateKeyOpt)
+        .addOption(blockchainOpt)
+        .action(registerAddressAction);
+}
+
+async function registerAddressAction(options: OptionValues) {
+    validateOptsOrExit(options);
+
+    const {
+        api,
+        extrinsics: { registerAddress },
+    } = await newApi(options.url);
+
+    // Reads CC_SECRET env variable if it exists or propmpts the user to enter a mneumonic
+    const signer = await initCallerKeyring(options);
+    const wallet = new Wallet(options.privateKey);
+
+    // create the cryptographic proof of ownership
+    const proof = signAccountId(api, wallet, signer.address);
+
+    registerAddress(wallet.address, options.blockchain, proof, signer)
+        .then(handleSuccess)
+        .catch(handleError);
+}
+
+function handleSuccess(_: AddressRegistered) {
+    console.log(chalk.green(`Address Registered Successfully!`));
+    process.exit(0);
+}
+
+function handleError(reason: any) {
+    fatalErr(`ERROR: The call to register address was unsuccessful: ${reason}`);
+}
+
+function validateOptsOrExit(options: OptionValues) {
+    if (options.blockchain === undefined) {
+        fatalErr(
+            `ERROR: A blockchain must be specified (possible values: ${blockchains})`,
+        );
+    }
+
+    if (options.privateKey === undefined) {
+        fatalErr("ERROR: No external address specified");
+    }
+
+
+    if (!isValidPrivateKey(options.privateKey)) {
+        fatalErr(`ERROR: Invalid private key: ${options.privateKey}`)
+    }
+}
+
+export function fatalErr(s: string) {
+    errorMsg(s);
+    process.exit(1);
+}
+
+function errorMsg(s: string) {
+    console.log(chalk.red(s));
+}
+
+// https://github.com/ethers-io/ethers.js/discussions/2939
+export function isValidPrivateKey(pk: string): boolean {
+    return utils.isHexString(pk, 32)
+}

--- a/scripts/cc-cli/src/commands/registerAddress.ts
+++ b/scripts/cc-cli/src/commands/registerAddress.ts
@@ -22,7 +22,7 @@ export function makeRegisterAddressCmd() {
 
   return new Command("register-address")
     .description(
-      "Register an external off-chain address as belonging to a CreditCoin address",
+      "Link a CreditCoin address to an address from another blockchain",
     )
     .addOption(privateKeyOpt)
     .addOption(blockchainOpt)

--- a/scripts/cc-cli/src/index.ts
+++ b/scripts/cc-cli/src/index.ts
@@ -17,6 +17,8 @@ import { makeDistributeRewardsCommand } from "./commands/distributeRewards";
 import { makeUnbondCommand } from "./commands/unbond";
 import { makeStatusCommand } from "./commands/status";
 import { makeWithdrawUnbondedCommand } from "./commands/withdrawUnbonded";
+import { makeCollectCoinsCmd } from "./commands/collectCoins";
+import { makeRegisterAddressCmd } from "./commands/registerAddress";
 
 const program = new Command();
 
@@ -30,8 +32,10 @@ program
   .addCommand(makeBalanceCommand())
   .addCommand(makeBondCommand())
   .addCommand(makeChillCommand())
+  .addCommand(makeCollectCoinsCmd())
   .addCommand(makeDistributeRewardsCommand())
   .addCommand(makeNewSeedCommand())
+  .addCommand(makeRegisterAddressCmd())
   .addCommand(makeRotateKeysCommand())
   .addCommand(makeSendCommand())
   .addCommand(makeSetKeysCommand())

--- a/scripts/cc-cli/src/test/unit-tests/collect-coins.test.ts
+++ b/scripts/cc-cli/src/test/unit-tests/collect-coins.test.ts
@@ -1,0 +1,38 @@
+import { isExternalAddressValid, isTxHashValid } from "../../commands/collectCoins";
+
+describe('Test isTxHashValid', () => {
+    test('success', () => {
+        expect(isTxHashValid('0x2446f1fd773fbb9f080e674b60c6a033c7ed7427b8b9413cf28a2a4a6da9b56c')).toBeTruthy()
+    })
+
+    test('Fails with missing prefix', () => {
+        expect(isTxHashValid('2446f1fd773fbb9f080e674b60c6a033c7ed7427b8b9413cf28a2a4a6da9b56c')).toBeFalsy()
+    })
+
+    test('fails with missing final character', () => {
+        expect(isTxHashValid('0x2446f1fd773fbb9f080e674b60c6a033c7ed7427b8b9413cf28a2a4a6da9b56')).toBeFalsy()
+    })
+
+    test('fails with empty string', () => {
+        expect(isTxHashValid("")).toBeFalsy()
+    })
+
+})
+
+describe('Test isExternalAddressValid', () => {
+    test('Success', () => {
+        expect(isExternalAddressValid('0x71C7656EC7ab88b098defB751B7401B5f6d8976F')).toBeTruthy()
+    })
+
+    test('Succeds with missing prefix', () => {
+        expect(isExternalAddressValid('71C7656EC7ab88b098defB751B7401B5f6d8976F')).toBeTruthy()
+    })
+
+    test('Fails with missing final character', () => {
+        expect(isExternalAddressValid('0x71C7656EC7ab88b098defB751B7401B5f6d8976')).toBeFalsy()
+    })
+
+    test('Fails with empty string', () => {
+        expect(isExternalAddressValid('')).toBeFalsy()
+    })
+})

--- a/scripts/cc-cli/src/test/unit-tests/collect-coins.test.ts
+++ b/scripts/cc-cli/src/test/unit-tests/collect-coins.test.ts
@@ -1,38 +1,58 @@
-import { isExternalAddressValid, isTxHashValid } from "../../commands/collectCoins";
+import {
+  isExternalAddressValid,
+  isTxHashValid,
+} from "../../commands/collectCoins";
 
-describe('Test isTxHashValid', () => {
-    test('success', () => {
-        expect(isTxHashValid('0x2446f1fd773fbb9f080e674b60c6a033c7ed7427b8b9413cf28a2a4a6da9b56c')).toBeTruthy()
-    })
+describe("Test isTxHashValid", () => {
+  test("success", () => {
+    expect(
+      isTxHashValid(
+        "0x2446f1fd773fbb9f080e674b60c6a033c7ed7427b8b9413cf28a2a4a6da9b56c",
+      ),
+    ).toBeTruthy();
+  });
 
-    test('Fails with missing prefix', () => {
-        expect(isTxHashValid('2446f1fd773fbb9f080e674b60c6a033c7ed7427b8b9413cf28a2a4a6da9b56c')).toBeFalsy()
-    })
+  test("Fails with missing prefix", () => {
+    expect(
+      isTxHashValid(
+        "2446f1fd773fbb9f080e674b60c6a033c7ed7427b8b9413cf28a2a4a6da9b56c",
+      ),
+    ).toBeFalsy();
+  });
 
-    test('fails with missing final character', () => {
-        expect(isTxHashValid('0x2446f1fd773fbb9f080e674b60c6a033c7ed7427b8b9413cf28a2a4a6da9b56')).toBeFalsy()
-    })
+  test("fails with missing final character", () => {
+    expect(
+      isTxHashValid(
+        "0x2446f1fd773fbb9f080e674b60c6a033c7ed7427b8b9413cf28a2a4a6da9b56",
+      ),
+    ).toBeFalsy();
+  });
 
-    test('fails with empty string', () => {
-        expect(isTxHashValid("")).toBeFalsy()
-    })
+  test("fails with empty string", () => {
+    expect(isTxHashValid("")).toBeFalsy();
+  });
+});
 
-})
+describe("Test isExternalAddressValid", () => {
+  test("Success", () => {
+    expect(
+      isExternalAddressValid("0x71C7656EC7ab88b098defB751B7401B5f6d8976F"),
+    ).toBeTruthy();
+  });
 
-describe('Test isExternalAddressValid', () => {
-    test('Success', () => {
-        expect(isExternalAddressValid('0x71C7656EC7ab88b098defB751B7401B5f6d8976F')).toBeTruthy()
-    })
+  test("Succeds with missing prefix", () => {
+    expect(
+      isExternalAddressValid("71C7656EC7ab88b098defB751B7401B5f6d8976F"),
+    ).toBeTruthy();
+  });
 
-    test('Succeds with missing prefix', () => {
-        expect(isExternalAddressValid('71C7656EC7ab88b098defB751B7401B5f6d8976F')).toBeTruthy()
-    })
+  test("Fails with missing final character", () => {
+    expect(
+      isExternalAddressValid("0x71C7656EC7ab88b098defB751B7401B5f6d8976"),
+    ).toBeFalsy();
+  });
 
-    test('Fails with missing final character', () => {
-        expect(isExternalAddressValid('0x71C7656EC7ab88b098defB751B7401B5f6d8976')).toBeFalsy()
-    })
-
-    test('Fails with empty string', () => {
-        expect(isExternalAddressValid('')).toBeFalsy()
-    })
-})
+  test("Fails with empty string", () => {
+    expect(isExternalAddressValid("")).toBeFalsy();
+  });
+});

--- a/scripts/cc-cli/src/test/unit-tests/collect-coins.test.ts
+++ b/scripts/cc-cli/src/test/unit-tests/collect-coins.test.ts
@@ -3,56 +3,76 @@ import {
   isTxHashValid,
 } from "../../commands/collectCoins";
 
-describe("Test isTxHashValid", () => {
-  test("success", () => {
+describe(isTxHashValid, () => {
+  test("should return true with a valid hash", () => {
     expect(
       isTxHashValid(
         "0x2446f1fd773fbb9f080e674b60c6a033c7ed7427b8b9413cf28a2a4a6da9b56c",
       ),
-    ).toBeTruthy();
+    ).toBe(true);
   });
 
-  test("Fails with missing prefix", () => {
+  test("Should return false with missing '0x' prefix", () => {
     expect(
       isTxHashValid(
         "2446f1fd773fbb9f080e674b60c6a033c7ed7427b8b9413cf28a2a4a6da9b56c",
       ),
-    ).toBeFalsy();
+    ).toBe(false);
   });
 
-  test("fails with missing final character", () => {
+  test("Should return false when hash is missing final character", () => {
     expect(
       isTxHashValid(
         "0x2446f1fd773fbb9f080e674b60c6a033c7ed7427b8b9413cf28a2a4a6da9b56",
       ),
-    ).toBeFalsy();
+    ).toBe(false);
   });
 
-  test("fails with empty string", () => {
-    expect(isTxHashValid("")).toBeFalsy();
+  test("should return false when called with empty", () => {
+    expect(isTxHashValid("")).toBe(false);
+  });
+
+  test("Should return false when input has non hexadecimal character", () => {
+    expect(
+      isTxHashValid(
+        "0x2446f1fd773fbb9f080e674b60c6a033c7ed7427b8b9413cf28a2a4a6da9b56Z",
+      ),
+    ).toBe(false);
   });
 });
 
-describe("Test isExternalAddressValid", () => {
-  test("Success", () => {
+describe(isExternalAddressValid, () => {
+  test("should return true with proper address", () => {
     expect(
       isExternalAddressValid("0x71C7656EC7ab88b098defB751B7401B5f6d8976F"),
-    ).toBeTruthy();
+    ).toBe(true);
   });
 
-  test("Succeds with missing prefix", () => {
+  test("should return true with proper address missing prefix", () => {
     expect(
       isExternalAddressValid("71C7656EC7ab88b098defB751B7401B5f6d8976F"),
-    ).toBeTruthy();
+    ).toBe(true);
   });
 
-  test("Fails with missing final character", () => {
+  test("should return false when argument is missing final character", () => {
     expect(
       isExternalAddressValid("0x71C7656EC7ab88b098defB751B7401B5f6d8976"),
-    ).toBeFalsy();
+    ).toBe(false);
   });
 
-  test("Fails with empty string", () => {
-    expect(isExternalAddressValid("")).toBeFalsy();
+  test("Should return false when called with empty string", () => {
+    expect(isExternalAddressValid("")).toBe(false);
+  });
+
+  test("Should return false when input has non hexadecimal characters", () => {
+    expect(
+      isExternalAddressValid("0x71C7656EC7ab88b098defB751B7401B5f6d8976Z"),
+    ).toBe(false);
+  });
+
+  test("Should return false when called with input with length > 42", () => {
+    expect(
+      isExternalAddressValid("0x71C7656EC7ab88b098defB751B7401B5f6d8976FF"),
+    ).toBe(false);
   });
 });

--- a/scripts/cc-cli/src/test/unit-tests/register-address.test.ts
+++ b/scripts/cc-cli/src/test/unit-tests/register-address.test.ts
@@ -1,0 +1,19 @@
+import { isValidPrivateKey } from "../../commands/registerAddress";
+
+describe('Test isValidPrivateKey', () => {
+    test('Success', () => {
+        expect(isValidPrivateKey("0x8da4ef21b864d2cc526dbdb2a120bd2874c36c9d0a1fb7f8c63d7f7a8b41de8f")).toBeTruthy()
+    });
+
+    test('fails with missing prefix', () => {
+        expect(isValidPrivateKey("8da4ef21b864d2cc526dbdb2a120bd2874c36c9d0a1fb7f8c63d7f7a8b41de8f")).toBeFalsy()
+    })
+
+    test('fails with missing final character', () => {
+        expect(isValidPrivateKey("0x8da4ef21b864d2cc526dbdb2a120bd2874c36c9d0a1fb7f8c63d7f7a8b41de8")).toBeFalsy()
+    })
+
+    test('fails with empty string', () => {
+        expect(isValidPrivateKey('')).toBeFalsy()
+    })
+})

--- a/scripts/cc-cli/src/test/unit-tests/register-address.test.ts
+++ b/scripts/cc-cli/src/test/unit-tests/register-address.test.ts
@@ -1,19 +1,31 @@
 import { isValidPrivateKey } from "../../commands/registerAddress";
 
-describe('Test isValidPrivateKey', () => {
-    test('Success', () => {
-        expect(isValidPrivateKey("0x8da4ef21b864d2cc526dbdb2a120bd2874c36c9d0a1fb7f8c63d7f7a8b41de8f")).toBeTruthy()
-    });
+describe("Test isValidPrivateKey", () => {
+  test("Success", () => {
+    expect(
+      isValidPrivateKey(
+        "0x8da4ef21b864d2cc526dbdb2a120bd2874c36c9d0a1fb7f8c63d7f7a8b41de8f",
+      ),
+    ).toBeTruthy();
+  });
 
-    test('fails with missing prefix', () => {
-        expect(isValidPrivateKey("8da4ef21b864d2cc526dbdb2a120bd2874c36c9d0a1fb7f8c63d7f7a8b41de8f")).toBeFalsy()
-    })
+  test("fails with missing prefix", () => {
+    expect(
+      isValidPrivateKey(
+        "8da4ef21b864d2cc526dbdb2a120bd2874c36c9d0a1fb7f8c63d7f7a8b41de8f",
+      ),
+    ).toBeFalsy();
+  });
 
-    test('fails with missing final character', () => {
-        expect(isValidPrivateKey("0x8da4ef21b864d2cc526dbdb2a120bd2874c36c9d0a1fb7f8c63d7f7a8b41de8")).toBeFalsy()
-    })
+  test("fails with missing final character", () => {
+    expect(
+      isValidPrivateKey(
+        "0x8da4ef21b864d2cc526dbdb2a120bd2874c36c9d0a1fb7f8c63d7f7a8b41de8",
+      ),
+    ).toBeFalsy();
+  });
 
-    test('fails with empty string', () => {
-        expect(isValidPrivateKey('')).toBeFalsy()
-    })
-})
+  test("fails with empty string", () => {
+    expect(isValidPrivateKey("")).toBeFalsy();
+  });
+});

--- a/scripts/cc-cli/src/test/unit-tests/register-address.test.ts
+++ b/scripts/cc-cli/src/test/unit-tests/register-address.test.ts
@@ -1,31 +1,47 @@
 import { isValidPrivateKey } from "../../commands/registerAddress";
 
-describe("Test isValidPrivateKey", () => {
-  test("Success", () => {
+describe(isValidPrivateKey, () => {
+  test("should return true when called with valid private key", () => {
     expect(
       isValidPrivateKey(
         "0x8da4ef21b864d2cc526dbdb2a120bd2874c36c9d0a1fb7f8c63d7f7a8b41de8f",
       ),
-    ).toBeTruthy();
+    ).toBe(true);
   });
 
-  test("fails with missing prefix", () => {
+  test("should return false when input is missing prefix", () => {
     expect(
       isValidPrivateKey(
         "8da4ef21b864d2cc526dbdb2a120bd2874c36c9d0a1fb7f8c63d7f7a8b41de8f",
       ),
-    ).toBeFalsy();
+    ).toBe(false);
   });
 
-  test("fails with missing final character", () => {
+  test("should return false when input is missing final character", () => {
     expect(
       isValidPrivateKey(
         "0x8da4ef21b864d2cc526dbdb2a120bd2874c36c9d0a1fb7f8c63d7f7a8b41de8",
       ),
-    ).toBeFalsy();
+    ).toBe(false);
   });
 
-  test("fails with empty string", () => {
-    expect(isValidPrivateKey("")).toBeFalsy();
+  test("should return false when argument is empty string", () => {
+    expect(isValidPrivateKey("")).toBe(false);
+  });
+
+  test("should return false when argument has non hexadecimal characters", () => {
+    expect(
+      isValidPrivateKey(
+        "0x8da4ef21b864d2cc526dbdb2a120bd2874c36c9d0a1fb7f8c63d7f7a8b41de8fZ",
+      ),
+    ).toBe(false);
+  });
+
+  test("should return false when argument non hexadecimal characters", () => {
+    expect(
+      isValidPrivateKey(
+        "0x8da4ef21b864d2cc526dbdb2a120bd2874c36c9d0a1fb7f8c63d7f7a8b41de8ff",
+      ),
+    ).toBe(false);
   });
 });

--- a/scripts/cc-cli/yarn.lock
+++ b/scripts/cc-cli/yarn.lock
@@ -277,9 +277,9 @@
     source-map-support "^0.5.16"
 
 "@babel/runtime@^7.20.13", "@babel/runtime@^7.20.6":
-  version "7.22.10"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.10.tgz#ae3e9631fd947cb7e3610d3e9d8fef5f76696682"
-  integrity sha512-21t/fkKLMZI4pqP2wlmsQAWnYW1PDyKyyUV4vCi+B25ydmdaYTKXPwCj0BzSUnZf4seIiYvSA3jcZ3gdsMFkLQ==
+  version "7.22.11"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.11.tgz#7a9ba3bbe406ad6f9e8dd4da2ece453eb23a77a4"
+  integrity sha512-ee7jVNlWN09+KftVOu9n7S8gQzD/Z6hN/I8VBRXW4P1+Xe7kJGXMwu8vds4aGIMHZnNbdpSWCfZZtinytpcAvA==
   dependencies:
     regenerator-runtime "^0.14.0"
 
@@ -985,10 +985,27 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
+"@noble/curves@1.1.0", "@noble/curves@~1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.1.0.tgz#f13fc667c89184bc04cccb9b11e8e7bae27d8c3d"
+  integrity sha512-091oBExgENk/kGj3AZmtBDMpxQPDtxQABR2B9lb1JbVTs6ytdzZNwvhxQ4MWasRNEzlbEH8jCWFCwhF/Obj5AA==
+  dependencies:
+    "@noble/hashes" "1.3.1"
+
 "@noble/hashes@1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.2.0.tgz#a3150eeb09cc7ab207ebf6d7b9ad311a9bdbed12"
   integrity sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==
+
+"@noble/hashes@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.1.tgz#8831ef002114670c603c458ab8b11328406953a9"
+  integrity sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA==
+
+"@noble/hashes@~1.3.0", "@noble/hashes@~1.3.1":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.2.tgz#6f26dbc8fbc7205873ce3cee2f690eba0d421b39"
+  integrity sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==
 
 "@noble/secp256k1@1.7.1":
   version "1.7.1"
@@ -1371,6 +1388,28 @@
   resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.1.tgz#ebb651ee52ff84f420097055f4bf46cfba403938"
   integrity sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA==
 
+"@scure/base@~1.1.0":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.3.tgz#8584115565228290a6c6c4961973e0903bb3df2f"
+  integrity sha512-/+SgoRjLq7Xlf0CWuLHq2LUZeL/w65kfzAPG5NH9pcmBhs+nunQTn4gvdwgMTIXnt9b2C/1SeL2XiysZEyIC9Q==
+
+"@scure/bip32@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@scure/bip32/-/bip32-1.3.1.tgz#7248aea723667f98160f593d621c47e208ccbb10"
+  integrity sha512-osvveYtyzdEVbt3OfwwXFr4P2iVBL5u1Q3q4ONBfDY/UpOuXmOlbgwc1xECEboY8wIays8Yt6onaWMUdUbfl0A==
+  dependencies:
+    "@noble/curves" "~1.1.0"
+    "@noble/hashes" "~1.3.1"
+    "@scure/base" "~1.1.0"
+
+"@scure/bip39@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@scure/bip39/-/bip39-1.2.1.tgz#5cee8978656b272a917b7871c981e0541ad6ac2a"
+  integrity sha512-Z3/Fsz1yr904dduJD0NpiyRHhRYHdcnyh73FZWiV+/qhWi83wNJ3NWolYqCEN+ZWsUz2TWwajJggcRE9r1zUYg==
+  dependencies:
+    "@noble/hashes" "~1.3.0"
+    "@scure/base" "~1.1.0"
+
 "@sinclair/typebox@^0.25.16":
   version "0.25.24"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.25.24.tgz#8c7688559979f7079aacaf31aa881c3aa410b718"
@@ -1525,9 +1564,9 @@
     form-data "^3.0.0"
 
 "@types/node@*":
-  version "20.5.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.5.0.tgz#7fc8636d5f1aaa3b21e6245e97d56b7f56702313"
-  integrity sha512-Mgq7eCtoTjT89FqNoTzzXg2XvCi5VMhRV6+I2aYanc6kQCBImeNaAYRs/DyoVqk1YEUJK5gN9VO7HRIdz4Wo3Q==
+  version "20.5.7"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.5.7.tgz#4b8ecac87fbefbc92f431d09c30e176fc0a7c377"
+  integrity sha512-dP7f3LdZIysZnmvP3ANJYTSwg+wLLl8p7RqniVlV7j+oXSXAbt9h0WIBFmJy5inWZoX9wZN6eXx+YXd9Rh3RBA==
 
 "@types/prettier@^2.1.5":
   version "2.7.3"
@@ -1553,9 +1592,9 @@
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
 
 "@types/websocket@^1.0.5":
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/@types/websocket/-/websocket-1.0.5.tgz#3fb80ed8e07f88e51961211cd3682a3a4a81569c"
-  integrity sha512-NbsqiNX9CnEfC1Z0Vf4mE1SgAJ07JnRYcNex7AJ9zAVzmiGHmjKFEk7O4TJIsgv2B1sLEb6owKFZrACwdYngsQ==
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@types/websocket/-/websocket-1.0.6.tgz#ec8dce5915741632ac3a4b1f951b6d4156e32d03"
+  integrity sha512-JXkliwz93B2cMWOI1ukElQBPN88vMg3CruvW4KVSKpflt3NyNCJImnhIuB/f97rG7kakqRJGFiwkA895Kn02Dg==
   dependencies:
     "@types/node" "*"
 
@@ -1752,6 +1791,11 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
+available-typed-arrays@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
+  integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
+
 babel-jest@^29.5.0:
   version "29.5.0"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-29.5.0.tgz#3fe3ddb109198e78b1c88f9ebdecd5e4fc2f50a5"
@@ -1887,6 +1931,14 @@ bufferutil@^4.0.1:
   integrity sha512-kukuqc39WOHtdxtw4UScxF/WVnMFVSQVKhtx3AjZJzhd0RGZZldcrfSEbVsWWe6KNH253574cq5F+wpv0G9pJw==
   dependencies:
     node-gyp-build "^4.3.0"
+
+call-bind@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.2.tgz#b1d4e89e688119c3c9a903ad30abb2f6a919be3c"
+  integrity sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==
+  dependencies:
+    function-bind "^1.1.1"
+    get-intrinsic "^1.0.2"
 
 callsites@^3.0.0:
   version "3.1.0"
@@ -2040,7 +2092,7 @@ create-require@^1.1.0:
 
 "creditcoin-js@file:../../creditcoin-js/creditcoin-js-v0.9.5.tgz":
   version "0.9.5"
-  resolved "file:../../creditcoin-js/creditcoin-js-v0.9.5.tgz#3a32da51bd0305df6bc0b4ddb2a92731c7c04cde"
+  resolved "file:../../creditcoin-js/creditcoin-js-v0.9.5.tgz#18073861b6c446c2fdb7547824d50c1337c47463"
   dependencies:
     "@polkadot/api" "9.14.2"
     ethers "^5.7.1"
@@ -2318,6 +2370,16 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
+ethereum-cryptography@^2.0.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/ethereum-cryptography/-/ethereum-cryptography-2.1.2.tgz#18fa7108622e56481157a5cb7c01c0c6a672eb67"
+  integrity sha512-Z5Ba0T0ImZ8fqXrJbpHcbpAvIswRte2wGNR/KePnu8GbbvgJ47lMxT/ZZPG6i9Jaht4azPDop4HaM00J0J59ug==
+  dependencies:
+    "@noble/curves" "1.1.0"
+    "@noble/hashes" "1.3.1"
+    "@scure/bip32" "1.3.1"
+    "@scure/bip39" "1.2.1"
+
 ethers@^5.7.1:
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.7.2.tgz#3a7deeabbb8c030d4126b24f84e525466145872e"
@@ -2509,6 +2571,13 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
+for-each@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
+  integrity sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==
+  dependencies:
+    is-callable "^1.1.3"
+
 form-data@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
@@ -2549,6 +2618,16 @@ get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
+
+get-intrinsic@^1.0.2, get-intrinsic@^1.1.3:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.1.tgz#d295644fed4505fc9cde952c37ee12b477a83d82"
+  integrity sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==
+  dependencies:
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-proto "^1.0.1"
+    has-symbols "^1.0.3"
 
 get-package-type@^0.1.0:
   version "0.1.0"
@@ -2610,6 +2689,13 @@ globby@^11.1.0:
     merge2 "^1.4.1"
     slash "^3.0.0"
 
+gopd@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.0.1.tgz#29ff76de69dac7489b7c0918a5788e56477c332c"
+  integrity sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==
+  dependencies:
+    get-intrinsic "^1.1.3"
+
 graceful-fs@^4.2.9:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
@@ -2641,6 +2727,23 @@ has-flag@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
+
+has-proto@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/has-proto/-/has-proto-1.0.1.tgz#1885c1305538958aff469fef37937c22795408e0"
+  integrity sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==
+
+has-symbols@^1.0.2, has-symbols@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.3.tgz#bb7b2c4349251dce87b125f7bdf874aa7c8b39f8"
+  integrity sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
+
+has-tostringtag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-tostringtag/-/has-tostringtag-1.0.0.tgz#7e133818a7d394734f941e73c3d3f9291e658b25"
+  integrity sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==
+  dependencies:
+    has-symbols "^1.0.2"
 
 has@^1.0.3:
   version "1.0.3"
@@ -2715,10 +2818,23 @@ inherits@2, inherits@^2.0.3, inherits@^2.0.4:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
+is-arguments@^1.0.4:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.1.1.tgz#15b3f88fda01f2a97fec84ca761a560f123efa9b"
+  integrity sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==
+  dependencies:
+    call-bind "^1.0.2"
+    has-tostringtag "^1.0.0"
+
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==
+
+is-callable@^1.1.3:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.7.tgz#3bc2a85ea742d9e36205dcacdd72ca1fdc51b055"
+  integrity sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==
 
 is-core-module@^2.11.0:
   version "2.12.1"
@@ -2741,6 +2857,13 @@ is-generator-fn@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
   integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
+
+is-generator-function@^1.0.7:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/is-generator-function/-/is-generator-function-1.0.10.tgz#f1558baf1ac17e0deea7c0415c438351ff2b3c72"
+  integrity sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==
+  dependencies:
+    has-tostringtag "^1.0.0"
 
 is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3:
   version "4.0.3"
@@ -2770,6 +2893,13 @@ is-stream@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.1.tgz#fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077"
   integrity sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==
+
+is-typed-array@^1.1.3:
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/is-typed-array/-/is-typed-array-1.1.12.tgz#d0bab5686ef4a76f7a73097b95470ab199c57d4a"
+  integrity sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==
+  dependencies:
+    which-typed-array "^1.1.11"
 
 is-typedarray@^1.0.0:
   version "1.0.0"
@@ -3443,9 +3573,9 @@ next-tick@^1.1.0:
   integrity sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==
 
 nock@^13.3.0:
-  version "13.3.2"
-  resolved "https://registry.yarnpkg.com/nock/-/nock-13.3.2.tgz#bfa6be92d37f744b1b758ea89b1105cdaf5c8b3f"
-  integrity sha512-CwbljitiWJhF1gL83NbanhoKs1l23TDlRioNraPTZrzZIEooPemrHRj5m0FZCPkB1ecdYCSWWGcHysJgX/ngnQ==
+  version "13.3.3"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-13.3.3.tgz#179759c07d3f88ad3e794ace885629c1adfd3fe7"
+  integrity sha512-z+KUlILy9SK/RjpeXDiDUEAq4T94ADPHE3qaRkf66mpEhzc/ytOMm3Bwdrbq6k1tMWkbdujiKim3G2tfQARuJw==
   dependencies:
     debug "^4.1.0"
     json-stringify-safe "^5.0.1"
@@ -3467,9 +3597,9 @@ node-fetch@^3.3.0:
     formdata-polyfill "^4.0.10"
 
 node-gyp-build@^4.3.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.6.0.tgz#0c52e4cbf54bbd28b709820ef7b6a3c2d6209055"
-  integrity sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.6.1.tgz#24b6d075e5e391b8d5539d98c7fc5c210cac8a3e"
+  integrity sha512-24vnklJmyRS8ViBNI8KbtK/r/DmXQMRiOMXTNz2nrTnAYUwjmEEbnnpB/+kt+yWRv73bPsSPRFddrcIbAxSiMQ==
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -3988,9 +4118,9 @@ ts-node@^10.8.0:
     yn "3.1.1"
 
 tslib@^2.1.0:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.1.tgz#fd8c9a0ff42590b25703c0acb3de3d3f4ede0410"
-  integrity sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
+  integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
 
 tweetnacl@1.x.x, tweetnacl@^1.0.3:
   version "1.0.3"
@@ -4068,6 +4198,17 @@ utf-8-validate@^5.0.2:
   dependencies:
     node-gyp-build "^4.3.0"
 
+util@^0.12.5:
+  version "0.12.5"
+  resolved "https://registry.yarnpkg.com/util/-/util-0.12.5.tgz#5f17a6059b73db61a875668781a1c2b136bd6fbc"
+  integrity sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==
+  dependencies:
+    inherits "^2.0.3"
+    is-arguments "^1.0.4"
+    is-generator-function "^1.0.7"
+    is-typed-array "^1.1.3"
+    which-typed-array "^1.1.2"
+
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
@@ -4094,6 +4235,29 @@ web-streams-polyfill@^3.0.3:
   resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz#71c2718c52b45fd49dbeee88634b3a60ceab42a6"
   integrity sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==
 
+web3-errors@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/web3-errors/-/web3-errors-1.1.1.tgz#1a73b84f4f8315945a1eb0ae0ab1f16bf5fac28a"
+  integrity sha512-9IEhcympCJEK3Nmkz2oE/daKnOh+3CxHceuVWWRkHWKUfuIiJQgXAv9wRkPGk63JJTP/R9jtGmP+IbkScKoTBA==
+  dependencies:
+    web3-types "^1.1.1"
+
+web3-types@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/web3-types/-/web3-types-1.1.1.tgz#d3df5e9839bf70a19b070313fd3d9ee07fbffbf3"
+  integrity sha512-bXmIPJi/NPed43JBcya71gT+euZSMvfQx6NYv8G97PSNxR1HWwANYBKbamTZvzBbq10QCwQLh0hZw3tyOXuPFA==
+
+web3-validator@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/web3-validator/-/web3-validator-2.0.1.tgz#8da5b9f871c0aac7677f4a5eca46b4fee9b6d0ff"
+  integrity sha512-RIdZCNhceBEOQpmzcEk6K3qqLHRfDIMkg2PJe7yllpuEc0fa0cmUZgGUl1FEnioc5Rx9GBEE8eTllaneIAiiQQ==
+  dependencies:
+    ethereum-cryptography "^2.0.0"
+    util "^0.12.5"
+    web3-errors "^1.1.1"
+    web3-types "^1.1.1"
+    zod "^3.21.4"
+
 websocket@^1.0.34:
   version "1.0.34"
   resolved "https://registry.yarnpkg.com/websocket/-/websocket-1.0.34.tgz#2bdc2602c08bf2c82253b730655c0ef7dcab3111"
@@ -4105,6 +4269,17 @@ websocket@^1.0.34:
     typedarray-to-buffer "^3.1.5"
     utf-8-validate "^5.0.2"
     yaeti "^0.0.6"
+
+which-typed-array@^1.1.11, which-typed-array@^1.1.2:
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.11.tgz#99d691f23c72aab6768680805a271b69761ed61a"
+  integrity sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==
+  dependencies:
+    available-typed-arrays "^1.0.5"
+    call-bind "^1.0.2"
+    for-each "^0.3.3"
+    gopd "^1.0.1"
+    has-tostringtag "^1.0.0"
 
 which@^2.0.1:
   version "2.0.2"
@@ -4197,3 +4372,8 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zod@^3.21.4:
+  version "3.22.2"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.22.2.tgz#3add8c682b7077c05ac6f979fea6998b573e157b"
+  integrity sha512-wvWkphh5WQsJbVk1tbx1l1Ly4yg+XecD+Mq280uBGt9wa5BKSWf4Mhp6GmrkPixhMxmabYY7RbzlwVP32pbGCg==


### PR DESCRIPTION
- Added `chalk@4.1.2` to the `yarn.lock` file of `cc-cli`.  Chalk version 5 doesn't work nicely with typescript.

- Added `web3-validator` for validating Ethereum-like addresses.

This PR doesn't add a full e2e test of either function. This will be added in the following PR for CSUB-708