### PR TITLE
CSUB-918: Rebased & cleaned-up - Integration tests for burn() and burn_all()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,6 @@ jobs:
 
           docker run -d -p 9933:9933 -p 30333:30333 gluwa/creditcoin   \
               --validator --chain mainnet                                   \
-              --mining-key 5DkPYq8hFiCeGxFBkz6DAwnTrvKevAJfTYrzFtr9hpDsEAU1 \
               --name "test-node-$GITHUB_RUN_ID-attempt-$GITHUB_RUN_ATTEMPT" \
               --public-addr "/dns4/$IP_ADDRESS/tcp/30333" \
               --prometheus-external \
@@ -507,7 +506,7 @@ jobs:
       - name: Start creditcoin-node
         run: |
           chmod a+x ./target/release/creditcoin-node
-          ./target/release/creditcoin-node --dev --mining-key 5DkPYq8hFiCeGxFBkz6DAwnTrvKevAJfTYrzFtr9hpDsEAU1 --monitor-nonce auto >~/creditcoin-node.log 2>&1 &
+          ./target/release/creditcoin-node --dev --monitor-nonce auto >~/creditcoin-node.log 2>&1 &
 
       - uses: actions/checkout@v4
 
@@ -575,7 +574,7 @@ jobs:
       - name: Start SUT
         run: |
           chmod a+x ./target/release/creditcoin-node
-          ./target/release/creditcoin-node --dev --mining-key 5DkPYq8hFiCeGxFBkz6DAwnTrvKevAJfTYrzFtr9hpDsEAU1 --monitor-nonce auto >~/creditcoin-node.log 2>&1 &
+          ./target/release/creditcoin-node --dev --monitor-nonce auto >~/creditcoin-node.log 2>&1 &
 
       - name: Start local Ethereum node
         run: |

--- a/.github/workflows/runtime-upgrade.yml
+++ b/.github/workflows/runtime-upgrade.yml
@@ -197,7 +197,6 @@ jobs:
           ./creditcoin-node \
             --name "test-node-$GITHUB_RUN_ID-attempt-$GITHUB_RUN_ATTEMPT" \
             --chain ${{ needs.setup.outputs.target_chain }} \
-            --validator --mining-key 5DkPYq8hFiCeGxFBkz6DAwnTrvKevAJfTYrzFtr9hpDsEAU1 \
             --bootnodes "${{ needs.setup.outputs.boot_node }}" \
             --prometheus-external \
             --telemetry-url "wss://telemetry.creditcoin.network/submit/ 0" \
@@ -277,7 +276,6 @@ jobs:
           ./creditcoin-node \
             --name "test-node-$GITHUB_RUN_ID-attempt-$GITHUB_RUN_ATTEMPT" \
             --chain ${{ needs.setup.outputs.target_chain }} \
-            --validator --mining-key 5DkPYq8hFiCeGxFBkz6DAwnTrvKevAJfTYrzFtr9hpDsEAU1 \
             --bootnodes "${{ needs.setup.outputs.boot_node }}" \
             --prometheus-external --pruning archive \
             --telemetry-url "wss://telemetry.creditcoin.network/submit/ 0" \
@@ -337,7 +335,6 @@ jobs:
 
           ./target/release/creditcoin-node --version
           ./target/release/creditcoin-node --chain ./creditcoin-fork.json --validator --alice --pruning archive \
-                            --mining-key 5DkPYq8hFiCeGxFBkz6DAwnTrvKevAJfTYrzFtr9hpDsEAU1 \
                             --base-path /mnt \
                             --monitor-nonce auto >creditcoin-node-with-forked-chain.log 2>&1 &
 
@@ -455,7 +452,6 @@ jobs:
             --name "test-node-disconnected-$GITHUB_RUN_ID-attempt-$GITHUB_RUN_ATTEMPT" \
             --chain ${{ needs.setup.outputs.target_chain }} \
             --validator --alice --pruning archive \
-            --mining-key 5DkPYq8hFiCeGxFBkz6DAwnTrvKevAJfTYrzFtr9hpDsEAU1 \
             --prometheus-external \
             --telemetry-url "wss://telemetry.creditcoin.network/submit/ 0" \
             --base-path /mnt \
@@ -671,7 +667,6 @@ jobs:
           ./target/release/creditcoin-node \
             --name "test-node-$GITHUB_RUN_ID-attempt-$GITHUB_RUN_ATTEMPT" \
             --chain ${{ needs.setup.outputs.target_chain }} \
