### PR TITLE
Fix Test Against Fork CI

### DIFF
--- a/.github/workflows/runtime-upgrade.yml
+++ b/.github/workflows/runtime-upgrade.yml
@@ -127,7 +127,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release --features "fast-runtime try-runtime"
+          args: --release --features "try-runtime"
 
       - name: Upload creditcoin-node binary
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
# Description of proposed changes

Removing the `fast-runtime`  flag that caused errors when trying to sync from Testnet/Mainnet which don't use the flag.

---
Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
