### PR TITLE
CSUB-1008: Do not attach unsupported Windows binaries as release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,6 +119,7 @@ jobs:
           exclusions: "creditcoin-node.d"
 
       - name: Upload binary
+        if: matrix.operating-system != 'windows-2022'
         uses: actions/upload-artifact@v4
         with:
           path: "creditcoin-${{ env.TAG_NAME }}-*.zip"

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ node.
 cargo run --release -- --dev --tmp
 ```
 
+_WARNING: running natively on Windows [is unsupported](https://github.com/gluwa/creditcoin/security/advisories/GHSA-cx5c-xwcv-vhmq)._
+
 ### Explore Node Options
 
 Once the project has been built, the following command can be used to explore all parameters and
@@ -122,5 +124,3 @@ If you want to see the multi-node consensus algorithm in action, refer to our
 
 - [Legacy Creditcoin 1.x Account Migration](./docs/legacy-account-migration.md)
 - [Legacy Creditcoin 1.x Repos](https://github.com/gluwa?q=legacy)
-
-### Testing

--- a/docs/dev-guide/src/getting-started/building.md
+++ b/docs/dev-guide/src/getting-started/building.md
@@ -2,7 +2,7 @@
 # Building the `creditcoin-node` from source
 
 _Note on development platforms: development is easiest from a unix environment (whether that be linux, macOS, or WSL). It should be possible to
-develop natively in windows but you'll most likely be on your own._
+develop natively on Windows, [however that is unsupported](https://github.com/gluwa/creditcoin/security/advisories/GHSA-cx5c-xwcv-vhmq)._
 
 ## Build prerequisites
 

--- a/docs/dev-guide/src/getting-started/running-a-node.md
+++ b/docs/dev-guide/src/getting-started/running-a-node.md
@@ -1,5 +1,8 @@
 # Running a Creditcoin node
 
+_Note on runtime platforms: running a Creditcoin node is easiest on a Unix-like environment (whether that be Linux, MacOS, or WSL).
+Running natively on Windows [is unsupported](https://github.com/gluwa/creditcoin/security/advisories/GHSA-cx5c-xwcv-vhmq)._
+
 ## Running a development node
 
 Now that you've built a `creditcoin-node` from source, you can get a minimal development node running with:


### PR DESCRIPTION
> The blockchain team takes the stance that running Creditcoin on Windows
> is officially unsupported and at best should be thought of as experimental.

See:
https://github.com/gluwa/creditcoin/security/advisories/GHSA-cx5c-xwcv-vhmq

# Description of proposed changes

<describe what this PR is about and why we want it>

---
Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
