### PR TITLE
CSUB-861, CSUB-1020: Use distinctive names when uploading logs

### DIFF
--- a/.github/workflows/runtime-upgrade.yml
+++ b/.github/workflows/runtime-upgrade.yml
@@ -232,7 +232,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: logs
+          name: fork-creditcoin-logs
           path: "*.log"
 
       - name: Upload creditcoin-fork.json
@@ -303,7 +303,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: logs
+          name: live-sync-creditcoin-logs
           path: "*.log"
 
   test-against-fork:
@@ -405,7 +405,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: logs
+          name: test-against-fork-logs
           path: "*.log"
 
       - name: Kill hardhat-dev
@@ -533,7 +533,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: logs
+          name: test-against-disconnected-live-node-logs
           path: "*.log"
 
       - name: Kill creditcoin-node
@@ -696,7 +696,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: logs
+          name: test-migrations-via-try-runtime-logs
           path: "*.log"
 
   remove-github-runner:


### PR DESCRIPTION
for actions/upload-artifact@v4 https://github.com/actions/upoad-artifact#breaking-changes says:

> Uploading to the same named Artifact multiple times.

> Due to how Artifacts are created in this new version, it is no longer possible to upload
> to the same named Artifact multiple times. You must either split the uploads into multiple
> Artifacts with different names, or only upload once. Otherwise you will encounter an error.

# Description of proposed changes

<describe what this PR is about and why we want it>

---
Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