-            --validator --mining-key 5DkPYq8hFiCeGxFBkz6DAwnTrvKevAJfTYrzFtr9hpDsEAU1 \
             --bootnodes "${{ needs.setup.outputs.boot_node }}" \
             --rpc-max-request-size  200000 \
             --rpc-max-response-size 200000 \

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -28,7 +28,7 @@ This test suite is built with creditcoin-js, Polkadot.js and Jest!
    for more information:
 
 ```bash
-cargo run --release --bin creditcoin-node -- --dev --mining-key 5DkPYq8hFiCeGxFBkz6DAwnTrvKevAJfTYrzFtr9hpDsEAU1 --monitor-nonce auto
+cargo run --release --bin creditcoin-node -- --dev --monitor-nonce auto
 ```
 
 1. Execute a local Ethereum node:

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -28,7 +28,7 @@ This test suite is built with creditcoin-js, Polkadot.js and Jest!
    for more information:
 
 ```bash
-cargo run --release -- --dev --mining-key 5DkPYq8hFiCeGxFBkz6DAwnTrvKevAJfTYrzFtr9hpDsEAU1 --monitor-nonce auto
+cargo run --release --bin creditcoin-node -- --dev --mining-key 5DkPYq8hFiCeGxFBkz6DAwnTrvKevAJfTYrzFtr9hpDsEAU1 --monitor-nonce auto
 ```
 
 1. Execute a local Ethereum node:

