### PR TITLE
Allow actions-rs/grcov to fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,7 +294,9 @@ jobs:
           CARGO_INCREMENTAL: ${{ env.CARGO_INCREMENTAL }}
           RUSTFLAGS: ${{ env.RUSTFLAGS }}
           RUSTDOCFLAGS: ${{ env.RUSTDOCFLAGS }}
+
       - id: coverage
+        continue-on-error: true
         uses: actions-rs/grcov@v0.1
         with:
           config: .grcov.yml


### PR DESCRIPTION
because recently it started failing with:

  Error: failed to compile `grcov v0.8.19`, intermediate artifacts can be found at `/var/folders/h1/8hndypj13nsbj5pn4xsnv1tm0000gn/T/cargo-installyBLQUt`
  Caused by:
    package `clap_lex v0.7.0` cannot be built because it requires rustc 1.74 or newer, while the currently active rustc version is 1.72.0-nightly
    Try re-running cargo install with `--locked`

and this actions doesn't allow control over how `cargo install` is executed internally

# Description of proposed changes

<describe what this PR is about and why we want it>

---
Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
