### PR TITLE
CSUB-975: Forcefully remove test container in CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
         run: |
           # this will also kill the parent container
           sudo killall -9 creditcoin-node
+          sleep 10
+          docker rm -f creditcoin-validator
+          sleep 10
 
       - name: Start docker-compose
         run: |

--- a/.github/workflows/runtime-upgrade.yml
+++ b/.github/workflows/runtime-upgrade.yml
@@ -516,10 +516,13 @@ jobs:
           name: creditcoin_node_runtime.compact.compressed.wasm
 
       - name: Upgrade WASM
+        if: env.LENDER_PRIVATE_KEY
         run: |
           yarn --cwd ./scripts/js upgrade 'creditcoin-js'
-          yarn --cwd ./scripts/js runtimeUpgrade ws://127.0.0.1:9944 ../../creditcoin_node_runtime.compact.compressed.wasm //Alice 0
+          yarn --cwd ./scripts/js runtimeUpgrade ws://127.0.0.1:9944 ../../creditcoin_node_runtime.compact.compressed.wasm "${{ env.LENDER_PRIVATE_KEY }}" 0
           sleep 10
+        env:
+          LENDER_PRIVATE_KEY: ${{ secrets.TESTNET_LENDER_PRIVATE_KEY }}
 
       # TODO: wait & confirm wasm upgrade has finished, incl. migrations
       - name: Execute integration tests


### PR DESCRIPTION
because we now use the same container name when launching via the `docker` command and via `docker-compose` we need to make sure the container is no more before proceeding to the next step of the test.

Sometimes killing the process may take a bit longer and docker falls on its face when that happens!

Example of where this failed because we didn't have this patch:
https://github.com/gluwa/creditcoin/actions/runs/7251999841/job/19755545943

Example of where the same (w/o this patch) passed b/c it is time sensitive:
https://github.com/gluwa/creditcoin/actions/runs/7224934734/job/19687313625



# Description of proposed changes

<describe what this PR is about and why we want it>

---
Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