--- a/integration-tests/src/test/burn.test.ts
+++ b/integration-tests/src/test/burn.test.ts
@@ -39,7 +39,7 @@ describeIf((global as any).CREDITCOIN_EXECUTE_SETUP_AUTHORITY, 'burn', () => {
 
         expect(starting.freeBalance.isZero()).toBe(false);
 
-        await api.tx.creditcoin.burnAll(sudoSigner.address).signAndSend(wallet);
+        await api.tx.creditcoin.burnAll(wallet.address).signAndSend(wallet);
         await forElapsedBlocks(api);
 
         const ending = await api.derive.balances.all(wallet.address);
@@ -59,7 +59,7 @@ describeIf((global as any).CREDITCOIN_EXECUTE_SETUP_AUTHORITY, 'burn', () => {
         const starting = await api.derive.balances.all(burner.address);
         expect(starting.freeBalance.isZero()).toBe(false);
 
-        await api.tx.creditcoin.burn(BURN_AMOUNT, sudoSigner.address).signAndSend(burner);
+        await api.tx.creditcoin.burn(BURN_AMOUNT, burner.address).signAndSend(burner);
         await forElapsedBlocks(api);
 
         const ending = await api.derive.balances.all(burner.address);
@@ -78,7 +78,7 @@ describeIf((global as any).CREDITCOIN_EXECUTE_SETUP_AUTHORITY, 'burn', () => {
 
         return new Promise((resolve, reject): void => {
             const unsubscribe = api.tx.creditcoin
-                .burnAll(sudoSigner.address)
+                .burnAll(burner.address)
                 .signAndSend(burner, { nonce: -1 }, async ({ dispatchError, events, status }) => {
                     await extractFee(resolve, reject, unsubscribe, api, dispatchError, events, status);
                 })

--- a/integration-tests/src/test/burn.test.ts
+++ b/integration-tests/src/test/burn.test.ts
@@ -1,0 +1,111 @@
+import { Blockchain, KeyringPair, creditcoinApi, BN, CREDO_PER_CTC } from 'creditcoin-js';
+import { forElapsedBlocks, testData } from 'creditcoin-js/lib/testUtils';
+import { CreditcoinApi } from 'creditcoin-js/lib/types';
+import { mnemonicGenerate } from '@polkadot/util-crypto';
+import { extractFee, describeIf } from '../utils';
+import { POINT_01_CTC } from 'creditcoin-js';
+
+describeIf((global as any).CREDITCOIN_EXECUTE_SETUP_AUTHORITY, 'burn', () => {
+    let ccApi: CreditcoinApi;
+    let sudoSigner: KeyringPair;
+
+    const testingData = testData(
+        (global as any).CREDITCOIN_ETHEREUM_CHAIN as Blockchain,
+        (global as any).CREDITCOIN_CREATE_WALLET,
+    );
+    const { keyring } = testingData;
+
+    const ONE_CTC = new BN((1 * CREDO_PER_CTC).toString(), 10);
+
+    beforeAll(async () => {
+        ccApi = await creditcoinApi((global as any).CREDITCOIN_API_URL);
+        sudoSigner = (global as any).CREDITCOIN_CREATE_SIGNER(keyring, 'sudo');
+    });
+
+    afterAll(async () => await ccApi.api.disconnect());
+
+    it('burn_all works as expected', async (): Promise<void> => {
+        const wallet = keyring.addFromMnemonic(mnemonicGenerate(12));
+
+        const { api } = ccApi;
+
+        await api.tx.sudo
+            .sudo(api.tx.balances.setBalance(wallet.address, ONE_CTC, 0))
+            .signAndSend(sudoSigner, { nonce: -1 });
+        await forElapsedBlocks(api);
+
+        const starting = await api.derive.balances.all(wallet.address);
+
+        expect(starting.freeBalance.isZero()).toBe(false);
+
+        await api.tx.creditcoin.burnAll(sudoSigner.address).signAndSend(wallet);
+        await forElapsedBlocks(api);
+
+        const ending = await api.derive.balances.all(wallet.address);
+        expect(ending.freeBalance.isZero()).toBe(true);
+    }, 100_000);
+
+    it('burn works as expected', async (): Promise<void> => {
+        const burner = keyring.addFromMnemonic(mnemonicGenerate(12));
+
+        const { api } = ccApi;
+
+        await api.tx.sudo
+            .sudo(api.tx.balances.setBalance(burner.address, ONE_CTC, 0))
+            .signAndSend(sudoSigner, { nonce: -1 });
+        await forElapsedBlocks(api);
+
+        const starting = await api.derive.balances.all(burner.address);
+        expect(starting.freeBalance.isZero()).toBe(false);
+
+        await api.tx.creditcoin.burn(POINT_01_CTC, sudoSigner.address).signAndSend(burner);
+        await forElapsedBlocks(api);
+
+        const ending = await api.derive.balances.all(burner.address);
+        expect(starting.freeBalance.gt(ending.freeBalance)).toBe(true);
+    }, 100_000);
+
+    it('burn_all fee is min 0.01 CTC', async (): Promise<void> => {
+        const burner = keyring.addFromMnemonic(mnemonicGenerate(12));
+
+        const { api } = ccApi;
+
+        await api.tx.sudo
+            .sudo(api.tx.balances.setBalance(burner.address, ONE_CTC, 0))
+            .signAndSend(sudoSigner, { nonce: -1 });
+        await forElapsedBlocks(api);
+
+        return new Promise((resolve, reject): void => {
+            const unsubscribe = api.tx.creditcoin
+                .burnAll(sudoSigner.address)
+                .signAndSend(burner, { nonce: -1 }, async ({ dispatchError, events, status }) => {
+                    await extractFee(resolve, reject, unsubscribe, api, dispatchError, events, status);
+                })
+                .catch((error) => reject(error));
+        }).then((fee) => {
+            expect(fee).toBeGreaterThanOrEqual((global as any).CREDITCOIN_MINIMUM_TXN_FEE);
+        });
+    }, 150_000);
+
+    it('burn fee is min 0.01 CTC', async (): Promise<void> => {
+        const burner = keyring.addFromMnemonic(mnemonicGenerate(12));
+
+        const { api } = ccApi;
+
+        await api.tx.sudo
+            .sudo(api.tx.balances.setBalance(burner.address, ONE_CTC, 0))
+            .signAndSend(sudoSigner, { nonce: -1 });
+        await forElapsedBlocks(api);
+
+        return new Promise((resolve, reject): void => {
+            const unsubscribe = api.tx.creditcoin
+                .burn(POINT_01_CTC, burner.address)
+                .signAndSend(burner, { nonce: -1 }, async ({ dispatchError, events, status }) => {
+                    await extractFee(resolve, reject, unsubscribe, api, dispatchError, events, status);
+                })
+                .catch((error) => reject(error));
+        }).then((fee) => {
+            expect(fee).toBeGreaterThanOrEqual((global as any).CREDITCOIN_MINIMUM_TXN_FEE);
+        });
+    }, 150_000);
+});

--- a/integration-tests/src/test/burn.test.ts
+++ b/integration-tests/src/test/burn.test.ts
@@ -16,6 +16,7 @@ describeIf((global as any).CREDITCOIN_EXECUTE_SETUP_AUTHORITY, 'burn', () => {
     const { keyring } = testingData;
 
     const ONE_CTC = new BN((1 * CREDO_PER_CTC).toString(), 10);
+    const BURN_AMOUNT = new BN(POINT_01_CTC.toString(), 10);
 
     beforeAll(async () => {
         ccApi = await creditcoinApi((global as any).CREDITCOIN_API_URL);
@@ -58,7 +59,7 @@ describeIf((global as any).CREDITCOIN_EXECUTE_SETUP_AUTHORITY, 'burn', () => {
         const starting = await api.derive.balances.all(burner.address);
         expect(starting.freeBalance.isZero()).toBe(false);
 
-        await api.tx.creditcoin.burn(POINT_01_CTC, sudoSigner.address).signAndSend(burner);
+        await api.tx.creditcoin.burn(BURN_AMOUNT, sudoSigner.address).signAndSend(burner);
         await forElapsedBlocks(api);
 
         const ending = await api.derive.balances.all(burner.address);
@@ -99,7 +100,7 @@ describeIf((global as any).CREDITCOIN_EXECUTE_SETUP_AUTHORITY, 'burn', () => {
 
         return new Promise((resolve, reject): void => {
             const unsubscribe = api.tx.creditcoin
-                .burn(POINT_01_CTC, burner.address)
+                .burn(BURN_AMOUNT, burner.address)
                 .signAndSend(burner, { nonce: -1 }, async ({ dispatchError, events, status }) => {
                     await extractFee(resolve, reject, unsubscribe, api, dispatchError, events, status);
                 })


### PR DESCRIPTION
Rebased #1435 to latest `dev`, dropped changes to `Cargo.lock` and `yarn.lock` and squashed relevant commits together.