### PR TITLE
CSUB-861: Skip upgrade against disconnected nodes

### DIFF
--- a/.github/workflows/runtime-upgrade.yml
+++ b/.github/workflows/runtime-upgrade.yml
@@ -422,7 +422,10 @@ jobs:
 
   test-against-disconnected-live-node:
     # execute only against Testnet b/c we don't have sudo key for Mainnet
-    if: github.base_ref == 'testnet'
+    # if: github.base_ref == 'testnet'
+    # skip upgrades against disconnected live nodes, see
+    # https://gluwa.atlassian.net/wiki/spaces/CB/pages/1119912022/Context+decision+for+CSUB-861+runtime+upgrade+testing+against+disconnected+node
+    if: false
     needs:
       - build-sut
       - setup


### PR DESCRIPTION
https://gluwa.atlassian.net/wiki/spaces/CB/pages/1119912022/Context+decision+for+CSUB-861+runtime+upgrade+testing+against+disconnected+node

# Description of proposed changes

<describe what this PR is about and why we want it>

---
Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
