### PR TITLE
CSUB-1020: Adjust upload-artifact/download-artifact for v4 in release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,6 +122,7 @@ jobs:
         if: matrix.operating-system != 'windows-2022'
         uses: actions/upload-artifact@v4
         with:
+          name: binary-for-${{ matrix.operating-system }}
           path: "creditcoin-${{ env.TAG_NAME }}-*.zip"
           if-no-files-found: error
 
@@ -162,6 +163,7 @@ jobs:
       - name: Upload binary
         uses: actions/upload-artifact@v4
         with:
+          name: binary-for-wasm
           path: "*.wasm"
           if-no-files-found: error
 
@@ -230,6 +232,7 @@ jobs:
       - name: Upload binary
         uses: actions/upload-artifact@v4
         with:
+          name: binary-for-creditcoin-js
           path: "creditcoin-js/creditcoin-js-v${{ env.TAG_NAME }}.tgz"
           if-no-files-found: error
 
@@ -254,6 +257,10 @@ jobs:
 
       - name: Download binaries
         uses: actions/download-artifact@v4
+        with:
+          path: artifact
+          pattern: binary-for-*
+          merge-multiple: true
 
       - name: DEBUG
         shell: bash


### PR DESCRIPTION
Example pipeline for Creditcoin3 -> https://github.com/gluwa/creditcoin3/pull/184#issuecomment-1907843713

The changes here are the same + a patch for uploading creditcoin-js tarball. 