### PR TITLE
Switch to Node.js v20 before we can upgrade @polkadot dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
       - run: npm install -g yarn
 
       - name: Install creditcoin-js & creditcoin-cli
@@ -313,7 +313,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
       - run: npm install -g yarn
 
       - name: Execute tests
@@ -393,7 +393,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
       - run: npm install -g yarn
 
       - name: Install creditcoin-js & creditcoin-cli
@@ -464,7 +464,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
@@ -591,7 +591,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
       - run: npm install -g yarn
 
       - name: Prepare for integration tests
@@ -675,7 +675,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
       - run: npm install -g yarn
 
       - name: Run tools
@@ -701,7 +701,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
       - run: npm install -g yarn
 
       - name: Run tools
@@ -727,7 +727,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
       - run: npm install -g yarn
 
       - name: Run tools

--- a/.github/workflows/extrinsics.yml
+++ b/.github/workflows/extrinsics.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Node Dependencies
         uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 20
       - run: npm install --ignore-scripts -g @polkadot/metadata-cmp
 
       - name: Set-Up

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,7 +205,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
       - run: npm install -g yarn
 
       - name: Figure out tag name

--- a/.github/workflows/runtime-upgrade.yml
+++ b/.github/workflows/runtime-upgrade.yml
@@ -353,7 +353,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
       - run: npm install -g yarn
 
       - name: Prepare for integration tests
@@ -477,7 +477,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
       - run: npm install -g yarn
 
       - name: Prepare for integration tests

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install JS Dependencies
         uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
       - run: |
           npm install -g yarn
           pushd ./creditcoin-js && yarn install && yarn pack && popd

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends ca-certificates curl && \
     update-ca-certificates && \
-    curl -fsSL https://deb.nodesource.com/setup_16.x | bash - && \
+    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
     apt-get install -y nodejs --no-install-recommends && \
     npm install -g yarn
 


### PR DESCRIPTION
@polkadot/keyring@12.6.1: The engine "node" is incompatible with this module. Expected version ">=18". Got "16.20.2"


initially detected in https://github.com/gluwa/creditcoin/pull/1445