### PR TITLE
feat(DO-2340): Docker Scout CVE scan posts as PR comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,24 @@ jobs:
         run: |
           docker build -t gluwa/creditcoin .
 
+      # DO-2336/DO-2340: informational only, never fails the build. docker/scout-action
+      # authenticates to the Scout backend even for a local:// image and hard-fails
+      # ("no credential found") without a real DockerHub login (see DO-2338) — uses the
+      # read-only gluwabot org secret, never a push-capable credential, since PR builds
+      # run untrusted PR content. Posts as a PR comment via a dedicated gluwa-bot PAT
+      # (GLUWA_BOT_PR) rather than elevating GITHUB_TOKEN's own permissions.
+      - name: Docker Scout - CVE scan (gluwa/creditcoin)
+        continue-on-error: true
+        uses: docker/scout-action@v1
+        with:
+          command: cves
+          image: local://gluwa/creditcoin
+          dockerhub-user: ${{ secrets.DOCKERHUB_SCOUT_USERNAME }}
+          dockerhub-password: ${{ secrets.DOCKERHUB_SCOUT_TOKEN }}
+          exit-code: false
+          write-comment: true
+          github-token: ${{ secrets.GLUWA_BOT_PR }}
+
       - name: Start a container from image
         run: |
           # see https://opensource.com/article/18/5/how-find-ip-address-linux


### PR DESCRIPTION
## Summary
- Adds an informational Docker Scout CVE scan on the PR-built `gluwa/creditcoin` image, posted as a review comment via `docker/scout-action` instead of only appearing in the raw CI log.
- Uses the org-wide read-only `DOCKERHUB_SCOUT_USERNAME`/`DOCKERHUB_SCOUT_TOKEN` credential for Scout auth, and a dedicated `GLUWA_BOT_PR` PAT (pull-requests:write only) for the comment post — same pattern established on creditcoin3 (DO-2338), never touching this job's own `GITHUB_TOKEN` permissions.
- `continue-on-error: true` + `exit-code: false` — purely informational, never blocks the build.

Part of DO-2336 (org-wide Docker Scout CVE-scan rework across ~32 repos).

## Test plan
- [ ] Confirm the PR-triggered `CI` workflow run on this PR completes and posts a Scout CVE comment with real vulnerability data