### PR TITLE
Make test-migrations-via-try-runtime CI job depend on live-sync-credi…

### DIFF
--- a/.github/workflows/runtime-upgrade.yml
+++ b/.github/workflows/runtime-upgrade.yml
@@ -631,6 +631,7 @@ jobs:
       - build-sut
       - setup
       - setup-self-hosted
+      - live-sync-creditcoin
       - deploy-github-runner
     steps:
       - uses: actions/checkout@v4
@@ -663,6 +664,9 @@ jobs:
           echo "INFO: IP_ADDRESS=$IP_ADDRESS"
 
           ./target/release/creditcoin-node --version
+
+          # node should be reusing the database from the
+          # live-sync-creditcoin CI job listed as dependency above
           ./target/release/creditcoin-node \
             --name "test-node-$GITHUB_RUN_ID-attempt-$GITHUB_RUN_ATTEMPT" \
             --chain ${{ needs.setup.outputs.target_chain }} \
@@ -670,7 +674,7 @@ jobs:
             --bootnodes "${{ needs.setup.outputs.boot_node }}" \
             --rpc-max-request-size  200000 \
             --rpc-max-response-size 200000 \
-            --prometheus-external \
+            --prometheus-external --pruning archive \
             --telemetry-url "wss://telemetry.creditcoin.network/submit/ 0" \
             --base-path /mnt \
             --public-addr "/dns4/$IP_ADDRESS/tcp/30333" >creditcoin-node-used-for-try-runtime.log 2>&1 &


### PR DESCRIPTION
…tcoin

this should reuse the database which is already on-disk and not cause a second sync, hopefully reducing the overall execution time for this CI pipeline.

Also specify missing `--pruning archive` option to deal with errors like:

Error = Call(Custom(ErrorObject { code: ServerError(-32000), message: "Client error: UnknownBlock: State already discarded for 0x7a6052272f51d086f3c0f89ced306b845ba93465591026107c6e236174d993d4", data: None }))

# Description of proposed changes

<describe what this PR is about and why we want it>

---
Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
