### PR TITLE
[CSUB-718] Fix Status command not showing Stash/Controller addresses

### DIFF
--- a/scripts/cc-cli/src/utils/validatorStatus.ts
+++ b/scripts/cc-cli/src/utils/validatorStatus.ts
@@ -55,8 +55,10 @@ export async function getControllerStatus(
 }
 
 export async function getValidatorStatus(address: string, api: ApiPromise) {
+  // Check if address is a controller and get its stash
   const controllerStatus = await getControllerStatus(address, api);
 
+  // If it is a controller, set the stash to its stash address
   let stash;
   if (controllerStatus.isController && controllerStatus.stash) {
     console.log(
@@ -68,13 +70,17 @@ export async function getValidatorStatus(address: string, api: ApiPromise) {
     stash = address;
   }
 
+  // Get the staking information for the stash
   const res = await api.derive.staking.account(stash);
 
+  // Get the controller address
   const controller = res.controllerId ? res.controllerId.toString() : undefined;
 
+  // Get the total staked amount
   const totalStaked = readAmount(res.stakingLedger.total.toString());
   const bonded = totalStaked.gt(new BN(0));
 
+  // Get information about any unbonding tokens and unlocked chunks
   const unlockingRes = res.stakingLedger.unlocking;
   const currentEra = (await api.query.staking.currentEra()).unwrap();
   const unlocking = unlockingRes
@@ -85,6 +91,8 @@ export async function getValidatorStatus(address: string, api: ApiPromise) {
     ? readAmountFromHex(res.redeemable.toString())
     : new BN(0);
 
+  // Get the unlocked chunks that are ready for withdrawal
+  // by comparing the era of each chunk to the current era
   const readyForWithdraw = res.stakingLedger.unlocking
     .map((u: any) => {
       const chunk: UnlockChunk = {
@@ -103,15 +111,14 @@ export async function getValidatorStatus(address: string, api: ApiPromise) {
   const nextUnbondingAmount =
     unlocking.length > 0 ? unlocking[0].value.toBn() : null;
 
+  // Get lists of all validators, active validators, and waiting validators
   const validatorEntries = await api.query.staking.validators
     .entries()
     .then((r) => r.map((v) => v[0].toHuman()?.toString()));
-
   const activeValidatorsRes = await api.derive.staking.validators();
   const activeValidators: string[] = activeValidatorsRes.validators.map((v) =>
     v.toString()
   );
-
   const waitingValidators = validatorEntries.filter((v) => {
     if (v !== undefined) {
       return !activeValidators.includes(v);
@@ -120,13 +127,18 @@ export async function getValidatorStatus(address: string, api: ApiPromise) {
     }
   });
 
+  // Check if the validator is validating, waiting, or active
+  const validating = validatorEntries.includes(stash);
+  const waiting = waitingValidators.includes(stash);
+  const active = activeValidators.includes(stash);
+
   const validatorStatus: Status = {
     bonded,
     stash,
     controller,
-    validating: validatorEntries.includes(stash),
-    waiting: waitingValidators.includes(stash),
-    active: activeValidators.includes(stash),
+    validating,
+    waiting,
+    active,
     canWithdraw,
     readyForWithdraw,
     nextUnbondingDate,

--- a/scripts/cc-cli/src/utils/validatorStatus.ts
+++ b/scripts/cc-cli/src/utils/validatorStatus.ts
@@ -130,7 +130,7 @@ export async function getValidatorStatus(address: string, api: ApiPromise) {
     canWithdraw,
     readyForWithdraw,
     nextUnbondingDate,
-    nextUnbondingAmount: nextUnbondingAmount ? nextUnbondingAmount : new BN(0),
+    nextUnbondingAmount: nextUnbondingAmount || new BN(0),
     redeemable,
   };
 
@@ -154,8 +154,8 @@ export async function printValidatorStatus(status: Status, api: ApiPromise) {
       table.push([`Unlocked since era ${chunk.era}`, toCTCString(chunk.value)]);
     });
   }
-  let nextUnlocking = "None";
-  if (status.nextUnbondingAmount && status.nextUnbondingAmount.eq(new BN(0))) {
+  let nextUnlocking;
+  if (status.nextUnbondingAmount?.eq(new BN(0))) {
     nextUnlocking = "None";
   } else if (status.nextUnbondingAmount && status.nextUnbondingDate) {
     const nextUnbondingAmount = toCTCString(status.nextUnbondingAmount);
@@ -176,9 +176,8 @@ export function requireStatus(
 ) {
   if (!status[condition]) {
     console.error(
-      message
-        ? message
-        : `Cannot perform action, validator is not ${condition.toString()}`
+      message ||
+        `Cannot perform action, validator is not ${condition.toString()}`
     );
     process.exit(1);
   }

--- a/scripts/cc-cli/src/utils/validatorStatus.ts
+++ b/scripts/cc-cli/src/utils/validatorStatus.ts
@@ -32,7 +32,7 @@ export interface ControllerStatus {
 
 export async function getControllerStatus(
   address: string,
-  api: ApiPromise
+  api: ApiPromise,
 ): Promise<ControllerStatus> {
   const stashRes = await api.query.staking.ledger(address);
   const stash = stashRes.isSome
@@ -62,7 +62,7 @@ export async function getValidatorStatus(address: string, api: ApiPromise) {
   let stash;
   if (controllerStatus.isController && controllerStatus.stash) {
     console.log(
-      `Address belongs to the Controller account for validator ${controllerStatus.stash}`
+      `Address belongs to the Controller account for validator ${controllerStatus.stash}`,
     );
     console.log(`Showing status for ${controllerStatus.stash}...`);
     stash = controllerStatus.stash;
@@ -117,7 +117,7 @@ export async function getValidatorStatus(address: string, api: ApiPromise) {
     .then((r) => r.map((v) => v[0].toHuman()?.toString()));
   const activeValidatorsRes = await api.derive.staking.validators();
   const activeValidators: string[] = activeValidatorsRes.validators.map((v) =>
-    v.toString()
+    v.toString(),
   );
   const waitingValidators = validatorEntries.filter((v) => {
     if (v !== undefined) {
@@ -173,7 +173,7 @@ export async function printValidatorStatus(status: Status, api: ApiPromise) {
     const nextUnbondingAmount = toCTCString(status.nextUnbondingAmount);
     const nextUnbondingDate = await timeTillEra(api, status.nextUnbondingDate);
     nextUnlocking = `${nextUnbondingAmount} in ${formatDaysHoursMinutes(
-      nextUnbondingDate.toNumber()
+      nextUnbondingDate.toNumber(),
     )}`;
   }
   table.push(["Next unlocking", nextUnlocking]);
@@ -184,12 +184,12 @@ export async function printValidatorStatus(status: Status, api: ApiPromise) {
 export function requireStatus(
   status: Status,
   condition: keyof Status,
-  message?: string
+  message?: string,
 ) {
   if (!status[condition]) {
     console.error(
       message ||
-        `Cannot perform action, validator is not ${condition.toString()}`
+        `Cannot perform action, validator is not ${condition.toString()}`,
     );
     process.exit(1);
   }


### PR DESCRIPTION
# Description of proposed changes

This PR fixes a bug where the Status command was not showing Controller/Stash account address when it matched the queried address. Example: querying a controller account would show the Controller field as empty.

- Add `getControllerStatus` func which checks if account is a controller and gets its associated Stash.
- `getValidatorStatus` now checks if account is a Controller; if true, gets status for its associated Stash instead.
- Some minor clean up for `getValidatorStatus`

---
Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
